### PR TITLE
feat: product page — nordic styling and i18n for product tabs

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -89,7 +89,19 @@
     "returnPolicy": "Return Policy",
     "freeShipping": "Free shipping on orders over {amount}",
     "selectVariant": "Select an option",
-    "unavailable": "Currently unavailable"
+    "unavailable": "Currently unavailable",
+    "productInformation": "Product Information",
+    "shippingAndReturns": "Shipping & Returns",
+    "countryOfOrigin": "Country of origin",
+    "type": "Type",
+    "fastDelivery": "Fast delivery",
+    "fastDeliveryDescription": "Your package will arrive in 3-5 business days...",
+    "simpleExchanges": "Simple exchanges",
+    "simpleExchangesDescription": "Is the fit not quite right?...",
+    "easyReturns": "Easy returns",
+    "easyReturnsDescription": "Just return your product...",
+    "relatedProductsTitle": "Related products",
+    "relatedProductsDescription": "You might also want to check out these products."
   },
   "collection": {
     "title": "Collections",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -89,7 +89,19 @@
     "returnPolicy": "退换政策",
     "freeShipping": "满 {amount} 免运费",
     "selectVariant": "请选择",
-    "unavailable": "暂时缺货"
+    "unavailable": "暂时缺货",
+    "productInformation": "产品信息",
+    "shippingAndReturns": "配送与退换",
+    "countryOfOrigin": "原产地",
+    "type": "类型",
+    "fastDelivery": "快速配送",
+    "fastDeliveryDescription": "您的包裹将在3-5个工作日内送达。",
+    "simpleExchanges": "轻松换货",
+    "simpleExchangesDescription": "尺寸不合适？没关系，我们会为您更换。",
+    "easyReturns": "便捷退货",
+    "easyReturnsDescription": "退货即可获得退款，无需理由。",
+    "relatedProductsTitle": "相关产品",
+    "relatedProductsDescription": "您可能还喜欢这些产品。"
   },
   "collection": {
     "title": "商品系列",

--- a/src/modules/products/components/product-tabs/accordion.tsx
+++ b/src/modules/products/components/product-tabs/accordion.tsx
@@ -56,7 +56,7 @@ const Item: React.FC<AccordionItemProps> = ({
         <div className="flex flex-col">
           <div className="flex w-full items-center justify-between">
             <div className="flex items-center gap-4">
-              <Text className="text-ui-fg-subtle text-sm">{title}</Text>
+              <Text className="text-[#2C3E2D] text-sm">{title}</Text>
             </div>
             <AccordionPrimitive.Trigger>
               {customTrigger || <MorphingTrigger />}

--- a/src/modules/products/components/product-tabs/index.tsx
+++ b/src/modules/products/components/product-tabs/index.tsx
@@ -3,6 +3,7 @@
 import Back from "@modules/common/icons/back"
 import FastDelivery from "@modules/common/icons/fast-delivery"
 import Refresh from "@modules/common/icons/refresh"
+import { useTranslations } from "next-intl"
 
 import Accordion from "./accordion"
 import { HttpTypes } from "@medusajs/types"
@@ -12,14 +13,16 @@ type ProductTabsProps = {
 }
 
 const ProductTabs = ({ product }: ProductTabsProps) => {
+  const t = useTranslations("product")
+
   const tabs = [
     {
-      label: "Product Information",
-      component: <ProductInfoTab product={product} />,
+      label: t("productInformation"),
+      component: <ProductInfoTab product={product} t={t} />,
     },
     {
-      label: "Shipping & Returns",
-      component: <ShippingInfoTab />,
+      label: t("shippingAndReturns"),
+      component: <ShippingInfoTab t={t} />,
     },
   ]
 
@@ -41,31 +44,34 @@ const ProductTabs = ({ product }: ProductTabsProps) => {
   )
 }
 
-const ProductInfoTab = ({ product }: ProductTabsProps) => {
+const ProductInfoTab = ({
+  product,
+  t,
+}: ProductTabsProps & { t: ReturnType<typeof useTranslations> }) => {
   return (
-    <div className="text-small-regular py-8">
+    <div className="text-small-regular py-8 text-[#2C3E2D]/60">
       <div className="grid grid-cols-2 gap-x-8">
         <div className="flex flex-col gap-y-4">
           <div>
-            <span className="font-semibold">Material</span>
+            <span className="font-semibold">{t("material")}</span>
             <p>{product.material ? product.material : "-"}</p>
           </div>
           <div>
-            <span className="font-semibold">Country of origin</span>
+            <span className="font-semibold">{t("countryOfOrigin")}</span>
             <p>{product.origin_country ? product.origin_country : "-"}</p>
           </div>
           <div>
-            <span className="font-semibold">Type</span>
+            <span className="font-semibold">{t("type")}</span>
             <p>{product.type ? product.type.value : "-"}</p>
           </div>
         </div>
         <div className="flex flex-col gap-y-4">
           <div>
-            <span className="font-semibold">Weight</span>
+            <span className="font-semibold">{t("weight")}</span>
             <p>{product.weight ? `${product.weight} g` : "-"}</p>
           </div>
           <div>
-            <span className="font-semibold">Dimensions</span>
+            <span className="font-semibold">{t("dimensions")}</span>
             <p>
               {product.length && product.width && product.height
                 ? `${product.length}L x ${product.width}W x ${product.height}H`
@@ -78,38 +84,38 @@ const ProductInfoTab = ({ product }: ProductTabsProps) => {
   )
 }
 
-const ShippingInfoTab = () => {
+const ShippingInfoTab = ({
+  t,
+}: {
+  t: ReturnType<typeof useTranslations>
+}) => {
   return (
-    <div className="text-small-regular py-8">
+    <div className="text-small-regular py-8 text-[#2C3E2D]/60">
       <div className="grid grid-cols-1 gap-y-8">
         <div className="flex items-start gap-x-2">
           <FastDelivery />
           <div>
-            <span className="font-semibold">Fast delivery</span>
+            <span className="font-semibold">{t("fastDelivery")}</span>
             <p className="max-w-sm">
-              Your package will arrive in 3-5 business days at your pick up
-              location or in the comfort of your home.
+              {t("fastDeliveryDescription")}
             </p>
           </div>
         </div>
         <div className="flex items-start gap-x-2">
           <Refresh />
           <div>
-            <span className="font-semibold">Simple exchanges</span>
+            <span className="font-semibold">{t("simpleExchanges")}</span>
             <p className="max-w-sm">
-              Is the fit not quite right? No worries - we&apos;ll exchange your
-              product for a new one.
+              {t("simpleExchangesDescription")}
             </p>
           </div>
         </div>
         <div className="flex items-start gap-x-2">
           <Back />
           <div>
-            <span className="font-semibold">Easy returns</span>
+            <span className="font-semibold">{t("easyReturns")}</span>
             <p className="max-w-sm">
-              Just return your product and we&apos;ll refund your money. No
-              questions asked – we&apos;ll do our best to make sure your return
-              is hassle-free.
+              {t("easyReturnsDescription")}
             </p>
           </div>
         </div>

--- a/src/modules/products/components/related-products/index.tsx
+++ b/src/modules/products/components/related-products/index.tsx
@@ -2,6 +2,7 @@ import { listProducts } from "@lib/data/products"
 import { getRegion } from "@lib/data/regions"
 import { HttpTypes } from "@medusajs/types"
 import Product from "../product-preview"
+import { getTranslations } from "next-intl/server"
 
 type RelatedProductsProps = {
   product: HttpTypes.StoreProduct
@@ -12,6 +13,7 @@ export default async function RelatedProducts({
   product,
   countryCode,
 }: RelatedProductsProps) {
+  const t = await getTranslations("product")
   const region = await getRegion(countryCode)
 
   if (!region) {
@@ -50,10 +52,10 @@ export default async function RelatedProducts({
     <div className="product-page-constraint">
       <div className="flex flex-col items-center text-center mb-16">
         <span className="text-base-regular text-gray-600 mb-6">
-          Related products
+          {t("relatedProductsTitle")}
         </span>
         <p className="text-2xl-regular text-ui-fg-base max-w-lg">
-          You might also want to check out these products.
+          {t("relatedProductsDescription")}
         </p>
       </div>
 

--- a/src/modules/products/templates/index.tsx
+++ b/src/modules/products/templates/index.tsx
@@ -32,7 +32,7 @@ const ProductTemplate: React.FC<ProductTemplateProps> = ({
   return (
     <>
       <div
-        className="content-container  flex flex-col small:flex-row small:items-start py-6 relative"
+        className="content-container bg-[#FAFAF8] flex flex-col small:flex-row small:items-start py-6 relative"
         data-testid="product-container"
       >
         <div className="flex flex-col small:sticky small:top-48 small:py-0 small:max-w-[300px] w-full py-8 gap-y-6">

--- a/src/modules/products/templates/product-info/index.tsx
+++ b/src/modules/products/templates/product-info/index.tsx
@@ -20,14 +20,14 @@ const ProductInfo = ({ product }: ProductInfoProps) => {
         )}
         <Heading
           level="h2"
-          className="text-3xl leading-10 text-ui-fg-base"
+          className="text-3xl leading-10 text-[#2C3E2D]"
           data-testid="product-title"
         >
           {product.title}
         </Heading>
 
         <Text
-          className="text-medium text-ui-fg-subtle whitespace-pre-line"
+          className="text-medium text-[#2C3E2D]/70 whitespace-pre-line"
           data-testid="product-description"
         >
           {product.description}


### PR DESCRIPTION
### Motivation
- Add i18n for product tab strings and related-products copy and apply Nordic-inspired visual refinements to the product detail page so content and style match the new design language.

### Description
- Replace hardcoded strings in the product tabs with `useTranslations("product")` in `src/modules/products/components/product-tabs/index.tsx` and pass translations into tab components.
- Use `getTranslations("product")` in the async server component `src/modules/products/components/related-products/index.tsx` and replace the related-products title/description with translation keys.
- Add the required translation keys to `messages/en.json` and `messages/zh.json` for tab labels, shipping/exchange/return copy, and related-products copy.
- Apply Nordic style tweaks: set product page background to `bg-[#FAFAF8]`, change product title to `text-[#2C3E2D]`, description to `text-[#2C3E2D]/70`, and update tab heading/content colors via `src/modules/products/components/product-tabs/accordion.tsx` and related files.

### Testing
- Ran `npm run build` which failed due to a missing required environment variable `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY`.
- Ran `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY=dummy npm run build` which proceeded but failed in this environment due to Google Fonts fetch/network errors.
- Started the dev server with `npm run dev` (with a dummy publishable key) and captured a product page screenshot at `artifacts/product-page-nordic.png` to verify visual changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a8201d417c8333849d8bbc6c9b6f61)