### PR TITLE
feat: optimize product images & enrich main metadata

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -28,6 +28,7 @@ const nextConfig = {
     ignoreBuildErrors: true,
   },
   images: {
+    formats: ["image/avif", "image/webp"],
     remotePatterns: [
       {
         protocol: "http",

--- a/src/app/[locale]/[countryCode]/(main)/layout.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/layout.tsx
@@ -2,7 +2,6 @@ import { Metadata } from "next"
 
 import { listCartOptions, retrieveCart } from "@lib/data/cart"
 import { retrieveCustomer } from "@lib/data/customer"
-import { getBaseURL } from "@lib/util/env"
 import { StoreCartShippingOption } from "@medusajs/types"
 import CartMismatchBanner from "@modules/layout/components/cart-mismatch-banner"
 import Footer from "@modules/layout/templates/footer"
@@ -10,7 +9,19 @@ import Nav from "@modules/layout/templates/nav"
 import FreeShippingPriceNudge from "@modules/shipping/components/free-shipping-price-nudge"
 
 export const metadata: Metadata = {
-  metadataBase: new URL(getBaseURL()),
+  metadataBase: new URL("https://nordhjem.store"),
+  openGraph: {
+    type: "website",
+    siteName: "NordHjem",
+    locale: "en_US",
+  },
+  twitter: {
+    card: "summary_large_image",
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
 }
 
 export default async function PageLayout(props: { children: React.ReactNode }) {

--- a/src/modules/products/components/image-gallery/index.tsx
+++ b/src/modules/products/components/image-gallery/index.tsx
@@ -20,11 +20,12 @@ const ImageGallery = ({ images }: ImageGalleryProps) => {
               {!!image.url && (
                 <Image
                   src={image.url}
-                  priority={index <= 2 ? true : false}
+                  priority={index === 0}
+                  loading={index === 0 ? undefined : "lazy"}
                   className="absolute inset-0 rounded-rounded"
                   alt={`Product image ${index + 1}`}
                   fill
-                  sizes="(max-width: 576px) 280px, (max-width: 768px) 360px, (max-width: 992px) 480px, 800px"
+                  sizes="(max-width: 640px) 100vw, (max-width: 1024px) 75vw, 50vw"
                   style={{
                     objectFit: "cover",
                   }}


### PR DESCRIPTION
### Motivation
- Improve product page performance by prioritizing the primary product image and lazily loading the rest, and provide responsive `sizes` so Next/Image picks appropriate sources. 
- Improve global SEO / social previews by adding comprehensive metadata in the main layout and fixing the metadata base URL.

### Description
- Updated product gallery at `src/modules/products/components/image-gallery/index.tsx` to set `priority` only for the first image (`index === 0`), set other images to `loading="lazy"`, and adjust `sizes` to `"(max-width: 640px) 100vw, (max-width: 1024px) 75vw, 50vw"` to better reflect responsive display widths. 
- Added modern image output formats to `next.config.js` by adding `formats: ["image/avif", "image/webp"]` under the `images` config to enable AVIF/WebP generation where supported. 
- Enhanced the main layout metadata in `src/app/[locale]/[countryCode]/(main)/layout.tsx` to include `metadataBase: new URL("https://nordhjem.store")`, `openGraph` (`type`, `siteName`, `locale`), `twitter.card`, and `robots: { index: true, follow: true }` for improved SEO and social previews. 
- Preserved constraints: no changes made to `generateStaticParams`, `dynamic`, or `revalidate`, no JSON-LD added, and no changes to payment/checkout code.

### Testing
- Ran targeted ESLint on modified files with `yarn eslint src/modules/products/components/image-gallery/index.tsx 'src/app/[locale]/[countryCode]/(main)/layout.tsx' next.config.js`, which surfaced an existing Next ESLint runtime error in this environment (`TypeError` from `@next/next/no-html-link-for-pages`).
- Ran full lint with `yarn lint`, which did not complete because required environment variables (notably `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY`) are missing in this environment; no new lint errors attributable to these changes were observed prior to these environment-related failures.
- Files changed: `src/modules/products/components/image-gallery/index.tsx`, `src/app/[locale]/[countryCode]/(main)/layout.tsx`, and `next.config.js`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ab3b78eafc8333819facdd3810b2c7)