### PR TITLE
fix: frontend bugs batch 1 - redirect, price, title, i18n

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -60,6 +60,24 @@ const nextConfig = {
         : []),
     ],
   },
+  async redirects() {
+    const defaultLocale = "en"
+    const defaultCountryCode =
+      process.env.NEXT_PUBLIC_DEFAULT_REGION?.toLowerCase() || "us"
+
+    return [
+      {
+        source: "/",
+        destination: `/${defaultLocale}/${defaultCountryCode}`,
+        permanent: false,
+      },
+      {
+        source: `/${defaultLocale}`,
+        destination: `/${defaultLocale}/${defaultCountryCode}`,
+        permanent: false,
+      },
+    ]
+  },
 }
 
 module.exports = withNextIntl(nextConfig)

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,6 +25,7 @@ const notoSansSC = Noto_Sans_SC({
 
 export const metadata: Metadata = {
   metadataBase: new URL(getBaseURL()),
+  title: "NordHjem - Nordic Minimalist Furniture",
 }
 
 export default function RootLayout(props: { children: React.ReactNode }) {

--- a/src/lib/util/money.ts
+++ b/src/lib/util/money.ts
@@ -26,5 +26,5 @@ export const convertToLocale = ({
         minimumFractionDigits,
         maximumFractionDigits,
       }).format(amount / 100)
-    : amount.toString()
+    : (amount / 100).toFixed(2)
 }

--- a/src/modules/layout/components/cart-dropdown/index.tsx
+++ b/src/modules/layout/components/cart-dropdown/index.tsx
@@ -24,6 +24,7 @@ const CartDropdown = ({
   cart?: HttpTypes.StoreCart | null
 }) => {
   const t = useTranslations("nav")
+  const tCart = useTranslations("cart")
   const [activeTimer, setActiveTimer] = useState<NodeJS.Timer | undefined>(
     undefined
   )
@@ -105,7 +106,7 @@ const CartDropdown = ({
             data-testid="nav-cart-dropdown"
           >
             <div className="p-4 flex items-center justify-center">
-              <h3 className="text-large-semi">Cart</h3>
+              <h3 className="text-large-semi">{tCart("title")}</h3>
             </div>
             {cartState && cartState.items?.length ? (
               <>
@@ -153,7 +154,7 @@ const CartDropdown = ({
                                   data-testid="cart-item-quantity"
                                   data-value={item.quantity}
                                 >
-                                  Quantity: {item.quantity}
+                                  {tCart("quantity")}: {item.quantity}
                                 </span>
                               </div>
                               <div className="flex justify-end">
@@ -170,7 +171,7 @@ const CartDropdown = ({
                             className="mt-1"
                             data-testid="cart-item-remove-button"
                           >
-                            Remove
+                            {tCart("remove")}
                           </DeleteButton>
                         </div>
                       </div>
@@ -179,7 +180,7 @@ const CartDropdown = ({
                 <div className="p-4 flex flex-col gap-y-4 text-small-regular">
                   <div className="flex items-center justify-between">
                     <span className="text-ui-fg-base font-semibold">
-                      Subtotal{" "}
+                      {tCart("subtotal")}{" "}
                       <span className="font-normal">(excl. taxes)</span>
                     </span>
                     <span
@@ -199,7 +200,7 @@ const CartDropdown = ({
                       size="large"
                       data-testid="go-to-cart-button"
                     >
-                      Go to cart
+                      {tCart("title")}
                     </Button>
                   </LocalizedClientLink>
                 </div>
@@ -210,12 +211,12 @@ const CartDropdown = ({
                   <div className="bg-gray-900 text-small-regular flex items-center justify-center w-6 h-6 rounded-full text-white">
                     <span>0</span>
                   </div>
-                  <span>Your shopping bag is empty.</span>
+                  <span>{tCart("empty")}</span>
                   <div>
                     <LocalizedClientLink href="/store">
                       <>
-                        <span className="sr-only">Go to all products page</span>
-                        <Button onClick={close}>Explore products</Button>
+                        <span className="sr-only">{tCart("continueShopping")}</span>
+                        <Button onClick={close}>{tCart("continueShopping")}</Button>
                       </>
                     </LocalizedClientLink>
                   </div>

--- a/src/modules/layout/templates/footer/index.tsx
+++ b/src/modules/layout/templates/footer/index.tsx
@@ -1,6 +1,7 @@
 import { getTranslations } from "next-intl/server"
 
 import { listCategories } from "@lib/data/categories"
+import { getLocale } from "@lib/data/locale-actions"
 import { Text, clx } from "@medusajs/ui"
 
 import LocalizedClientLink from "@modules/common/components/localized-client-link"
@@ -8,7 +9,16 @@ import LocalizedClientLink from "@modules/common/components/localized-client-lin
 export default async function Footer() {
   const t = await getTranslations("footer")
   const homeT = await getTranslations("home")
-  const productCategories = await listCategories()
+  const collectionNamesT = await getTranslations("collection.names")
+  const [productCategories, currentLocale] = await Promise.all([listCategories(), getLocale()])
+
+  const getCategoryLabel = (handle: string, fallback: string) => {
+    if (currentLocale !== "zh") {
+      return fallback
+    }
+
+    return collectionNamesT.has(handle) ? collectionNamesT(handle) : fallback
+  }
 
   return (
     <footer className="border-t border-forest/10 w-full bg-forest text-warm">
@@ -125,7 +135,7 @@ export default async function Footer() {
                           href={`/categories/${c.handle}`}
                           data-testid="category-link"
                         >
-                          {c.name}
+                          {getCategoryLabel(c.handle, c.name)}
                         </LocalizedClientLink>
                         {children && (
                           <ul className="grid grid-cols-1 ml-3 gap-2">
@@ -136,7 +146,7 @@ export default async function Footer() {
                                   href={`/categories/${child.handle}`}
                                   data-testid="category-link"
                                 >
-                                  {child.name}
+                                  {getCategoryLabel(child.handle, child.name)}
                                 </LocalizedClientLink>
                               </li>
                             ))}


### PR DESCRIPTION
### Motivation
- Fix the root routing issue so `/` (and `/en`) redirect to a language+country path (e.g. `/en/us`) to prevent 404s from locale-only redirects.
- Ensure Medusa monetary values (stored in cents) are always normalized when rendered so prices like `$68,900` do not appear instead of `$689.00`.
- Replace hard-coded UI copy that remained in English (cart dropdown) and make footer category labels follow current locale to complete i18n coverage.
- Make the global browser tab title explicit instead of the default brand placeholder.

### Description
- Added a redirects rule in `next.config.js` to redirect `/` and `/${defaultLocale}` to `/${defaultLocale}/${defaultCountryCode}` as a middleware safety net.
- Set the global metadata title in `src/app/layout.tsx` to `"NordHjem - Nordic Minimalist Furniture"`.
- Updated `convertToLocale` in `src/lib/util/money.ts` so the fallback path treats amounts as cents (`(amount / 100).toFixed(2)`) and existing `Intl.NumberFormat` usage remains for when `currency_code` is present.
- Replaced hardcoded strings in the cart dropdown (`src/modules/layout/components/cart-dropdown/index.tsx`) with `next-intl` translation keys from the `cart` namespace (title, quantity, remove, subtotal, empty, continue shopping).
- Made footer category labels locale-aware by loading `collection.names` and `getLocale` in `src/modules/layout/templates/footer/index.tsx` and preferring localized names when `currentLocale === "zh"`.

### Testing
- Ran `git diff --check` on modified files and it returned clean results (passed).
- Attempted `yarn lint` which fails in this environment due to missing required environment variables and project lint-rule loading issues (not introduced by this change), so lint could not be fully validated here (failed / blocked).
- Ran type-check with `yarn exec tsc --noEmit` which surfaced pre-existing type errors unrelated to these changes (reported but not caused by this PR).
- Launched the dev server (`NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY=dummy yarn dev`) and captured a homepage screenshot using a Playwright script to validate the app starts and root redirect behavior visually (screenshot artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a8a5ba12408333bd9b1e338741cd9c)