### PR TITLE
fix: use URL locale for category zh_name display

### DIFF
--- a/src/app/[locale]/[countryCode]/(main)/categories/[...category]/page.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/categories/[...category]/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from "next"
+import { getLocale } from "next-intl/server"
 import { notFound } from "next/navigation"
 
 import { getCategoryByHandle, listCategories } from "@lib/data/categories"
@@ -74,12 +75,15 @@ export default async function CategoryPage(props: Props) {
     notFound()
   }
 
+  const locale = await getLocale()
+
   return (
     <CategoryTemplate
       category={productCategory}
       sortBy={sortBy}
       page={page}
       countryCode={params.countryCode}
+      locale={locale}
     />
   )
 }

--- a/src/lib/data/categories.ts
+++ b/src/lib/data/categories.ts
@@ -38,7 +38,7 @@ export const getCategoryByHandle = async (categoryHandle: string[]) => {
       `/store/product-categories`,
       {
         query: {
-          fields: "*category_children, *products",
+          fields: "*category_children, *products, +metadata, +category_children.metadata",
           handle,
         },
         next,

--- a/src/modules/categories/templates/index.tsx
+++ b/src/modules/categories/templates/index.tsx
@@ -9,16 +9,28 @@ import PaginatedProducts from "@modules/store/templates/paginated-products"
 import LocalizedClientLink from "@modules/common/components/localized-client-link"
 import { HttpTypes } from "@medusajs/types"
 
+function getCategoryLabel(
+  category: { name: string; metadata?: Record<string, any> | null },
+  locale: string | null
+): string {
+  if (locale === "zh" && category.metadata?.zh_name) {
+    return category.metadata.zh_name
+  }
+  return category.name
+}
+
 export default function CategoryTemplate({
   category,
   sortBy,
   page,
   countryCode,
+  locale,
 }: {
   category: HttpTypes.StoreProductCategory
   sortBy?: SortOptions
   page?: string
   countryCode: string
+  locale?: string | null
 }) {
   const pageNumber = page ? parseInt(page) : 1
   const sort = sortBy || "created_at"
@@ -36,6 +48,8 @@ export default function CategoryTemplate({
 
   getParents(category)
 
+  const currentLocale = locale ?? null
+
   return (
     <div
       className="flex flex-col small:flex-row small:items-start py-6 content-container"
@@ -52,12 +66,12 @@ export default function CategoryTemplate({
                   href={`/categories/${parent.handle}`}
                   data-testid="sort-by-link"
                 >
-                  {parent.name}
+                  {getCategoryLabel(parent, currentLocale)}
                 </LocalizedClientLink>
                 /
               </span>
             ))}
-          <h1 data-testid="category-page-title">{category.name}</h1>
+          <h1 data-testid="category-page-title">{getCategoryLabel(category, currentLocale)}</h1>
         </div>
         {category.description && (
           <div className="mb-8 text-base-regular">
@@ -70,7 +84,7 @@ export default function CategoryTemplate({
               {category.category_children?.map((c) => (
                 <li key={c.id}>
                   <InteractiveLink href={`/categories/${c.handle}`}>
-                    {c.name}
+                    {getCategoryLabel(c, currentLocale)}
                   </InteractiveLink>
                 </li>
               ))}

--- a/src/modules/layout/templates/footer/index.tsx
+++ b/src/modules/layout/templates/footer/index.tsx
@@ -1,7 +1,6 @@
-import { getTranslations } from "next-intl/server"
+import { getTranslations, getLocale } from "next-intl/server"
 
 import { listCategories } from "@lib/data/categories"
-import { getLocale } from "@lib/data/locale-actions"
 import { Text, clx } from "@medusajs/ui"
 
 import LocalizedClientLink from "@modules/common/components/localized-client-link"


### PR DESCRIPTION
### Motivation
- Direct visits to `/zh/us` returned a null locale because `getLocale()` previously read from cookies, so Chinese category names from `metadata.zh_name` were never displayed.
- The category template rendered `name` directly for parents, current category and children, which prevented locale-aware labels from showing.
- The category API query did not request `+metadata`, so `zh_name` was not available in the store response.

### Description
- Switched footer locale source to `next-intl/server` by importing `getLocale` from `next-intl/server` and using it to resolve URL-based locale in `src/modules/layout/templates/footer/index.tsx`.
- Added a `locale` prop and `getCategoryLabel` helper to `src/modules/categories/templates/index.tsx`, and replaced direct uses of `parent.name`, `category.name`, and child `c.name` with `getCategoryLabel(...)` to prefer `metadata.zh_name` when `locale === 'zh'`.
- Pulled URL locale in the category route by calling `getLocale()` in `src/app/[locale]/[countryCode]/(main)/categories/[...category]/page.tsx` and passed the `locale` into `CategoryTemplate`.
- Included metadata fields in the category fetch by adding `+metadata` and `+category_children.metadata` to the `fields` query in `src/lib/data/categories.ts` so `zh_name` is returned by the API.

### Testing
- Ran `yarn lint`, which failed due to missing required environment variables (`NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY`) in this environment.
- Started the dev server with a placeholder key using `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY=dummy yarn dev`, which started successfully.
- Automated browser check with Playwright navigated to `http://127.0.0.1:8000/zh/us` and produced a screenshot for visual verification of Chinese category labels, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69aa8a55710c833384ede49028105bab)