### PR TITLE
fix: resolve frontend redirects, pricing, image hosts, and branding

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -35,6 +35,10 @@ const nextConfig = {
       },
       {
         protocol: "https",
+        hostname: "images.unsplash.com",
+      },
+      {
+        protocol: "https",
         hostname: "medusa-public-images.s3.eu-west-1.amazonaws.com",
       },
       {

--- a/src/app/[locale]/[countryCode]/(checkout)/layout.tsx
+++ b/src/app/[locale]/[countryCode]/(checkout)/layout.tsx
@@ -29,7 +29,7 @@ export default function CheckoutLayout({
             className="txt-compact-xlarge-plus text-ui-fg-subtle hover:text-ui-fg-base uppercase"
             data-testid="store-link"
           >
-            Medusa Store
+            NordHjem
           </LocalizedClientLink>
           <div className="flex-1 basis-0" />
         </nav>

--- a/src/app/[locale]/[countryCode]/(main)/account/@dashboard/profile/page.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/account/@dashboard/profile/page.tsx
@@ -12,7 +12,7 @@ import { retrieveCustomer } from "@lib/data/customer"
 
 export const metadata: Metadata = {
   title: "Profile",
-  description: "View and edit your Medusa Store profile.",
+  description: "View and edit your NordHjem profile.",
 }
 
 export default async function Profile() {

--- a/src/app/[locale]/[countryCode]/(main)/account/@login/page.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/account/@login/page.tsx
@@ -4,7 +4,7 @@ import LoginTemplate from "@modules/account/templates/login-template"
 
 export const metadata: Metadata = {
   title: "Sign in",
-  description: "Sign in to your Medusa Store account.",
+  description: "Sign in to your NordHjem account.",
 }
 
 export default function Login() {

--- a/src/app/[locale]/[countryCode]/(main)/categories/[...category]/page.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/categories/[...category]/page.tsx
@@ -47,12 +47,12 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
   try {
     const productCategory = await getCategoryByHandle(params.category)
 
-    const title = productCategory.name + " | Medusa Store"
+    const title = `${productCategory.name} | NordHjem`
 
     const description = productCategory.description ?? `${title} category.`
 
     return {
-      title: `${title} | Medusa Store`,
+      title,
       description,
       alternates: {
         canonical: `${params.category.join("/")}`,

--- a/src/app/[locale]/[countryCode]/(main)/collections/[handle]/page.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/collections/[handle]/page.tsx
@@ -59,7 +59,7 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
   }
 
   const metadata = {
-    title: `${collection.title} | Medusa Store`,
+    title: `${collection.title} | NordHjem`,
     description: `${collection.title} collection`,
   } as Metadata
 

--- a/src/app/[locale]/[countryCode]/(main)/products/[handle]/page.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/products/[handle]/page.tsx
@@ -88,10 +88,10 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
   }
 
   return {
-    title: `${product.title} | Medusa Store`,
+    title: `${product.title} | NordHjem`,
     description: `${product.title}`,
     openGraph: {
-      title: `${product.title} | Medusa Store`,
+      title: `${product.title} | NordHjem`,
       description: `${product.title}`,
       images: product.thumbnail ? [product.thumbnail] : [],
     },

--- a/src/lib/util/money.ts
+++ b/src/lib/util/money.ts
@@ -21,6 +21,6 @@ export const convertToLocale = ({
         currency: currency_code,
         minimumFractionDigits,
         maximumFractionDigits,
-      }).format(amount)
+      }).format(amount / 100)
     : amount.toString()
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,9 +1,28 @@
 import createMiddleware from "next-intl/middleware"
+import { NextRequest, NextResponse } from "next/server"
 import { routing } from "./i18n/routing"
 
 const intlMiddleware = createMiddleware(routing)
+const DEFAULT_COUNTRY_CODE =
+  process.env.NEXT_PUBLIC_DEFAULT_REGION?.toLowerCase() || "us"
 
-export function middleware(request: any) {
+export function middleware(request: NextRequest) {
+  const { pathname, search } = request.nextUrl
+
+  if (pathname === "/") {
+    return NextResponse.redirect(
+      new URL(`/${routing.defaultLocale}/${DEFAULT_COUNTRY_CODE}${search}`, request.url)
+    )
+  }
+
+  const localeMatch = pathname.match(/^\/([a-zA-Z-]+)\/?$/)
+
+  if (localeMatch && routing.locales.includes(localeMatch[1] as "en" | "zh")) {
+    return NextResponse.redirect(
+      new URL(`/${localeMatch[1]}/${DEFAULT_COUNTRY_CODE}${search}`, request.url)
+    )
+  }
+
   return intlMiddleware(request)
 }
 

--- a/src/modules/account/components/register/index.tsx
+++ b/src/modules/account/components/register/index.tsx
@@ -21,10 +21,10 @@ const Register = ({ setCurrentView }: Props) => {
       data-testid="register-page"
     >
       <h1 className="text-large-semi uppercase mb-6">
-        Become a Medusa Store Member
+        Become a NordHjem Member
       </h1>
       <p className="text-center text-base-regular text-ui-fg-base mb-4">
-        Create your Medusa Store Member profile, and get access to an enhanced
+        Create your NordHjem Member profile, and get access to an enhanced
         shopping experience.
       </p>
       <form className="w-full flex flex-col" action={formAction}>
@@ -69,7 +69,7 @@ const Register = ({ setCurrentView }: Props) => {
         </div>
         <ErrorMessage error={message} data-testid="register-error" />
         <span className="text-center text-ui-fg-base text-small-regular mt-6">
-          By creating an account, you agree to Medusa Store&apos;s{" "}
+          By creating an account, you agree to NordHjem&apos;s{" "}
           <LocalizedClientLink
             href="/content/privacy-policy"
             className="underline"


### PR DESCRIPTION
### Motivation
- Ensure the storefront routes to a valid default region when no country code is present so `/` and `/{locale}` do not land on a 404 page. 
- Correct price display by converting stored integer cent values into decimal currency units before localization formatting. 
- Allow Next.js image optimization to fetch Unsplash-hosted thumbnails without 400 responses. 
- Replace generic `Medusa Store` branding with `NordHjem` in page metadata and visible UI strings.

### Description
- Updated `src/middleware.ts` to use `NextRequest`/`NextResponse`, read `NEXT_PUBLIC_DEFAULT_REGION` (fallback `us`) and redirect `
  - "/" → `/{routing.defaultLocale}/{DEFAULT_COUNTRY_CODE}` and
  - `/{locale}` → `/{locale}/{DEFAULT_COUNTRY_CODE}` before falling back to the `next-intl` middleware.
- Fixed money formatting in `src/lib/util/money.ts` by dividing amounts by `100` inside `convertToLocale` so cents are converted to currency units before `Intl.NumberFormat`.
- Added `images.unsplash.com` to `images.remotePatterns` in `next.config.js` without removing existing patterns so remote image optimization can accept Unsplash URLs.
- Replaced occurrences of `Medusa Store` with `NordHjem` in metadata and visible text across impacted files (examples: checkout header, product/collection/category metadata, login/profile descriptions, registration copy).

### Testing
- Ran `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY=dummy yarn next build` which failed due to Google Fonts fetch errors in the restricted environment (network font fetch blocked), so a full production build could not complete (failed).
- Running `yarn next dev` with `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY=dummy` succeeded and served the app (success).
- Verified redirects with automated HTTP checks against the dev server: `GET /` and `GET /en` both returned `307` with `Location: /en/us` (success).
- Confirmed `images.unsplash.com` is present in `next.config.js` via a file search (success).
- Confirmed no remaining `Medusa Store` matches in `src/` via code search (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a63fe6cc948333bf275bfabe14b289)