### PR TITLE
feat(store): localize store list page and apply Nordic styling tweaks

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -277,5 +277,12 @@
     "currency": "Currency",
     "english": "English",
     "chinese": "中文"
+  },
+  "store": {
+    "allProducts": "All products",
+    "sortBy": "Sort by",
+    "latestArrivals": "Latest Arrivals",
+    "priceLowToHigh": "Price: Low -> High",
+    "priceHighToLow": "Price: High -> Low"
   }
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -277,5 +277,12 @@
     "currency": "货币",
     "english": "English",
     "chinese": "中文"
+  },
+  "store": {
+    "allProducts": "所有商品",
+    "sortBy": "排序方式",
+    "latestArrivals": "最新上架",
+    "priceLowToHigh": "价格：从低到高",
+    "priceHighToLow": "价格：从高到低"
   }
 }

--- a/src/modules/store/components/refinement-list/sort-products/index.tsx
+++ b/src/modules/store/components/refinement-list/sort-products/index.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import FilterRadioGroup from "@modules/common/components/filter-radio-group"
+import { useTranslations } from "next-intl"
 
 export type SortOptions = "price_asc" | "price_desc" | "created_at"
 
@@ -10,33 +11,35 @@ type SortProductsProps = {
   "data-testid"?: string
 }
 
-const sortOptions = [
-  {
-    value: "created_at",
-    label: "Latest Arrivals",
-  },
-  {
-    value: "price_asc",
-    label: "Price: Low -> High",
-  },
-  {
-    value: "price_desc",
-    label: "Price: High -> Low",
-  },
-]
-
 const SortProducts = ({
   "data-testid": dataTestId,
   sortBy,
   setQueryParams,
 }: SortProductsProps) => {
+  const t = useTranslations("store")
+
+  const sortOptions = [
+    {
+      value: "created_at" as const,
+      label: t("latestArrivals"),
+    },
+    {
+      value: "price_asc" as const,
+      label: t("priceLowToHigh"),
+    },
+    {
+      value: "price_desc" as const,
+      label: t("priceHighToLow"),
+    },
+  ]
+
   const handleChange = (value: SortOptions) => {
     setQueryParams("sortBy", value)
   }
 
   return (
     <FilterRadioGroup
-      title="Sort by"
+      title={t("sortBy")}
       items={sortOptions}
       value={sortBy}
       handleChange={handleChange}

--- a/src/modules/store/templates/index.tsx
+++ b/src/modules/store/templates/index.tsx
@@ -3,10 +3,11 @@ import { Suspense } from "react"
 import SkeletonProductGrid from "@modules/skeletons/templates/skeleton-product-grid"
 import RefinementList from "@modules/store/components/refinement-list"
 import { SortOptions } from "@modules/store/components/refinement-list/sort-products"
+import { getTranslations } from "next-intl/server"
 
 import PaginatedProducts from "./paginated-products"
 
-const StoreTemplate = ({
+const StoreTemplate = async ({
   sortBy,
   page,
   countryCode,
@@ -15,18 +16,19 @@ const StoreTemplate = ({
   page?: string
   countryCode: string
 }) => {
+  const t = await getTranslations("store")
   const pageNumber = page ? parseInt(page) : 1
   const sort = sortBy || "created_at"
 
   return (
     <div
-      className="flex flex-col small:flex-row small:items-start py-6 content-container"
+      className="flex flex-col small:flex-row small:items-start py-6 content-container bg-[#FAFAF8]"
       data-testid="category-container"
     >
       <RefinementList sortBy={sort} />
       <div className="w-full">
-        <div className="mb-8 text-2xl-semi">
-          <h1 data-testid="store-page-title">All products</h1>
+        <div className="mb-8 text-2xl-semi text-[#2C3E2D] font-heading">
+          <h1 data-testid="store-page-title">{t("allProducts")}</h1>
         </div>
         <Suspense fallback={<SkeletonProductGrid />}>
           <PaginatedProducts


### PR DESCRIPTION
### Motivation
- Provide i18n for the store listing UI and make sort labels translatable for multi-language support.
- Apply small Nordic-themed visual adjustments to the store listing page to match the design direction.

### Description
- Added a new `store` namespace to `messages/en.json` and `messages/zh.json` with keys `allProducts`, `sortBy`, `latestArrivals`, `priceLowToHigh`, and `priceHighToLow`.
- Updated `src/modules/store/templates/index.tsx` to be an async server component that calls `getTranslations("store")`, replaced the hard-coded title with `{t("allProducts")}`, and added `bg-[#FAFAF8]` plus `text-[#2C3E2D] font-heading` for the page heading.
- Updated `src/modules/store/components/refinement-list/sort-products/index.tsx` to import `useTranslations("store")`, move `sortOptions` inside the client component and build labels with `t(...)`, and change the `title` prop to `t("sortBy")`.
- Kept all other code and configuration unchanged and preserved types for `SortOptions`.

### Testing
- Ran `npm run build`, which failed due to missing required environment variable `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY` in this environment; failure is environment-related and not caused by the code changes.
- Verified updated files compile locally in-editor (no runtime exceptions observed from the applied changes during static inspection).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a82361f9a0833386895280440f5e37)