### PR TITLE
fix: add `_document` fallback to resolve 404 prerender build error

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,0 +1,13 @@
+import { Head, Html, Main, NextScript } from "next/document"
+
+export default function Document() {
+  return (
+    <Html>
+      <Head />
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  )
+}


### PR DESCRIPTION
### Motivation
- Next.js 15 App Router in combination with `next-intl` v4 can trigger a prerender step for `/404` that expects a Pages Router `_document` module, causing `Cannot find module for page: /_document` during `next build`; a minimal Pages Router `Document` fallback prevents the prerender error without changing app behavior.

### Description
- Add a minimal Pages Router `Document` at `src/pages/_document.tsx` that imports `Head`, `Html`, `Main`, and `NextScript` from `next/document` and renders the basic structure, with no changes to ISR settings or business/UI components.

### Testing
- Attempting to run `npm run build` in this environment failed because the `next` binary was not available (`next: not found`) due to dependencies not being installed. 
- Running `npm install` failed with a `403` error from the registry, and `yarn install --immutable` also failed with a `RequestError: Bad response: 403`, so a full local build could not be executed here. 
- Presence and contents of `src/pages/_document.tsx` were inspected to verify the minimal fallback was created successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ab3bfee0e0833390232010c646ec7f)