### PR TITLE
fix: complete i18n coverage for checkout components

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -168,7 +168,13 @@
     "processing": "Processing...",
     "orderSummary": "Order Summary",
     "editCart": "Edit Cart",
-    "termsAgree": "By placing this order, you agree to our {terms} and {privacy}"
+    "company": "Company",
+    "contact": "Contact",
+    "edit": "Edit",
+    "backToCart": "Back to Shopping Cart",
+    "addPromoCode": "Add Promotion Code",
+    "billingSameAsDelivery": "Billing and delivery address are the same.",
+    "termsAgree": "By placing this order, you agree to our <terms>Terms of Use</terms> and <privacy>Privacy Policy</privacy>"
   },
   "order": {
     "confirmation": "Order Confirmation",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -168,7 +168,13 @@
     "processing": "处理中...",
     "orderSummary": "订单摘要",
     "editCart": "修改购物车",
-    "termsAgree": "提交订单即表示您同意我们的{terms}和{privacy}"
+    "company": "公司",
+    "contact": "联系方式",
+    "edit": "编辑",
+    "backToCart": "返回购物车",
+    "addPromoCode": "添加优惠码",
+    "billingSameAsDelivery": "账单地址与配送地址相同。",
+    "termsAgree": "提交订单即表示您同意我们的<terms>使用条款</terms>和<privacy>隐私政策</privacy>"
   },
   "order": {
     "confirmation": "订单确认",

--- a/src/modules/checkout/components/addresses/index.tsx
+++ b/src/modules/checkout/components/addresses/index.tsx
@@ -58,7 +58,7 @@ const Addresses = ({
               className="text-ui-fg-interactive hover:text-ui-fg-interactive-hover"
               data-testid="edit-address-button"
             >
-              Edit
+              {t("edit")}
             </button>
           </Text>
         )}
@@ -126,7 +126,7 @@ const Addresses = ({
                     data-testid="shipping-contact-summary"
                   >
                     <Text className="txt-medium-plus text-ui-fg-base mb-1">
-                      Contact
+                      {t("contact")}
                     </Text>
                     <Text className="txt-medium text-ui-fg-subtle">
                       {cart.shipping_address.phone}
@@ -146,7 +146,7 @@ const Addresses = ({
 
                     {sameAsBilling ? (
                       <Text className="txt-medium text-ui-fg-subtle">
-                        Billing and delivery address are the same.
+                        {t("billingSameAsDelivery")}
                       </Text>
                     ) : (
                       <>

--- a/src/modules/checkout/components/billing_address/index.tsx
+++ b/src/modules/checkout/components/billing_address/index.tsx
@@ -62,7 +62,7 @@ const BillingAddress = ({ cart }: { cart: HttpTypes.StoreCart | null }) => {
           data-testid="billing-address-input"
         />
         <Input
-          label="Company"
+          label={t("company")}
           name="billing_address.company"
           value={formData["billing_address.company"]}
           onChange={handleChange}

--- a/src/modules/checkout/components/discount-code/index.tsx
+++ b/src/modules/checkout/components/discount-code/index.tsx
@@ -2,6 +2,7 @@
 
 import { Badge, Heading, Input, Label, Text } from "@medusajs/ui"
 import React from "react"
+import { useTranslations } from "next-intl"
 
 import { applyPromotions } from "@lib/data/cart"
 import { convertToLocale } from "@lib/util/money"
@@ -17,6 +18,7 @@ type DiscountCodeProps = {
 }
 
 const DiscountCode: React.FC<DiscountCodeProps> = ({ cart }) => {
+  const t = useTranslations("checkout")
   const [isOpen, setIsOpen] = React.useState(false)
   const [errorMessage, setErrorMessage] = React.useState("")
 
@@ -66,7 +68,7 @@ const DiscountCode: React.FC<DiscountCodeProps> = ({ cart }) => {
               className="txt-medium text-ui-fg-interactive hover:text-ui-fg-interactive-hover"
               data-testid="add-discount-button"
             >
-              Add Promotion Code(s)
+              {t("addPromoCode")}
             </button>
 
             {/* <Tooltip content="You can add multiple promotion codes">

--- a/src/modules/checkout/components/payment/index.tsx
+++ b/src/modules/checkout/components/payment/index.tsx
@@ -129,7 +129,7 @@ const Payment = ({
               className="text-ui-fg-interactive hover:text-ui-fg-interactive-hover"
               data-testid="edit-payment-button"
             >
-              Edit
+              {t("edit")}
             </button>
           </Text>
         )}

--- a/src/modules/checkout/components/review/index.tsx
+++ b/src/modules/checkout/components/review/index.tsx
@@ -40,7 +40,18 @@ const Review = ({ cart }: { cart: any }) => {
           <div className="flex items-start gap-x-1 w-full mb-6">
             <div className="w-full">
               <Text className="txt-medium-plus text-ui-fg-base mb-1">
-                {t("termsAgree")}
+                {t.rich("termsAgree", {
+                  terms: (chunks) => (
+                    <a href="/terms" className="underline">
+                      {chunks}
+                    </a>
+                  ),
+                  privacy: (chunks) => (
+                    <a href="/privacy" className="underline">
+                      {chunks}
+                    </a>
+                  ),
+                })}
               </Text>
             </div>
           </div>

--- a/src/modules/checkout/components/shipping-address/index.tsx
+++ b/src/modules/checkout/components/shipping-address/index.tsx
@@ -143,7 +143,7 @@ const ShippingAddress = ({
           data-testid="shipping-address-input"
         />
         <Input
-          label="Company"
+          label={t("company")}
           name="shipping_address.company"
           value={formData["shipping_address.company"]}
           onChange={handleChange}

--- a/src/modules/checkout/components/shipping/index.tsx
+++ b/src/modules/checkout/components/shipping/index.tsx
@@ -240,7 +240,7 @@ const Shipping: React.FC<ShippingProps> = ({
                 className="text-ui-fg-interactive hover:text-ui-fg-interactive-hover"
                 data-testid="edit-delivery-button"
               >
-                Edit
+                {t("edit")}
               </button>
             </Text>
           )}


### PR DESCRIPTION
### Motivation
- Ensure all checkout UI strings are localized and the `termsAgree` text correctly renders linked `terms` and `privacy` placeholders for i18n consumers.

### Description
- Replace `t("termsAgree")` with `t.rich("termsAgree", { terms: ..., privacy: ... })` in `src/modules/checkout/components/review/index.tsx` so the `{terms}` and `{privacy}` placeholders render as links to `/terms` and `/privacy`.
- Add missing `checkout` keys (`company`, `contact`, `edit`, `backToCart`, `addPromoCode`, `billingSameAsDelivery`) and update `termsAgree` to use rich tags in `messages/en.json` and `messages/zh.json`.
- Replace remaining hardcoded checkout strings with `t()` calls in checkout components: `Edit` buttons (`addresses`, `shipping`, `payment`), `Contact` and billing/delivery same-address text (`addresses`), and `Company` field labels (`shipping-address`, `billing_address`), and wire `useTranslations` in `discount-code` to use `t("addPromoCode")`.

### Testing
- Parsed `messages/en.json` and `messages/zh.json` with `node` to validate JSON and it succeeded.
- Searched the checkout module for target hardcoded strings to verify replacements and the search returned no remaining occurrences for the specified targets.
- Ran `git diff --check` to ensure no whitespace issues and it reported no problems.
- Attempted `npm run -s lint` but it was blocked due to a missing environment variable (`NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY`).
- Attempted a Playwright screenshot against `http://127.0.0.1:3000`, but it failed with `ERR_EMPTY_RESPONSE` because the app was not serving in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a806a0e640833389beb7a76c9b078d)