### PR TITLE
perf: migrate product/category/collection pages from SSG to ISR

### DIFF
--- a/src/app/[locale]/[countryCode]/(main)/categories/[...category]/page.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/categories/[...category]/page.tsx
@@ -2,12 +2,13 @@ import { Metadata } from "next"
 import { getLocale } from "next-intl/server"
 import { notFound } from "next/navigation"
 
-import { getCategoryByHandle, listCategories } from "@lib/data/categories"
-import { listRegions } from "@lib/data/regions"
-import { StoreRegion } from "@medusajs/types"
+import { getCategoryByHandle } from "@lib/data/categories"
 import CategoryTemplate from "@modules/categories/templates"
 import { SortOptions } from "@modules/store/components/refinement-list/sort-products"
 
+
+export const dynamic = "force-dynamic"
+export const revalidate = 300 // 5 minutes
 type Props = {
   params: Promise<{ category: string[]; countryCode: string }>
   searchParams: Promise<{
@@ -17,30 +18,7 @@ type Props = {
 }
 
 export async function generateStaticParams() {
-  const product_categories = await listCategories()
-
-  if (!product_categories) {
-    return []
-  }
-
-  const countryCodes = await listRegions().then((regions: StoreRegion[]) =>
-    regions?.map((r) => r.countries?.map((c) => c.iso_2)).flat()
-  )
-
-  const categoryHandles = product_categories.map(
-    (category: any) => category.handle
-  )
-
-  const staticParams = countryCodes
-    ?.map((countryCode: string | undefined) =>
-      categoryHandles.map((handle: any) => ({
-        countryCode,
-        category: [handle],
-      }))
-    )
-    .flat()
-
-  return staticParams
+  return []
 }
 
 export async function generateMetadata(props: Props): Promise<Metadata> {

--- a/src/app/[locale]/[countryCode]/(main)/collections/[handle]/page.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/collections/[handle]/page.tsx
@@ -1,12 +1,14 @@
 import { Metadata } from "next"
 import { notFound } from "next/navigation"
 
-import { getCollectionByHandle, listCollections } from "@lib/data/collections"
-import { listRegions } from "@lib/data/regions"
-import { StoreCollection, StoreRegion } from "@medusajs/types"
+import { getCollectionByHandle } from "@lib/data/collections"
+import { StoreCollection } from "@medusajs/types"
 import CollectionTemplate from "@modules/collections/templates"
 import { SortOptions } from "@modules/store/components/refinement-list/sort-products"
 
+
+export const dynamic = "force-dynamic"
+export const revalidate = 300 // 5 minutes
 type Props = {
   params: Promise<{ handle: string; countryCode: string }>
   searchParams: Promise<{
@@ -18,36 +20,7 @@ type Props = {
 export const PRODUCT_LIMIT = 12
 
 export async function generateStaticParams() {
-  const { collections } = await listCollections({
-    fields: "*products",
-  })
-
-  if (!collections) {
-    return []
-  }
-
-  const countryCodes = await listRegions().then(
-    (regions: StoreRegion[]) =>
-      regions
-        ?.map((r) => r.countries?.map((c) => c.iso_2))
-        .flat()
-        .filter(Boolean) as string[]
-  )
-
-  const collectionHandles = collections.map(
-    (collection: StoreCollection) => collection.handle
-  )
-
-  const staticParams = countryCodes
-    ?.map((countryCode: string) =>
-      collectionHandles.map((handle: string | undefined) => ({
-        countryCode,
-        handle,
-      }))
-    )
-    .flat()
-
-  return staticParams
+  return []
 }
 
 export async function generateMetadata(props: Props): Promise<Metadata> {

--- a/src/app/[locale]/[countryCode]/(main)/products/[handle]/page.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/products/[handle]/page.tsx
@@ -1,9 +1,12 @@
 import { Metadata } from "next"
 import { notFound } from "next/navigation"
 import { listProducts } from "@lib/data/products"
-import { getRegion, listRegions } from "@lib/data/regions"
+import { getRegion } from "@lib/data/regions"
 import ProductTemplate from "@modules/products/templates"
 import { HttpTypes } from "@medusajs/types"
+
+export const dynamic = "force-dynamic"
+export const revalidate = 300 // 5 minutes
 
 type Props = {
   params: Promise<{ countryCode: string; handle: string }>
@@ -11,45 +14,7 @@ type Props = {
 }
 
 export async function generateStaticParams() {
-  try {
-    const countryCodes = await listRegions().then((regions) =>
-      regions?.map((r) => r.countries?.map((c) => c.iso_2)).flat()
-    )
-
-    if (!countryCodes) {
-      return []
-    }
-
-    const promises = countryCodes.map(async (country) => {
-      const { response } = await listProducts({
-        countryCode: country,
-        queryParams: { limit: 100, fields: "handle" },
-      })
-
-      return {
-        country,
-        products: response.products,
-      }
-    })
-
-    const countryProducts = await Promise.all(promises)
-
-    return countryProducts
-      .flatMap((countryData) =>
-        countryData.products.map((product) => ({
-          countryCode: countryData.country,
-          handle: product.handle,
-        }))
-      )
-      .filter((param) => param.handle)
-  } catch (error) {
-    console.error(
-      `Failed to generate static paths for product pages: ${
-        error instanceof Error ? error.message : "Unknown error"
-      }.`
-    )
-    return []
-  }
+  return []
 }
 
 function getImagesForVariant(


### PR DESCRIPTION
### Motivation
- The site was pre-generating a very large number of static pages at build time (≈58k), causing long builds and timeouts, so product/category/collection routes should be converted from full SSG to on-demand ISR with caching.

### Description
- Changed `src/app/[locale]/[countryCode]/(main)/products/[handle]/page.tsx`, `src/app/[locale]/[countryCode]/(main)/categories/[...category]/page.tsx`, and `src/app/[locale]/[countryCode]/(main)/collections/[handle]/page.tsx` to use ISR by adding `export const dynamic = "force-dynamic"` and `export const revalidate = 300` at the top of each file.
- Replaced each file's `generateStaticParams` implementation with a simple `export async function generateStaticParams() { return [] }` so pages are generated on-demand instead of being fully pre-generated at build time.
- Removed now-unused list pre-generation imports (e.g. `listRegions`, `listCollections`, `listCategories`) and cleaned up related type imports in the modified files.

### Testing
- Ran `npm run build` to validate the change, but the build failed in this environment due to a missing required environment variable `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY`, so full build verification (ensuring pages are marked `λ` instead of `●`) could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ab35c4edf0833388171419bea08e9a)