### PR TITLE
feat: enhance Crisp chat with locale-aware welcome message and customer context

### DIFF
--- a/src/modules/common/components/crisp-chat/index.tsx
+++ b/src/modules/common/components/crisp-chat/index.tsx
@@ -1,31 +1,109 @@
 "use client"
 
 import { useEffect } from "react"
+import { usePathname } from "next/navigation"
 
 declare global {
   interface Window {
     $crisp: unknown[]
     CRISP_WEBSITE_ID: string
+    CRISP_RUNTIME_CONFIG?: {
+      locale?: string
+    }
   }
 }
 
+const ZH_WELCOME_MESSAGE = "你好！有任何关于北欧家具的问题，随时问我。"
+const EN_WELCOME_MESSAGE =
+  "Hi! Feel free to ask any questions about Nordic furniture."
+
+const isChineseLocale = (locale: string) => locale.toLowerCase().startsWith("zh")
+
+const detectLocale = (pathname: string) => {
+  const localeFromPath = pathname.split("/").filter(Boolean)[0]
+
+  if (localeFromPath) {
+    return localeFromPath
+  }
+
+  if (typeof navigator !== "undefined" && navigator.language) {
+    return navigator.language
+  }
+
+  return "en"
+}
+
 const CrispChat = () => {
+  const pathname = usePathname()
+
   useEffect(() => {
     const websiteId = process.env.NEXT_PUBLIC_CRISP_WEBSITE_ID
     if (!websiteId) return
 
-    window.$crisp = []
+    const locale = detectLocale(pathname)
+    const welcomeMessage = isChineseLocale(locale)
+      ? ZH_WELCOME_MESSAGE
+      : EN_WELCOME_MESSAGE
+
+    window.$crisp = window.$crisp || []
     window.CRISP_WEBSITE_ID = websiteId
+    window.CRISP_RUNTIME_CONFIG = {
+      locale,
+    }
+
+    window.$crisp.push(["set", "session:data", [[["locale", locale]]]])
+    window.$crisp.push([
+      "set",
+      "session:data",
+      [[["welcome_message", welcomeMessage]]],
+    ])
 
     const script = document.createElement("script")
     script.src = "https://client.crisp.chat/l.js"
     script.async = true
+
+    const syncCustomerData = async () => {
+      try {
+        const response = await fetch("/store/customers/me", {
+          credentials: "include",
+        })
+
+        if (!response.ok) return
+
+        const data = (await response.json()) as {
+          customer?: {
+            email?: string
+            first_name?: string
+            last_name?: string
+          }
+        }
+
+        const customer = data.customer
+        if (!customer) return
+
+        const nickname = [customer.first_name, customer.last_name]
+          .filter(Boolean)
+          .join(" ")
+
+        if (customer.email) {
+          window.$crisp.push(["set", "user:email", [customer.email]])
+        }
+
+        if (nickname) {
+          window.$crisp.push(["set", "user:nickname", [nickname]])
+        }
+      } catch {
+        // Ignore customer sync errors and allow Crisp to load normally.
+      }
+    }
+
     document.head.appendChild(script)
+    syncCustomerData()
 
     return () => {
       script.remove()
     }
-  }, [])
+  }, [pathname])
 
   return null
 }


### PR DESCRIPTION
### Motivation
- Provide a better Crisp chat experience by initializing Crisp on the client with locale-aware configuration and a localized welcome message. 
- Surface basic user context to Crisp when a visitor is logged in to improve chat personalization. 
- Keep changes scoped to the Crisp integration to avoid touching layout, header, or footer code. 

### Description
- Updated `src/modules/common/components/crisp-chat/index.tsx` to remain client-only and use `usePathname` + `useEffect` for safe client initialization. 
- Added locale detection (route-first with `navigator.language` fallback) and set `CRISP_RUNTIME_CONFIG.locale` plus session `locale` metadata. 
- Added localized welcome messages for Chinese (`"你好！有任何关于北欧家具的问题，随时问我。"`) and English (`"Hi! Feel free to ask any questions about Nordic furniture."`) and pushed them into Crisp session data. 
- Implemented a lightweight customer sync that calls `/store/customers/me` and, when available, pushes `user:email` and `user:nickname` to Crisp. 

### Testing
- Ran `yarn lint` which failed in this environment due to a missing required environment variable `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY`. 
- Ran `yarn eslint src/modules/common/components/crisp-chat/index.tsx` which failed due to the local Next.js ESLint plugin configuration expecting a pages path in this environment. 
- Ran `yarn tsc --noEmit` which failed due to pre-existing TypeScript errors in unrelated files, so full type-check of the project could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ab49387ac08333bfc8a0adf3308ddb)