### PR TITLE
feat: add Crisp chat widget

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -25,3 +25,5 @@ REVALIDATE_SECRET=supersecret
 # For Cloud users: add your Medusa Cloud S3 hostname and pathname to enable image optimization.
 MEDUSA_CLOUD_S3_HOSTNAME=
 MEDUSA_CLOUD_S3_PATHNAME=
+
+NEXT_PUBLIC_CRISP_WEBSITE_ID=

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import { getBaseURL } from "@lib/util/env"
+import CrispChat from "@modules/common/components/crisp-chat"
 import { Metadata } from "next"
 import "styles/globals.css"
 import { DM_Serif_Display, Inter, Noto_Sans_SC } from "next/font/google"
@@ -37,6 +38,7 @@ export default function RootLayout(props: { children: React.ReactNode }) {
     >
       <body>
         <main className="relative">{props.children}</main>
+        <CrispChat />
       </body>
     </html>
   )

--- a/src/modules/common/components/crisp-chat/index.tsx
+++ b/src/modules/common/components/crisp-chat/index.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import { useEffect } from "react"
+
+declare global {
+  interface Window {
+    $crisp: unknown[]
+    CRISP_WEBSITE_ID: string
+  }
+}
+
+const CrispChat = () => {
+  useEffect(() => {
+    const websiteId = process.env.NEXT_PUBLIC_CRISP_WEBSITE_ID
+    if (!websiteId) return
+
+    window.$crisp = []
+    window.CRISP_WEBSITE_ID = websiteId
+
+    const script = document.createElement("script")
+    script.src = "https://client.crisp.chat/l.js"
+    script.async = true
+    document.head.appendChild(script)
+
+    return () => {
+      script.remove()
+    }
+  }, [])
+
+  return null
+}
+
+export default CrispChat


### PR DESCRIPTION
### Motivation
- 在 NordHjem 前端全局嵌入 Crisp 聊天组件以便所有页面右下角显示聊天气泡。
- 聊天组件需从环境变量读取 `NEXT_PUBLIC_CRISP_WEBSITE_ID`，避免在代码中硬编码网站 ID。
- 使用原生 script 注入方式而非安装额外依赖以保持体积轻量。

### Description
- 新增客户端组件 `src/modules/common/components/crisp-chat/index.tsx`，组件在客户端 `useEffect` 中读取 `process.env.NEXT_PUBLIC_CRISP_WEBSITE_ID` 并注入 Crisp 脚本。 
- 在根布局 `src/app/layout.tsx` 顶部引入并在 `<main>` 之后渲染 `<CrispChat />`，确保聊天气泡在所有页面全局生效。 
- 在环境模板 `.env.template` 中添加 `NEXT_PUBLIC_CRISP_WEBSITE_ID=` 条目以便开发/部署配置。 

### Testing
- 运行 `yarn dev -p 3000` 以尝试启动应用，失败（未通过）因为当前环境缺少必需变量 `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY`。 
- 运行 `yarn eslint src/app/layout.tsx src/modules/common/components/crisp-chat/index.tsx` 遇到 ESLint/Next 规则运行时错误（未通过）：`@next/next/no-html-link-for-pages` 的 path 参数为 undefined。 
- 没有其他自动化测试可运行或通过，在当前环境下无法启动应用以做运行时验证。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a956ef1a4c83339d7aeaa0c4fea1d6)