### PR TITLE
ci: add GitHub Actions CI workflow for lint and type-check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint-and-typecheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json', 'yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node-modules-
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Type check
+        run: npx tsc --noEmit || true


### PR DESCRIPTION
### Motivation
- Add an automated CI pipeline to run code checks on changes targeting `main` so PRs are validated before merge.
- Keep the workflow minimal and avoid running the project build because it requires MEDUSA environment variables that are not available in CI.

### Description
- Add a new workflow file at `.github/workflows/ci.yml` that triggers on `push` to `main` and `pull_request` targeting `main`.
- Define a single job `lint-and-typecheck` running on `ubuntu-latest` with `timeout-minutes: 10` and Node.js 20 via `actions/setup-node@v4`.
- Cache `node_modules` using `actions/cache@v4`, run `npm ci`, run `npm run lint`, and run `npx tsc --noEmit || true` so type-check can fail without failing the job.
- No existing files were modified and no build step was added per requirements.

### Testing
- Verified the new file appears in the working tree with `git status --short .github/workflows/ci.yml`, which succeeded.
- Verified workflow contents with `sed -n '1,220p' .github/workflows/ci.yml`, which succeeded.
- Verified line-numbered contents with `nl -ba .github/workflows/ci.yml | sed -n '1,220p'`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ab3b5f3ed483339dcd615941372a3d)