### PR TITLE
feat: read category zh_name from Medusa metadata

### DIFF
--- a/src/lib/data/categories.ts
+++ b/src/lib/data/categories.ts
@@ -15,7 +15,7 @@ export const listCategories = async (query?: Record<string, any>) => {
       {
         query: {
           fields:
-            "*category_children, *products, *parent_category, *parent_category.parent_category",
+            "*category_children, *products, *parent_category, *parent_category.parent_category, +metadata, +category_children.metadata",
           limit,
           ...query,
         },

--- a/src/modules/layout/templates/footer/index.tsx
+++ b/src/modules/layout/templates/footer/index.tsx
@@ -9,15 +9,18 @@ import LocalizedClientLink from "@modules/common/components/localized-client-lin
 export default async function Footer() {
   const t = await getTranslations("footer")
   const homeT = await getTranslations("home")
-  const collectionNamesT = await getTranslations("collection.names")
   const [productCategories, currentLocale] = await Promise.all([listCategories(), getLocale()])
 
-  const getCategoryLabel = (handle: string, fallback: string) => {
-    if (currentLocale !== "zh") {
-      return fallback
+  const getCategoryLabel = (category: {
+    handle: string
+    name: string
+    metadata?: Record<string, string> | null
+  }) => {
+    if (currentLocale === "zh" && category.metadata?.zh_name) {
+      return category.metadata.zh_name
     }
 
-    return collectionNamesT.has(handle) ? collectionNamesT(handle) : fallback
+    return category.name
   }
 
   return (
@@ -126,6 +129,7 @@ export default async function Footer() {
                         name: child.name,
                         handle: child.handle,
                         id: child.id,
+                        metadata: child.metadata,
                       })) || null
 
                     return (
@@ -135,7 +139,7 @@ export default async function Footer() {
                           href={`/categories/${c.handle}`}
                           data-testid="category-link"
                         >
-                          {getCategoryLabel(c.handle, c.name)}
+                          {getCategoryLabel(c as { handle: string; name: string; metadata?: Record<string, string> | null })}
                         </LocalizedClientLink>
                         {children && (
                           <ul className="grid grid-cols-1 ml-3 gap-2">
@@ -146,7 +150,7 @@ export default async function Footer() {
                                   href={`/categories/${child.handle}`}
                                   data-testid="category-link"
                                 >
-                                  {getCategoryLabel(child.handle, child.name)}
+                                  {getCategoryLabel(child as { handle: string; name: string; metadata?: Record<string, string> | null })}
                                 </LocalizedClientLink>
                               </li>
                             ))}


### PR DESCRIPTION
### Motivation
- Ensure footer displays category names from Medusa backend for Chinese locale by reading `metadata.zh_name` instead of using a hardcoded translation mapping.

### Description
- Removed the `collectionNamesT` lookup and replaced it with `getCategoryLabel(category)` that returns `category.metadata.zh_name` when `currentLocale === "zh"`, otherwise falls back to `category.name`.
- Updated footer to pass full category objects (including child category `metadata`) into `getCategoryLabel` rather than just `handle`/`name`.
- Extended the categories API query to request `+metadata` and `+category_children.metadata` so `metadata` is available to the footer (`src/lib/data/categories.ts`).
- Changes committed on branch `feat/category-zh-from-metadata` (commit `d418c94`) and PR created with the same title.

### Testing
- Ran `yarn run tsc --noEmit`, which failed due to existing TypeScript errors unrelated to this change, so no clean full type-check could be completed here.
- Attempted `yarn dev`, which could not start due to missing required env var `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY`, so runtime verification on `/zh/us` and `/en/us` was not performed.
- Confirmed the modified files compile locally in isolation (footer/category code only) and committed changes (`git commit`) successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a93fb5bb4c8333a3e53a584967a62b)