### PR TITLE
fix: localize remaining homepage i18n strings

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -52,7 +52,7 @@
     "brandStory": "Our Story",
     "brandStoryText": "NordHjem was born from a love of Scandinavian simplicity. We believe your home should be a sanctuary — filled with pieces that are beautiful, functional, and built to last.",
     "brandStoryCta": "Learn More",
-    "viewAll": "View All",
+    "viewAll": "View all",
     "bestSellers": "Best Sellers",
     "category_livingRoom": "Living Room",
     "category_livingRoom_sub": "Sofas, Coffee Tables, Lighting",

--- a/src/modules/home/components/featured-products/product-rail/index.tsx
+++ b/src/modules/home/components/featured-products/product-rail/index.tsx
@@ -1,6 +1,7 @@
 import { listProducts } from "@lib/data/products"
 import { HttpTypes } from "@medusajs/types"
 import { Text } from "@medusajs/ui"
+import { getTranslations } from "next-intl/server"
 
 import InteractiveLink from "@modules/common/components/interactive-link"
 import ProductPreview from "@modules/products/components/product-preview"
@@ -12,6 +13,8 @@ export default async function ProductRail({
   collection: HttpTypes.StoreCollection
   region: HttpTypes.StoreRegion
 }) {
+  const t = await getTranslations("home")
+
   const {
     response: { products: pricedProducts },
   } = await listProducts({
@@ -31,7 +34,7 @@ export default async function ProductRail({
       <div className="flex justify-between mb-8">
         <Text className="txt-xlarge">{collection.title}</Text>
         <InteractiveLink href={`/collections/${collection.handle}`}>
-          View all
+          {t("viewAll")}
         </InteractiveLink>
       </div>
       <ul className="grid grid-cols-2 small:grid-cols-3 gap-x-6 gap-y-24 small:gap-y-36">

--- a/src/modules/layout/components/cart-dropdown/index.tsx
+++ b/src/modules/layout/components/cart-dropdown/index.tsx
@@ -14,6 +14,7 @@ import LineItemOptions from "@modules/common/components/line-item-options"
 import LineItemPrice from "@modules/common/components/line-item-price"
 import LocalizedClientLink from "@modules/common/components/localized-client-link"
 import Thumbnail from "@modules/products/components/thumbnail"
+import { useTranslations } from "next-intl"
 import { usePathname } from "next/navigation"
 import { Fragment, useEffect, useRef, useState } from "react"
 
@@ -22,6 +23,7 @@ const CartDropdown = ({
 }: {
   cart?: HttpTypes.StoreCart | null
 }) => {
+  const t = useTranslations("nav")
   const [activeTimer, setActiveTimer] = useState<NodeJS.Timer | undefined>(
     undefined
   )
@@ -85,7 +87,7 @@ const CartDropdown = ({
             className="hover:text-ui-fg-base"
             href="/cart"
             data-testid="nav-cart-link"
-          >{`Cart (${totalItems})`}</LocalizedClientLink>
+          >{`${t("cart")} (${totalItems})`}</LocalizedClientLink>
         </PopoverButton>
         <Transition
           show={cartDropdownOpen}


### PR DESCRIPTION
### Motivation
- Fix remaining frontend i18n issues on the homepage: the navbar cart label (`Cart (0)`) and the product rail `View all` link, and verify whether footer category labels require localization.

### Description
- Replace hardcoded navbar cart label in `src/modules/layout/components/cart-dropdown/index.tsx` with `t("cart")` from the `nav` namespace using `useTranslations` for client-side localization. 
- Replace hardcoded `View all` in `src/modules/home/components/featured-products/product-rail/index.tsx` with `t("viewAll")` from the `home` namespace using `getTranslations` on the server component. 
- Update `messages/en.json` to ensure `home.viewAll` is present as `"View all"` (and keep `messages/zh.json` with `"查看全部"`).
- Leave footer category labels unchanged because they are sourced from Medusa API via `listCategories()` (`c.name` / `child.name`) and therefore are not front-end hardcoded strings.

### Testing
- Searched project for occurrences of affected strings with `rg` to find impacted files and verify replacements, which succeeded. 
- Attempted `npm run build` to validate the app, but it failed due to `next` not being available in this environment so a full build could not be completed. 
- Attempted `npm install` to fetch dependencies, but the registry returned `403 Forbidden`, preventing installation and subsequent build validation. 
- Attempted a Playwright page screenshot to verify runtime UI, but the local dev server was not reachable (`net::ERR_EMPTY_RESPONSE`), so end-to-end verification could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a8182178148333a23143559f43628e)