### PR TITLE
feat(seo): add JSON-LD structured data for product pages and organization

### DIFF
--- a/src/app/[locale]/[countryCode]/(main)/products/[handle]/page.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/products/[handle]/page.tsx
@@ -3,6 +3,10 @@ import { notFound } from "next/navigation"
 import { listProducts } from "@lib/data/products"
 import { getRegion } from "@lib/data/regions"
 import ProductTemplate from "@modules/products/templates"
+import {
+  generateBreadcrumbJsonLd,
+  generateProductJsonLd,
+} from "@lib/util/structured-data"
 import { HttpTypes } from "@medusajs/types"
 
 export const dynamic = "force-dynamic"
@@ -85,12 +89,38 @@ export default async function ProductPage(props: Props) {
     notFound()
   }
 
+  const productJsonLd = generateProductJsonLd(pricedProduct)
+  const breadcrumbJsonLd = generateBreadcrumbJsonLd([
+    {
+      name: "Home",
+      item: "https://nordhjem.store",
+    },
+    {
+      name: "Products",
+      item: "https://nordhjem.store/products",
+    },
+    {
+      name: pricedProduct.title,
+      item: `https://nordhjem.store/products/${pricedProduct.handle}`,
+    },
+  ])
+
   return (
-    <ProductTemplate
-      product={pricedProduct}
-      region={region}
-      countryCode={params.countryCode}
-      images={images}
-    />
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(productJsonLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
+      />
+      <ProductTemplate
+        product={pricedProduct}
+        region={region}
+        countryCode={params.countryCode}
+        images={images}
+      />
+    </>
   )
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import { getBaseURL } from "@lib/util/env"
 import CrispChat from "@modules/common/components/crisp-chat"
+import { generateOrganizationJsonLd } from "@lib/util/structured-data"
 import { Metadata } from "next"
 import "styles/globals.css"
 import { DM_Serif_Display, Inter, Noto_Sans_SC } from "next/font/google"
@@ -30,6 +31,8 @@ export const metadata: Metadata = {
 }
 
 export default function RootLayout(props: { children: React.ReactNode }) {
+  const organizationJsonLd = generateOrganizationJsonLd()
+
   return (
     <html
       lang="en"
@@ -37,6 +40,12 @@ export default function RootLayout(props: { children: React.ReactNode }) {
       className={`${dmSerif.variable} ${inter.variable} ${notoSansSC.variable}`}
     >
       <body>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(organizationJsonLd),
+          }}
+        />
         <main className="relative">{props.children}</main>
         <CrispChat />
       </body>

--- a/src/lib/util/structured-data.ts
+++ b/src/lib/util/structured-data.ts
@@ -1,0 +1,75 @@
+import { HttpTypes } from "@medusajs/types"
+import { getProductPrice } from "@lib/util/get-product-price"
+import { getBaseURL } from "@lib/util/env"
+
+type BreadcrumbItem = {
+  name: string
+  item: string
+}
+
+const BRAND_NAME = "NordHjem"
+
+export function generateProductJsonLd(product: HttpTypes.StoreProduct) {
+  const { cheapestPrice } = getProductPrice({ product })
+
+  const imageUrls =
+    product.images
+      ?.map((image) => image.url)
+      .filter((url): url is string => Boolean(url)) ?? []
+
+  if (product.thumbnail) {
+    imageUrls.unshift(product.thumbnail)
+  }
+
+  const uniqueImageUrls = [...new Set(imageUrls)]
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "Product",
+    name: product.title,
+    description: product.description || product.subtitle || product.title,
+    image: uniqueImageUrls,
+    brand: {
+      "@type": "Brand",
+      name: BRAND_NAME,
+    },
+    offers: {
+      "@type": "Offer",
+      price: cheapestPrice?.calculated_price_number,
+      priceCurrency: cheapestPrice?.currency_code?.toUpperCase(),
+      availability:
+        product.variants?.some((variant) => {
+          if (!variant.manage_inventory || variant.allow_backorder) {
+            return true
+          }
+
+          return (variant.inventory_quantity || 0) > 0
+        })
+          ? "https://schema.org/InStock"
+          : "https://schema.org/OutOfStock",
+      url: `${getBaseURL()}/products/${product.handle}`,
+    },
+  }
+}
+
+export function generateBreadcrumbJsonLd(items: BreadcrumbItem[]) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: items.map((item, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: item.name,
+      item: item.item,
+    })),
+  }
+}
+
+export function generateOrganizationJsonLd() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    name: BRAND_NAME,
+    url: "https://nordhjem.store",
+  }
+}


### PR DESCRIPTION
### Motivation
- Add site- and product-level JSON-LD so search engines can better understand product details, breadcrumb structure and organization info for improved SEO.
- Make the change without touching page generation behavior or UI rendering logic (`generateStaticParams`, `dynamic`, `revalidate` remain unchanged).

### Description
- Added `src/lib/util/structured-data.ts` with `generateProductJsonLd(product)`, `generateBreadcrumbJsonLd(items)` and `generateOrganizationJsonLd()` helpers.  
- Injected Product and Breadcrumb JSON-LD scripts into the product detail page return tree in `src/app/[locale]/[countryCode]/(main)/products/[handle]/page.tsx` using `generateProductJsonLd` and `generateBreadcrumbJsonLd`.  
- Injected Organization JSON-LD into the root layout `src/app/layout.tsx` using `generateOrganizationJsonLd`.  
- Kept existing product UI and page generation settings intact (no changes to rendering logic or `generateStaticParams`/`dynamic`/`revalidate`).

### Testing
- Ran `yarn lint` in the environment, which failed due to a missing required environment variable `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY` and not because of the changes in this PR.  
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ab3b7354fc8333b894afc48a326bdd)