### PR TITLE
feat(email): add bilingual React email templates for order confirmation and shipping notification

### DIFF
--- a/src/lib/email/templates/order-confirmation.tsx
+++ b/src/lib/email/templates/order-confirmation.tsx
@@ -1,0 +1,243 @@
+import type { CSSProperties } from "react"
+
+type Locale = "zh" | "en"
+
+type OrderItem = {
+  name: string
+  quantity: number
+  price: number
+}
+
+type OrderConfirmationProps = {
+  orderId: string
+  orderDate: string
+  items: OrderItem[]
+  shippingAddress: string
+  total: number
+  currency: string
+  locale?: Locale
+}
+
+const contentByLocale = {
+  zh: {
+    title: "订单确认",
+    greeting: "感谢您的购买！您的订单已确认。",
+    orderNo: "订单号",
+    orderDate: "下单日期",
+    itemList: "商品清单",
+    itemName: "商品",
+    itemQty: "数量",
+    itemPrice: "价格",
+    shippingAddress: "收货地址",
+    total: "总金额",
+    footer: "NordHjem · 北欧简约生活",
+  },
+  en: {
+    title: "Order Confirmation",
+    greeting: "Thank you for your purchase! Your order has been confirmed.",
+    orderNo: "Order ID",
+    orderDate: "Order Date",
+    itemList: "Items",
+    itemName: "Item",
+    itemQty: "Qty",
+    itemPrice: "Price",
+    shippingAddress: "Shipping Address",
+    total: "Total",
+    footer: "NordHjem · Nordic Minimal Living",
+  },
+} as const
+
+const formatCurrency = (amount: number, currency: string, locale: Locale) => {
+  try {
+    return new Intl.NumberFormat(locale === "zh" ? "zh-CN" : "en-US", {
+      style: "currency",
+      currency,
+      currencyDisplay: "symbol",
+    }).format(amount)
+  } catch {
+    return `${currency} ${amount.toFixed(2)}`
+  }
+}
+
+const styles: Record<string, CSSProperties> = {
+  page: {
+    margin: 0,
+    padding: "24px 0",
+    backgroundColor: "#f5f6f4",
+    fontFamily:
+      "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif",
+    color: "#1f2937",
+  },
+  card: {
+    width: "100%",
+    maxWidth: "640px",
+    margin: "0 auto",
+    backgroundColor: "#ffffff",
+    border: "1px solid #e5e7eb",
+    borderRadius: "12px",
+    overflow: "hidden",
+  },
+  header: {
+    backgroundColor: "#2C3E2D",
+    color: "#ffffff",
+    padding: "20px 24px",
+  },
+  brand: {
+    margin: 0,
+    fontSize: "20px",
+    fontWeight: 700,
+    letterSpacing: "0.3px",
+  },
+  title: {
+    margin: "6px 0 0",
+    fontSize: "14px",
+    opacity: 0.9,
+  },
+  body: {
+    padding: "24px",
+  },
+  greeting: {
+    margin: "0 0 16px",
+    fontSize: "15px",
+    lineHeight: 1.6,
+  },
+  meta: {
+    width: "100%",
+    borderCollapse: "collapse",
+    marginBottom: "16px",
+  },
+  metaCell: {
+    padding: "8px 0",
+    fontSize: "14px",
+    borderBottom: "1px solid #f1f5f9",
+  },
+  metaLabel: {
+    color: "#6b7280",
+    width: "120px",
+    verticalAlign: "top",
+  },
+  sectionTitle: {
+    margin: "20px 0 12px",
+    fontSize: "15px",
+    fontWeight: 600,
+    color: "#2C3E2D",
+  },
+  itemsTable: {
+    width: "100%",
+    borderCollapse: "collapse",
+    fontSize: "14px",
+  },
+  itemsHead: {
+    textAlign: "left",
+    color: "#6b7280",
+    borderBottom: "1px solid #e5e7eb",
+    padding: "8px 0",
+    fontWeight: 600,
+  },
+  itemsCell: {
+    borderBottom: "1px solid #f1f5f9",
+    padding: "10px 0",
+    verticalAlign: "top",
+  },
+  right: {
+    textAlign: "right",
+  },
+  address: {
+    margin: 0,
+    padding: "12px",
+    backgroundColor: "#f8fafc",
+    border: "1px solid #e5e7eb",
+    borderRadius: "8px",
+    fontSize: "14px",
+    lineHeight: 1.6,
+    whiteSpace: "pre-line",
+  },
+  totalWrap: {
+    marginTop: "16px",
+    textAlign: "right",
+    fontSize: "18px",
+    fontWeight: 700,
+    color: "#2C3E2D",
+  },
+  footer: {
+    padding: "16px 24px",
+    borderTop: "1px solid #f1f5f9",
+    fontSize: "12px",
+    color: "#6b7280",
+    textAlign: "center",
+  },
+}
+
+const OrderConfirmationEmail = ({
+  orderId,
+  orderDate,
+  items,
+  shippingAddress,
+  total,
+  currency,
+  locale = "zh",
+}: OrderConfirmationProps) => {
+  const copy = contentByLocale[locale]
+
+  return (
+    <div style={styles.page}>
+      <div style={styles.card}>
+        <div style={styles.header}>
+          <h1 style={styles.brand}>NordHjem</h1>
+          <p style={styles.title}>{copy.title}</p>
+        </div>
+
+        <div style={styles.body}>
+          <p style={styles.greeting}>{copy.greeting}</p>
+
+          <table style={styles.meta} role="presentation">
+            <tbody>
+              <tr>
+                <td style={{ ...styles.metaCell, ...styles.metaLabel }}>{copy.orderNo}</td>
+                <td style={styles.metaCell}>{orderId}</td>
+              </tr>
+              <tr>
+                <td style={{ ...styles.metaCell, ...styles.metaLabel }}>{copy.orderDate}</td>
+                <td style={styles.metaCell}>{orderDate}</td>
+              </tr>
+            </tbody>
+          </table>
+
+          <h2 style={styles.sectionTitle}>{copy.itemList}</h2>
+          <table style={styles.itemsTable} role="presentation">
+            <thead>
+              <tr>
+                <th style={styles.itemsHead}>{copy.itemName}</th>
+                <th style={{ ...styles.itemsHead, ...styles.right }}>{copy.itemQty}</th>
+                <th style={{ ...styles.itemsHead, ...styles.right }}>{copy.itemPrice}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((item, index) => (
+                <tr key={`${item.name}-${index}`}>
+                  <td style={styles.itemsCell}>{item.name}</td>
+                  <td style={{ ...styles.itemsCell, ...styles.right }}>{item.quantity}</td>
+                  <td style={{ ...styles.itemsCell, ...styles.right }}>
+                    {formatCurrency(item.price, currency, locale)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          <h2 style={styles.sectionTitle}>{copy.shippingAddress}</h2>
+          <p style={styles.address}>{shippingAddress}</p>
+
+          <div style={styles.totalWrap}>
+            {copy.total}: {formatCurrency(total, currency, locale)}
+          </div>
+        </div>
+
+        <div style={styles.footer}>{copy.footer}</div>
+      </div>
+    </div>
+  )
+}
+
+export default OrderConfirmationEmail
+export type { OrderConfirmationProps, OrderItem }

--- a/src/lib/email/templates/shipping-notification.tsx
+++ b/src/lib/email/templates/shipping-notification.tsx
@@ -1,0 +1,181 @@
+import type { CSSProperties } from "react"
+
+type Locale = "zh" | "en"
+
+type ShippingNotificationProps = {
+  orderId: string
+  trackingNumber: string
+  trackingUrl: string
+  estimatedDelivery: string
+  locale?: Locale
+}
+
+const contentByLocale = {
+  zh: {
+    title: "订单发货通知",
+    greeting: "您的订单已发货，正在前往您的收货地址。",
+    orderNo: "订单号",
+    trackingNo: "快递单号",
+    estimatedDelivery: "预计送达",
+    trackButton: "查看物流",
+    hint: "若按钮无法点击，请复制以下链接到浏览器打开：",
+    footer: "NordHjem · 北欧简约生活",
+  },
+  en: {
+    title: "Shipping Notification",
+    greeting: "Your order has been shipped and is on the way.",
+    orderNo: "Order ID",
+    trackingNo: "Tracking Number",
+    estimatedDelivery: "Estimated Delivery",
+    trackButton: "Track Shipment",
+    hint: "If the button does not work, copy this link into your browser:",
+    footer: "NordHjem · Nordic Minimal Living",
+  },
+} as const
+
+const styles: Record<string, CSSProperties> = {
+  page: {
+    margin: 0,
+    padding: "24px 0",
+    backgroundColor: "#f5f6f4",
+    fontFamily:
+      "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif",
+    color: "#1f2937",
+  },
+  card: {
+    width: "100%",
+    maxWidth: "640px",
+    margin: "0 auto",
+    backgroundColor: "#ffffff",
+    border: "1px solid #e5e7eb",
+    borderRadius: "12px",
+    overflow: "hidden",
+  },
+  header: {
+    backgroundColor: "#2C3E2D",
+    color: "#ffffff",
+    padding: "20px 24px",
+  },
+  brand: {
+    margin: 0,
+    fontSize: "20px",
+    fontWeight: 700,
+    letterSpacing: "0.3px",
+  },
+  title: {
+    margin: "6px 0 0",
+    fontSize: "14px",
+    opacity: 0.9,
+  },
+  body: {
+    padding: "24px",
+  },
+  greeting: {
+    margin: "0 0 20px",
+    fontSize: "15px",
+    lineHeight: 1.6,
+  },
+  infoBox: {
+    marginBottom: "20px",
+    backgroundColor: "#f8fafc",
+    border: "1px solid #e5e7eb",
+    borderRadius: "8px",
+    padding: "12px 14px",
+  },
+  infoRow: {
+    margin: "8px 0",
+    fontSize: "14px",
+    lineHeight: 1.5,
+  },
+  label: {
+    color: "#6b7280",
+    marginRight: "6px",
+  },
+  buttonWrap: {
+    textAlign: "center",
+    margin: "24px 0 18px",
+  },
+  button: {
+    display: "inline-block",
+    backgroundColor: "#2C3E2D",
+    color: "#ffffff",
+    textDecoration: "none",
+    padding: "10px 18px",
+    borderRadius: "8px",
+    fontSize: "14px",
+    fontWeight: 600,
+  },
+  hint: {
+    margin: "0 0 8px",
+    fontSize: "12px",
+    color: "#6b7280",
+  },
+  link: {
+    fontSize: "12px",
+    color: "#2C3E2D",
+    wordBreak: "break-all",
+  },
+  footer: {
+    padding: "16px 24px",
+    borderTop: "1px solid #f1f5f9",
+    fontSize: "12px",
+    color: "#6b7280",
+    textAlign: "center",
+  },
+}
+
+const ShippingNotificationEmail = ({
+  orderId,
+  trackingNumber,
+  trackingUrl,
+  estimatedDelivery,
+  locale = "zh",
+}: ShippingNotificationProps) => {
+  const copy = contentByLocale[locale]
+
+  return (
+    <div style={styles.page}>
+      <div style={styles.card}>
+        <div style={styles.header}>
+          <h1 style={styles.brand}>NordHjem</h1>
+          <p style={styles.title}>{copy.title}</p>
+        </div>
+
+        <div style={styles.body}>
+          <p style={styles.greeting}>{copy.greeting}</p>
+
+          <div style={styles.infoBox}>
+            <p style={styles.infoRow}>
+              <span style={styles.label}>{copy.orderNo}:</span>
+              {orderId}
+            </p>
+            <p style={styles.infoRow}>
+              <span style={styles.label}>{copy.trackingNo}:</span>
+              {trackingNumber}
+            </p>
+            <p style={styles.infoRow}>
+              <span style={styles.label}>{copy.estimatedDelivery}:</span>
+              {estimatedDelivery}
+            </p>
+          </div>
+
+          <div style={styles.buttonWrap}>
+            <a href={trackingUrl} style={styles.button}>
+              {copy.trackButton}
+            </a>
+          </div>
+
+          <p style={styles.hint}>{copy.hint}</p>
+          <a href={trackingUrl} style={styles.link}>
+            {trackingUrl}
+          </a>
+        </div>
+
+        <div style={styles.footer}>{copy.footer}</div>
+      </div>
+    </div>
+  )
+}
+
+export default ShippingNotificationEmail
+export type { ShippingNotificationProps }


### PR DESCRIPTION
### Motivation
- Provide zero-dependency React templates for order lifecycle emails to be used with future Resend (or other) mail integrations.
- Deliver compact, email-compatible components with inline styles that match the NordHjem brand (primary color `#2C3E2D`).
- Support both Chinese and English copy via a `locale` prop for immediate i18n usage.

### Description
- Add `src/lib/email/templates/order-confirmation.tsx` implementing a pure-React order confirmation template with props `orderId`, `orderDate`, `items[]`, `shippingAddress`, `total`, `currency`, and optional `locale` (`zh`|`en`).
- Add `src/lib/email/templates/shipping-notification.tsx` implementing a pure-React shipping notification template with props `orderId`, `trackingNumber`, `trackingUrl`, `estimatedDelivery`, and optional `locale` (`zh`|`en`).
- Both templates render required content (order/meta, item list with name/qty/price, shipping address, totals, tracking CTA) and include inline CSS in an email-safe style, using NordHjem brand color `#2C3E2D`.
- Provide simple locale-based copy objects and a small `formatCurrency` helper for localized currency formatting.

### Testing
- Ran `yarn exec eslint src/lib/email/templates/order-confirmation.tsx src/lib/email/templates/shipping-notification.tsx`, which failed due to a Next ESLint plugin configuration error (`@next/next/no-html-link-for-pages`) originating from repository ESLint settings and not from the new files.
- Ran `yarn exec tsc --noEmit` which reported existing repository TypeScript errors unrelated to the new templates and therefore did not pass full project type-checking.
- Ran `yarn exec tsc --noEmit --jsx react-jsx --module esnext --target es2020 --moduleResolution node src/lib/email/templates/*.tsx` which produced `@types/node`/environment type conflicts unrelated to the added templates.
- The added template files themselves are self-contained TypeScript React components and inspected via file output; lint/type failures reported above are due to pre-existing repo/environment issues and not issues in the new templates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69abddbf0d348333b4d93e65455ae17d)