### PR TITLE
fix(checkout): await getCartId in setAddresses to avoid invalid shipping options

### DIFF
--- a/src/lib/data/cart.ts
+++ b/src/lib/data/cart.ts
@@ -350,7 +350,7 @@ export async function setAddresses(currentState: unknown, formData: FormData) {
     if (!formData) {
       throw new Error("No form data found when setting addresses")
     }
-    const cartId = getCartId()
+    const cartId = await getCartId()
     if (!cartId) {
       throw new Error("No existing cart found when setting addresses")
     }


### PR DESCRIPTION
### Motivation
- Fix an async bug where `getCartId()` was not awaited in `setAddresses`, which could allow address/cart updates to proceed with an unresolved Promise and cause shipping options to become invalid.

### Description
- In `src/lib/data/cart.ts` changed `const cartId = getCartId()` to `const cartId = await getCartId()` inside `setAddresses` so the cart ID is resolved before validation and updating.

### Testing
- Ran `yarn lint`, which failed in this environment due to a missing environment variable `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY`, so no additional automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a6876c87a88333a7f068cdfba5941d)