### PR TITLE
feat(i18n): localize collection names and finish remaining product UI copy

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -101,7 +101,10 @@
     "easyReturns": "Easy returns",
     "easyReturnsDescription": "Just return your product...",
     "relatedProductsTitle": "Related products",
-    "relatedProductsDescription": "You might also want to check out these products."
+    "relatedProductsDescription": "You might also want to check out these products.",
+    "adding": "Adding...",
+    "from": "From",
+    "originalPrice": "Original"
   },
   "collection": {
     "title": "Collections",
@@ -125,7 +128,17 @@
     "pagination": "Page {current} of {total}",
     "prevPage": "Previous",
     "nextPage": "Next",
-    "itemsPerPage": "Items per page"
+    "itemsPerPage": "Items per page",
+    "names": {
+      "living-room": "Living Room",
+      "bedroom": "Bedroom",
+      "dining": "Dining",
+      "office": "Office",
+      "lighting": "Lighting",
+      "outdoor": "Outdoor",
+      "storage": "Storage",
+      "decor": "Decor"
+    }
   },
   "cart": {
     "title": "Shopping Cart",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -101,7 +101,10 @@
     "easyReturns": "便捷退货",
     "easyReturnsDescription": "退货即可获得退款，无需理由。",
     "relatedProductsTitle": "相关产品",
-    "relatedProductsDescription": "您可能还喜欢这些产品。"
+    "relatedProductsDescription": "您可能还喜欢这些产品。",
+    "adding": "添加中...",
+    "from": "起",
+    "originalPrice": "原价"
   },
   "collection": {
     "title": "商品系列",
@@ -125,7 +128,17 @@
     "pagination": "第 {current} 页，共 {total} 页",
     "prevPage": "上一页",
     "nextPage": "下一页",
-    "itemsPerPage": "每页显示"
+    "itemsPerPage": "每页显示",
+    "names": {
+      "living-room": "客厅",
+      "bedroom": "卧室",
+      "dining": "餐厅",
+      "office": "办公",
+      "lighting": "灯具",
+      "outdoor": "户外",
+      "storage": "收纳",
+      "decor": "装饰"
+    }
   },
   "cart": {
     "title": "购物车",

--- a/src/lib/util/collection-name.ts
+++ b/src/lib/util/collection-name.ts
@@ -1,0 +1,20 @@
+/**
+ * Get localized collection name by handle.
+ * Falls back to the original title from Medusa if no translation found.
+ */
+export function getLocalizedCollectionName(
+  handle: string | undefined,
+  title: string,
+  t: (key: string) => string
+): string {
+  if (!handle) return title
+
+  const localized = t(`names.${handle}`)
+
+  // next-intl returns the key path if translation is missing
+  if (localized === `names.${handle}` || localized.startsWith("collection.names.")) {
+    return title
+  }
+
+  return localized
+}

--- a/src/modules/collections/templates/index.tsx
+++ b/src/modules/collections/templates/index.tsx
@@ -1,12 +1,14 @@
 import { Suspense } from "react"
+import { getTranslations } from "next-intl/server"
 
+import { getLocalizedCollectionName } from "@lib/util/collection-name"
 import SkeletonProductGrid from "@modules/skeletons/templates/skeleton-product-grid"
 import RefinementList from "@modules/store/components/refinement-list"
 import { SortOptions } from "@modules/store/components/refinement-list/sort-products"
 import PaginatedProducts from "@modules/store/templates/paginated-products"
 import { HttpTypes } from "@medusajs/types"
 
-export default function CollectionTemplate({
+export default async function CollectionTemplate({
   sortBy,
   collection,
   page,
@@ -17,6 +19,7 @@ export default function CollectionTemplate({
   page?: string
   countryCode: string
 }) {
+  const t = await getTranslations("collection")
   const pageNumber = page ? parseInt(page) : 1
   const sort = sortBy || "created_at"
 
@@ -25,7 +28,9 @@ export default function CollectionTemplate({
       <RefinementList sortBy={sort} />
       <div className="w-full">
         <div className="mb-8 text-2xl-semi">
-          <h1>{collection.title}</h1>
+          <h1>
+            {getLocalizedCollectionName(collection.handle, collection.title, t)}
+          </h1>
         </div>
         <Suspense
           fallback={

--- a/src/modules/home/components/featured-products/product-rail/index.tsx
+++ b/src/modules/home/components/featured-products/product-rail/index.tsx
@@ -1,4 +1,5 @@
 import { listProducts } from "@lib/data/products"
+import { getLocalizedCollectionName } from "@lib/util/collection-name"
 import { HttpTypes } from "@medusajs/types"
 import { Text } from "@medusajs/ui"
 import { getTranslations } from "next-intl/server"
@@ -14,6 +15,7 @@ export default async function ProductRail({
   region: HttpTypes.StoreRegion
 }) {
   const t = await getTranslations("home")
+  const tCollection = await getTranslations("collection")
 
   const {
     response: { products: pricedProducts },
@@ -32,7 +34,13 @@ export default async function ProductRail({
   return (
     <div className="content-container py-12 small:py-24">
       <div className="flex justify-between mb-8">
-        <Text className="txt-xlarge">{collection.title}</Text>
+        <Text className="txt-xlarge">
+          {getLocalizedCollectionName(
+            collection.handle,
+            collection.title,
+            tCollection
+          )}
+        </Text>
         <InteractiveLink href={`/collections/${collection.handle}`}>
           {t("viewAll")}
         </InteractiveLink>

--- a/src/modules/products/components/product-actions/index.tsx
+++ b/src/modules/products/components/product-actions/index.tsx
@@ -8,6 +8,7 @@ import Divider from "@modules/common/components/divider"
 import OptionSelect from "@modules/products/components/product-actions/option-select"
 import { isEqual } from "lodash"
 import { useParams, usePathname, useSearchParams } from "next/navigation"
+import { useTranslations } from "next-intl"
 import { useEffect, useMemo, useRef, useState } from "react"
 import ProductPrice from "../product-price"
 import MobileActions from "./mobile-actions"
@@ -39,6 +40,7 @@ export default function ProductActions({
   const [options, setOptions] = useState<Record<string, string | undefined>>({})
   const [isAdding, setIsAdding] = useState(false)
   const countryCode = useParams().countryCode as string
+  const t = useTranslations("product")
 
   // If there is only 1 variant, preselect the options
   useEffect(() => {
@@ -177,10 +179,10 @@ export default function ProductActions({
           data-testid="add-product-button"
         >
           {!selectedVariant && !options
-            ? "Select variant"
+            ? t("selectVariant")
             : !inStock || !isValidVariant
-            ? "Out of stock"
-            : "Add to cart"}
+            ? t("outOfStock")
+            : t("addToCart")}
         </Button>
         <MobileActions
           product={product}

--- a/src/modules/products/components/product-actions/mobile-actions.tsx
+++ b/src/modules/products/components/product-actions/mobile-actions.tsx
@@ -1,6 +1,7 @@
 import { Dialog, Transition } from "@headlessui/react"
 import { Button, clx } from "@medusajs/ui"
 import React, { Fragment, useMemo } from "react"
+import { useTranslations } from "next-intl"
 
 import useToggleState from "@lib/hooks/use-toggle-state"
 import ChevronDown from "@modules/common/icons/chevron-down"
@@ -35,6 +36,7 @@ const MobileActions: React.FC<MobileActionsProps> = ({
   optionsDisabled,
 }) => {
   const { state, open, close } = useToggleState()
+  const t = useTranslations("product")
 
   const price = getProductPrice({
     product: product,
@@ -111,7 +113,7 @@ const MobileActions: React.FC<MobileActionsProps> = ({
                   <span>
                     {variant
                       ? Object.values(options).join(" / ")
-                      : "Select Options"}
+                      : t("selectVariant")}
                   </span>
                   <ChevronDown />
                 </div>
@@ -124,10 +126,10 @@ const MobileActions: React.FC<MobileActionsProps> = ({
                 data-testid="mobile-cart-button"
               >
                 {!variant
-                  ? "Select variant"
+                  ? t("selectVariant")
                   : !inStock
-                  ? "Out of stock"
-                  : "Add to cart"}
+                  ? t("outOfStock")
+                  : t("addToCart")}
               </Button>
             </div>
           </div>

--- a/src/modules/products/components/product-price/index.tsx
+++ b/src/modules/products/components/product-price/index.tsx
@@ -1,7 +1,10 @@
+"use client"
+
 import { clx } from "@medusajs/ui"
 
 import { getProductPrice } from "@lib/util/get-product-price"
 import { HttpTypes } from "@medusajs/types"
+import { useTranslations } from "next-intl"
 
 export default function ProductPrice({
   product,
@@ -10,6 +13,8 @@ export default function ProductPrice({
   product: HttpTypes.StoreProduct
   variant?: HttpTypes.StoreProductVariant
 }) {
+  const t = useTranslations("product")
+
   const { cheapestPrice, variantPrice } = getProductPrice({
     product,
     variantId: variant?.id,
@@ -28,7 +33,7 @@ export default function ProductPrice({
           "text-ui-fg-interactive": selectedPrice.price_type === "sale",
         })}
       >
-        {!variant && "From "}
+        {!variant && `${t("from")} `}
         <span
           data-testid="product-price"
           data-value={selectedPrice.calculated_price_number}
@@ -39,7 +44,7 @@ export default function ProductPrice({
       {selectedPrice.price_type === "sale" && (
         <>
           <p>
-            <span className="text-ui-fg-subtle">Original: </span>
+            <span className="text-ui-fg-subtle">{t("originalPrice")}: </span>
             <span
               className="line-through"
               data-testid="original-product-price"

--- a/src/modules/products/templates/product-info/index.tsx
+++ b/src/modules/products/templates/product-info/index.tsx
@@ -1,12 +1,16 @@
+import { getLocalizedCollectionName } from "@lib/util/collection-name"
 import { HttpTypes } from "@medusajs/types"
 import { Heading, Text } from "@medusajs/ui"
 import LocalizedClientLink from "@modules/common/components/localized-client-link"
+import { getTranslations } from "next-intl/server"
 
 type ProductInfoProps = {
   product: HttpTypes.StoreProduct
 }
 
-const ProductInfo = ({ product }: ProductInfoProps) => {
+const ProductInfo = async ({ product }: ProductInfoProps) => {
+  const tCollection = await getTranslations("collection")
+
   return (
     <div id="product-info">
       <div className="flex flex-col gap-y-4 lg:max-w-[500px] mx-auto">
@@ -15,7 +19,11 @@ const ProductInfo = ({ product }: ProductInfoProps) => {
             href={`/collections/${product.collection.handle}`}
             className="text-medium text-ui-fg-muted hover:text-ui-fg-subtle"
           >
-            {product.collection.title}
+            {getLocalizedCollectionName(
+              product.collection.handle,
+              product.collection.title,
+              tCollection
+            )}
           </LocalizedClientLink>
         )}
         <Heading


### PR DESCRIPTION
### Motivation
- Medusa Admin does not provide multi-language collection names, so the storefront must map collection handles to localized names and fall back to Medusa titles when missing. 
- Several product UI labels remained hard-coded in English and needed to be replaced with i18n keys to ensure full localization parity.

### Description
- Added `collection.names` mappings (8 handles) to both `messages/en.json` and `messages/zh.json` and added missing `product` keys `adding`, `from`, and `originalPrice` in both locales.
- Added `src/lib/util/collection-name.ts` with `getLocalizedCollectionName(handle, title, t)` that falls back to the original `title` if no translation exists.
- Updated components to use localized collection names: `src/modules/collections/templates/index.tsx` (converted to async and uses `getTranslations("collection")`), `src/modules/home/components/featured-products/product-rail/index.tsx`, and `src/modules/products/templates/product-info/index.tsx` (converted to async).
- Replaced remaining hard-coded product UI strings with translations in `src/modules/products/components/product-actions/index.tsx` and `src/modules/products/components/product-actions/mobile-actions.tsx` (use `useTranslations("product")`).
- Converted `src/modules/products/components/product-price/index.tsx` to a Client Component (`"use client"`) and localized the "From" and "Original" labels using `useTranslations("product")`.

### Testing
- Attempted `npm run build`, which failed due to missing required environment variable `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY` (Next.js prevents building without it).
- Attempted `npm run lint`, which failed for the same missing environment variable during Next startup.
- Verified locale parity with a script that confirmed the `product` keys and `collection.names` handle sets match between `en` and `zh` (succeeded).
- Started the dev server with a dummy `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY` and captured a storefront screenshot for visual review (dev server and screenshot capture succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a834e17ec88333968446a0c3432aaa)