### PR TITLE
C-009: 完善 Checkout Stripe Elements 错误处理与支付方式 i18n

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -211,7 +211,33 @@
     "chooseAddress": "Choose an address",
     "anotherStep": "Another step will appear",
     "billingSameAsDelivery": "Billing and delivery address are the same.",
-    "termsAgree": "By placing this order, you agree to our <terms>Terms of Use</terms> and <privacy>Privacy Policy</privacy>"
+    "termsAgree": "By placing this order, you agree to our <terms>Terms of Use</terms> and <privacy>Privacy Policy</privacy>",
+    "processingPayment": "Processing payment...",
+    "enterCardDetails": "Enter card details",
+    "noPaymentMethodsTitle": "No payment methods available",
+    "noPaymentMethodsDescription": "Please check your billing details or try another region.",
+    "paymentMethods": {
+      "creditCard": "Credit card",
+      "ideal": "iDEAL",
+      "bancontact": "Bancontact",
+      "paypal": "PayPal",
+      "manual": "Manual Payment",
+      "fallback": "Payment method"
+    },
+    "paymentErrors": {
+      "title": "Payment failed",
+      "generic": "Your payment could not be completed. Please try again.",
+      "notReady": "Payment service is still loading. Please try again in a moment.",
+      "authenticationRequired": "Additional authentication is required. Please complete the 3D Secure verification in the popup and try again.",
+      "codes": {
+        "card_declined": "Your card was declined. Please use another card.",
+        "insufficient_funds": "Insufficient funds. Please use another payment method.",
+        "expired_card": "Your card has expired. Please use a valid card.",
+        "incorrect_cvc": "The CVC code is incorrect. Please check and retry.",
+        "processing_error": "We could not process your card. Please try again.",
+        "authentication_required": "3D Secure verification is required. Please complete the popup challenge."
+      }
+    }
   },
   "order": {
     "confirmation": "Order Confirmation",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -211,7 +211,33 @@
     "billingSameAsDelivery": "账单地址与配送地址相同。",
     "termsAgree": "提交订单即表示您同意我们的<terms>使用条款</terms>和<privacy>隐私政策</privacy>",
     "chooseAddress": "选择地址",
-    "anotherStep": "下一步将会显示"
+    "anotherStep": "下一步将会显示",
+    "processingPayment": "正在处理支付...",
+    "enterCardDetails": "输入卡片信息",
+    "noPaymentMethodsTitle": "暂无可用支付方式",
+    "noPaymentMethodsDescription": "请检查账单信息或尝试切换地区后重试。",
+    "paymentMethods": {
+      "creditCard": "信用卡",
+      "ideal": "iDEAL",
+      "bancontact": "Bancontact",
+      "paypal": "PayPal",
+      "manual": "手动支付",
+      "fallback": "支付方式"
+    },
+    "paymentErrors": {
+      "title": "支付失败",
+      "generic": "无法完成支付，请稍后重试。",
+      "notReady": "支付服务仍在加载中，请稍后重试。",
+      "authenticationRequired": "需要额外身份验证。请在弹窗中完成 3D Secure 验证后重试。",
+      "codes": {
+        "card_declined": "银行卡被拒绝，请更换银行卡。",
+        "insufficient_funds": "余额不足，请使用其他支付方式。",
+        "expired_card": "银行卡已过期，请使用有效银行卡。",
+        "incorrect_cvc": "安全码不正确，请检查后重试。",
+        "processing_error": "银行卡处理失败，请稍后重试。",
+        "authentication_required": "需要完成 3D Secure 验证，请先完成弹窗挑战。"
+      }
+    }
   },
   "order": {
     "confirmation": "订单确认",

--- a/src/modules/checkout/components/payment-button/index.tsx
+++ b/src/modules/checkout/components/payment-button/index.tsx
@@ -7,7 +7,7 @@ import { Button } from "@medusajs/ui"
 import { useElements, useStripe } from "@stripe/react-stripe-js"
 import React, { useState } from "react"
 import { useTranslations } from "next-intl"
-import ErrorMessage from "../error-message"
+import PaymentError from "../payment-error"
 
 type PaymentButtonProps = {
   cart: HttpTypes.StoreCart
@@ -64,6 +64,7 @@ const StripePaymentButton = ({
 }) => {
   const [submitting, setSubmitting] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [errorCode, setErrorCode] = useState<string | null>(null)
 
   const onPaymentCompleted = async () => {
     await placeOrder()
@@ -87,14 +88,24 @@ const StripePaymentButton = ({
 
   const handlePayment = async () => {
     setSubmitting(true)
+    setErrorMessage(null)
+    setErrorCode(null)
 
-    if (!stripe || !elements || !card || !cart) {
+    if (
+      !stripe ||
+      !elements ||
+      !card ||
+      !cart ||
+      !session?.data.client_secret
+    ) {
+      setErrorMessage(t("paymentErrors.notReady"))
       setSubmitting(false)
       return
     }
 
-    await stripe
-      .confirmCardPayment(session?.data.client_secret as string, {
+    const { error, paymentIntent } = await stripe.confirmCardPayment(
+      session.data.client_secret as string,
+      {
         payment_method: {
           card: card,
           billing_details: {
@@ -114,31 +125,45 @@ const StripePaymentButton = ({
             phone: cart.billing_address?.phone ?? undefined,
           },
         },
-      })
-      .then(({ error, paymentIntent }) => {
-        if (error) {
-          const pi = error.payment_intent
+      }
+    )
 
-          if (
-            (pi && pi.status === "requires_capture") ||
-            (pi && pi.status === "succeeded")
-          ) {
-            onPaymentCompleted()
-          }
+    if (error) {
+      const pi = error.payment_intent
 
-          setErrorMessage(error.message || null)
-          return
-        }
+      if (
+        (pi && pi.status === "requires_capture") ||
+        (pi && pi.status === "succeeded")
+      ) {
+        return onPaymentCompleted()
+      }
 
-        if (
-          (paymentIntent && paymentIntent.status === "requires_capture") ||
-          paymentIntent.status === "succeeded"
-        ) {
-          return onPaymentCompleted()
-        }
+      if (
+        error.type === "card_error" &&
+        error.code === "authentication_required"
+      ) {
+        setErrorMessage(t("paymentErrors.authenticationRequired"))
+      } else {
+        setErrorMessage(error.message || t("paymentErrors.generic"))
+      }
+      setErrorCode(error.code || null)
+      setSubmitting(false)
+      return
+    }
 
-        return
-      })
+    if (
+      (paymentIntent && paymentIntent.status === "requires_capture") ||
+      paymentIntent?.status === "succeeded"
+    ) {
+      return onPaymentCompleted()
+    }
+
+    if (paymentIntent?.status === "requires_action") {
+      setErrorMessage(t("paymentErrors.authenticationRequired"))
+      setErrorCode("authentication_required")
+    }
+
+    setSubmitting(false)
   }
 
   return (
@@ -150,10 +175,11 @@ const StripePaymentButton = ({
         isLoading={submitting}
         data-testid={dataTestId}
       >
-        {t("placeOrder")}
+        {submitting ? t("processingPayment") : t("placeOrder")}
       </Button>
-      <ErrorMessage
+      <PaymentError
         error={errorMessage}
+        code={errorCode}
         data-testid="stripe-payment-error-message"
       />
     </>
@@ -195,9 +221,9 @@ const ManualTestPaymentButton = ({
         size="large"
         data-testid="submit-order-button"
       >
-        {t("placeOrder")}
+        {submitting ? t("processingPayment") : t("placeOrder")}
       </Button>
-      <ErrorMessage
+      <PaymentError
         error={errorMessage}
         data-testid="manual-payment-error-message"
       />

--- a/src/modules/checkout/components/payment-error/index.tsx
+++ b/src/modules/checkout/components/payment-error/index.tsx
@@ -1,0 +1,52 @@
+"use client"
+
+import { useMemo } from "react"
+import { useTranslations } from "next-intl"
+import ErrorMessage from "../error-message"
+
+type PaymentErrorProps = {
+  error?: string | null
+  code?: string | null
+  "data-testid"?: string
+}
+
+const stripeErrorCodeMap: Record<string, string> = {
+  card_declined: "paymentErrors.codes.card_declined",
+  insufficient_funds: "paymentErrors.codes.insufficient_funds",
+  expired_card: "paymentErrors.codes.expired_card",
+  incorrect_cvc: "paymentErrors.codes.incorrect_cvc",
+  processing_error: "paymentErrors.codes.processing_error",
+  authentication_required: "paymentErrors.codes.authentication_required",
+}
+
+const PaymentError = ({
+  error,
+  code,
+  "data-testid": dataTestId,
+}: PaymentErrorProps) => {
+  const t = useTranslations("checkout")
+
+  const message = useMemo(() => {
+    const normalizedCode =
+      code ||
+      error?.match(
+        /(card_declined|insufficient_funds|expired_card|incorrect_cvc|processing_error|authentication_required)/
+      )?.[0]
+
+    if (normalizedCode && stripeErrorCodeMap[normalizedCode]) {
+      return `${t("paymentErrors.title")}: ${t(
+        stripeErrorCodeMap[normalizedCode]
+      )}`
+    }
+
+    if (!error) {
+      return null
+    }
+
+    return `${t("paymentErrors.title")}: ${error}`
+  }, [code, error, t])
+
+  return <ErrorMessage error={message} data-testid={dataTestId} />
+}
+
+export default PaymentError

--- a/src/modules/checkout/components/payment/index.tsx
+++ b/src/modules/checkout/components/payment/index.tsx
@@ -5,7 +5,7 @@ import { isStripeLike, paymentInfoMap } from "@lib/constants"
 import { initiatePaymentSession } from "@lib/data/cart"
 import { CheckCircleSolid, CreditCard } from "@medusajs/icons"
 import { Button, Container, Heading, Text, clx } from "@medusajs/ui"
-import ErrorMessage from "@modules/checkout/components/error-message"
+import PaymentError from "@modules/checkout/components/payment-error"
 import PaymentContainer, {
   StripeCardContainer,
 } from "@modules/checkout/components/payment-container"
@@ -39,6 +39,47 @@ const Payment = ({
   const pathname = usePathname()
 
   const isOpen = searchParams.get("step") === "payment"
+
+  const getPaymentMethodLabel = (providerId?: string) => {
+    if (!providerId) {
+      return t("paymentMethods.fallback")
+    }
+
+    if (
+      providerId === "pp_stripe_stripe" ||
+      providerId === "pp_medusa-payments_default"
+    ) {
+      return t("paymentMethods.creditCard")
+    }
+
+    if (providerId === "pp_stripe-ideal_stripe") {
+      return t("paymentMethods.ideal")
+    }
+
+    if (providerId === "pp_stripe-bancontact_stripe") {
+      return t("paymentMethods.bancontact")
+    }
+
+    if (providerId === "pp_paypal_paypal") {
+      return t("paymentMethods.paypal")
+    }
+
+    if (providerId === "pp_system_default") {
+      return t("paymentMethods.manual")
+    }
+
+    return paymentInfoMap[providerId]?.title || providerId
+  }
+
+  const localizedPaymentInfoMap = Object.fromEntries(
+    Object.entries(paymentInfoMap).map(([providerId, info]) => [
+      providerId,
+      {
+        ...info,
+        title: getPaymentMethodLabel(providerId),
+      },
+    ])
+  )
 
   const setPaymentMethod = async (method: string) => {
     setError(null)
@@ -136,7 +177,7 @@ const Payment = ({
       </div>
       <div>
         <div className={isOpen ? "block" : "hidden"}>
-          {!paidByGiftcard && availablePaymentMethods?.length && (
+          {!paidByGiftcard && availablePaymentMethods?.length > 0 && (
             <>
               <RadioGroup
                 value={selectedPaymentMethod}
@@ -148,14 +189,14 @@ const Payment = ({
                       <StripeCardContainer
                         paymentProviderId={paymentMethod.id}
                         selectedPaymentOptionId={selectedPaymentMethod}
-                        paymentInfoMap={paymentInfoMap}
+                        paymentInfoMap={localizedPaymentInfoMap}
                         setCardBrand={setCardBrand}
                         setError={setError}
                         setCardComplete={setCardComplete}
                       />
                     ) : (
                       <PaymentContainer
-                        paymentInfoMap={paymentInfoMap}
+                        paymentInfoMap={localizedPaymentInfoMap}
                         paymentProviderId={paymentMethod.id}
                         selectedPaymentOptionId={selectedPaymentMethod}
                       />
@@ -164,6 +205,20 @@ const Payment = ({
                 ))}
               </RadioGroup>
             </>
+          )}
+
+          {!paidByGiftcard && availablePaymentMethods?.length === 0 && (
+            <div
+              className="mt-4 rounded-rounded border border-ui-border-base p-4"
+              data-testid="payment-methods-empty-state"
+            >
+              <Text className="txt-medium-plus text-ui-fg-base">
+                {t("noPaymentMethodsTitle")}
+              </Text>
+              <Text className="txt-medium text-ui-fg-subtle mt-1">
+                {t("noPaymentMethodsDescription")}
+              </Text>
+            </div>
           )}
 
           {paidByGiftcard && (
@@ -180,7 +235,7 @@ const Payment = ({
             </div>
           )}
 
-          <ErrorMessage
+          <PaymentError
             error={error}
             data-testid="payment-method-error-message"
           />
@@ -197,7 +252,7 @@ const Payment = ({
             data-testid="submit-payment-button"
           >
             {!activeSession && isStripeLike(selectedPaymentMethod)
-              ? " Enter card details"
+              ? t("enterCardDetails")
               : t("review")}
           </Button>
         </div>
@@ -213,8 +268,7 @@ const Payment = ({
                   className="txt-medium text-ui-fg-subtle"
                   data-testid="payment-method-summary"
                 >
-                  {paymentInfoMap[activeSession?.provider_id]?.title ||
-                    activeSession?.provider_id}
+                  {getPaymentMethodLabel(activeSession?.provider_id)}
                 </Text>
               </div>
               <div className="flex flex-col w-1/3">
@@ -226,7 +280,7 @@ const Payment = ({
                   data-testid="payment-details-summary"
                 >
                   <Container className="flex items-center h-7 w-fit p-2 bg-ui-button-neutral-hover">
-                    {paymentInfoMap[selectedPaymentMethod]?.icon || (
+                    {localizedPaymentInfoMap[selectedPaymentMethod]?.icon || (
                       <CreditCard />
                     )}
                   </Container>


### PR DESCRIPTION
### Motivation

- 提升结算页 Stripe 支付的错误处理与用户提示，覆盖支付中状态、3D Secure 场景与常见 Stripe 错误码的友好文案；
- 将支付方式展示本地化（i18n）并在无可用支付方式时提供友好 fallback UI。

### Description

- 在 `src/modules/checkout/components/payment-button/index.tsx` 增强提交逻辑：在提交时显示 i18n 的 `processingPayment` 文案、捕获并解析 Stripe 错误（包括 `authentication_required` / `requires_action` 等），并通过新的 `PaymentError` 组件展示友好错误信息；
- 在 `src/modules/checkout/components/payment/index.tsx` 为 `paymentInfoMap` 提供本地化标题映射并替换错误展示为 `PaymentError`，同时增加当 `availablePaymentMethods` 为空时的 UI 提示，并将 "Enter card details" 改为 i18n 文案；
- 新增通用组件 `src/modules/checkout/components/payment-error/index.tsx`，支持将常见 Stripe 错误码（如 `card_declined`、`insufficient_funds`、`expired_card`、`incorrect_cvc`、`processing_error`、`authentication_required`）映射为用户友好文案，未命中时回退至原始错误文本；
- 更新 `messages/en.json` 与 `messages/zh.json`，新增 `processingPayment`、`enterCardDetails`、支付方式名称映射、无支付方式提示及 `paymentErrors` 文案集合；
- 保持 `stripe-wrapper.tsx` 的核心逻辑与 `payment.ts` API 调用未变动。

### Testing

- 已运行 `npx prettier --write` 并用 `yarn prettier --check` 校验并通过；
- 运行 `yarn eslint` 在当前仓库环境触发了与 Next ESLint 插件配置相关的异常（`@next/next/no-html-link-for-pages` path undefined），该错误非本次改动引入；
- 运行 `yarn tsc --noEmit` 报告仓库已有的 TypeScript 类型错误，问题与本次变更无关；
- 启动 `yarn dev` 未成功是因为缺失必需环境变量 `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY`，因此未能在本地做完整运行时验证。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ab48f7e11c83338dd75a51e858e7e0)