### PR TITLE
feat: add dynamic sitemap and robots metadata routes

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,12 @@
+import { MetadataRoute } from "next"
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: ["/checkout", "/account", "/api"],
+    },
+    sitemap: "https://nordhjem.store/sitemap.xml",
+  }
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,64 @@
+import { listCategories } from "@lib/data/categories"
+import { listCollections } from "@lib/data/collections"
+import { listRegions } from "@lib/data/regions"
+import { getBaseURL } from "@lib/util/env"
+import { routing } from "@/i18n/routing"
+import { MetadataRoute } from "next"
+
+const CATEGORY_CHANGE_FREQUENCY: MetadataRoute.Sitemap[number]["changeFrequency"] =
+  "weekly"
+const COLLECTION_CHANGE_FREQUENCY: MetadataRoute.Sitemap[number]["changeFrequency"] =
+  "weekly"
+const HOME_CHANGE_FREQUENCY: MetadataRoute.Sitemap[number]["changeFrequency"] =
+  "daily"
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const baseUrl = getBaseURL()
+
+  const [regions, categories, { collections }] = await Promise.all([
+    listRegions(),
+    listCategories(),
+    listCollections(),
+  ])
+
+  const countryCodes = Array.from(
+    new Set(
+      (regions ?? [])
+        .flatMap((region) => region.countries ?? [])
+        .map((country) => country.iso_2)
+        .filter((iso2): iso2 is string => Boolean(iso2))
+    )
+  )
+
+  const localeCountryPairs = routing.locales.flatMap((locale) =>
+    countryCodes.map((countryCode) => ({ locale, countryCode }))
+  )
+
+  const homeEntries: MetadataRoute.Sitemap = localeCountryPairs.map(
+    ({ locale, countryCode }) => ({
+      url: `${baseUrl}/${locale}/${countryCode}`,
+      changeFrequency: HOME_CHANGE_FREQUENCY,
+      priority: 1,
+    })
+  )
+
+  const categoryEntries: MetadataRoute.Sitemap = (categories ?? []).flatMap(
+    (category) =>
+      localeCountryPairs.map(({ locale, countryCode }) => ({
+        url: `${baseUrl}/${locale}/${countryCode}/categories/${category.handle}`,
+        changeFrequency: CATEGORY_CHANGE_FREQUENCY,
+        priority: 0.8,
+      }))
+  )
+
+  const collectionEntries: MetadataRoute.Sitemap = (collections ?? []).flatMap(
+    (collection) =>
+      localeCountryPairs.map(({ locale, countryCode }) => ({
+        url: `${baseUrl}/${locale}/${countryCode}/collections/${collection.handle}`,
+        changeFrequency: COLLECTION_CHANGE_FREQUENCY,
+        priority: 0.7,
+      }))
+  )
+
+  return [...homeEntries, ...categoryEntries, ...collectionEntries]
+}


### PR DESCRIPTION
### Motivation
- Provide dynamic `sitemap.xml` and `robots.txt` metadata routes so search engines can discover and index the site efficiently. 
- Use Medusa Store API data (regions, product categories, collections) to generate locale+country-aware URLs while avoiding per-product pages to keep the sitemap size manageable. 

### Description
- Added `src/app/sitemap.ts` which implements a Next.js App Router Metadata Route sitemap and builds URLs by calling `listRegions`, `listCategories`, and `listCollections` from the Medusa data helpers. 
- `sitemap.ts` emits home URLs for each locale/country pair plus all category and collection pages, and sets `changeFrequency` and `priority` values per URL type. 
- Added `src/app/robots.ts` which returns a MetadataRoute.Robots object that `Allow`s `/`, `Disallow`s `/checkout`, `/account`, and `/api`, and points to `https://nordhjem.store/sitemap.xml`. 
- No page components or JSON-LD were modified. 

### Testing
- Ran `yarn prettier --check src/app/sitemap.ts src/app/robots.ts`, which passed. 
- Ran `yarn lint`, which failed in this environment due to missing required env var `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY`. 
- Ran `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY=dummy yarn lint`, which failed due to an existing repository lint runtime issue (`@next/next/no-html-link-for-pages`) unrelated to these changes. 
- Ran `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY=dummy yarn tsc --noEmit`, which reported pre-existing TypeScript errors in unrelated files and therefore did not pass; the new files themselves are type-checked as part of the project but no new TS issues were introduced by these two files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ab491f6a988333b1749c050f6a3ef6)