### PR TITLE
fix(checkout): treat empty geo_zones as globally available shipping option

### DIFF
--- a/src/modules/checkout/components/shipping/index.tsx
+++ b/src/modules/checkout/components/shipping/index.tsx
@@ -58,7 +58,7 @@ const optionMatchesCountry = (
   const geoZones = option.service_zone?.geo_zones
 
   if (!Array.isArray(geoZones) || geoZones.length === 0) {
-    return false
+    return true
   }
 
   return geoZones.some((geoZone: any) => {


### PR DESCRIPTION
### Motivation
- Fix a bug where shipping options with an empty `service_zone.geo_zones` array were incorrectly filtered out and thus no shipping options appeared in the checkout delivery step.

### Description
- Update a single guard in `src/modules/checkout/components/shipping/index.tsx` so that when `service_zone.geo_zones` is missing or an empty array the function returns `true`, treating empty `geo_zones` as globally available.

### Testing
- Ran the automated linter via `yarn lint`, which failed in this environment due to a missing required environment variable `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY`, so no additional automated tests were completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a6fc625ffc8333810cfa5a97a556da)