### PR TITLE
feat(checkout): add progress indicator and saved-address autofill

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -237,7 +237,15 @@
         "processing_error": "We could not process your card. Please try again.",
         "authentication_required": "3D Secure verification is required. Please complete the popup challenge."
       }
-    }
+    },
+    "progress": {
+      "label": "Checkout progress",
+      "shipping": "Shipping",
+      "payment": "Payment",
+      "review": "Review",
+      "stepCount": "Step {current} of {total}"
+    },
+    "useSavedAddress": "Use a saved address"
   },
   "order": {
     "confirmation": "Order Confirmation",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -237,7 +237,15 @@
         "processing_error": "银行卡处理失败，请稍后重试。",
         "authentication_required": "需要完成 3D Secure 验证，请先完成弹窗挑战。"
       }
-    }
+    },
+    "progress": {
+      "label": "结账进度",
+      "shipping": "配送",
+      "payment": "支付",
+      "review": "确认",
+      "stepCount": "第 {current} / {total} 步"
+    },
+    "useSavedAddress": "使用保存的地址"
   },
   "order": {
     "confirmation": "订单确认",

--- a/src/modules/checkout/components/checkout-progress/index.tsx
+++ b/src/modules/checkout/components/checkout-progress/index.tsx
@@ -1,0 +1,144 @@
+"use client"
+
+import { CheckCircleMiniSolid } from "@medusajs/icons"
+import { HttpTypes } from "@medusajs/types"
+import { Text, clx } from "@medusajs/ui"
+import { useTranslations } from "next-intl"
+import { useSearchParams } from "next/navigation"
+
+type CheckoutProgressProps = {
+  cart: HttpTypes.StoreCart
+}
+
+type ProgressStep = {
+  id: "shipping" | "payment" | "review"
+  label: string
+  isCurrent: boolean
+  isCompleted: boolean
+}
+
+const CheckoutProgress = ({ cart }: CheckoutProgressProps) => {
+  const t = useTranslations("checkout")
+  const searchParams = useSearchParams()
+
+  const stepParam = searchParams?.get("step")
+
+  const shippingCompleted =
+    !!cart.shipping_address && (cart.shipping_methods?.length ?? 0) > 0
+
+  const paidByGiftcard =
+    (cart as any)?.gift_cards &&
+    (cart as any)?.gift_cards?.length > 0 &&
+    cart?.total === 0
+
+  const paymentCompleted =
+    !!cart.payment_collection?.payment_sessions?.find(
+      (paymentSession) => paymentSession.status === "pending"
+    ) || paidByGiftcard
+
+  const currentStep: ProgressStep["id"] = (() => {
+    if (stepParam === "payment") {
+      return "payment"
+    }
+
+    if (stepParam === "review") {
+      return "review"
+    }
+
+    return "shipping"
+  })()
+
+  const steps: ProgressStep[] = [
+    {
+      id: "shipping",
+      label: t("progress.shipping"),
+      isCurrent: currentStep === "shipping",
+      isCompleted: shippingCompleted || currentStep !== "shipping",
+    },
+    {
+      id: "payment",
+      label: t("progress.payment"),
+      isCurrent: currentStep === "payment",
+      isCompleted: paymentCompleted || currentStep === "review",
+    },
+    {
+      id: "review",
+      label: t("progress.review"),
+      isCurrent: currentStep === "review",
+      isCompleted: false,
+    },
+  ]
+
+  const currentStepIndex =
+    steps.findIndex((step) => step.id === currentStep) + 1
+
+  return (
+    <div className="mb-8" data-testid="checkout-progress">
+      <div className="small:hidden">
+        <Text className="txt-small text-ui-fg-subtle mb-2">
+          {t("progress.stepCount", {
+            current: currentStepIndex,
+            total: steps.length,
+          })}
+        </Text>
+        <Text className="txt-compact-medium-plus">
+          {steps[currentStepIndex - 1].label}
+        </Text>
+      </div>
+
+      <ol
+        className="hidden small:flex items-center gap-x-3"
+        aria-label={t("progress.label")}
+      >
+        {steps.map((step, index) => {
+          const isLast = index === steps.length - 1
+
+          return (
+            <li key={step.id} className="flex items-center flex-1 min-w-0">
+              <div className="flex items-center gap-x-2">
+                <span
+                  className={clx(
+                    "flex h-7 w-7 items-center justify-center rounded-full border",
+                    {
+                      "border-ui-fg-interactive bg-ui-fg-interactive text-ui-bg-base":
+                        step.isCurrent,
+                      "border-green-600 bg-green-600 text-white":
+                        step.isCompleted && !step.isCurrent,
+                      "border-ui-border-base text-ui-fg-subtle":
+                        !step.isCurrent && !step.isCompleted,
+                    }
+                  )}
+                >
+                  {step.isCompleted && !step.isCurrent ? (
+                    <CheckCircleMiniSolid className="h-4 w-4" />
+                  ) : (
+                    <Text size="small" leading="compact" weight="plus">
+                      {index + 1}
+                    </Text>
+                  )}
+                </span>
+                <Text
+                  className={clx("txt-small truncate", {
+                    "text-ui-fg-base": step.isCurrent,
+                    "text-ui-fg-subtle": !step.isCurrent,
+                  })}
+                >
+                  {step.label}
+                </Text>
+              </div>
+
+              {!isLast && (
+                <span
+                  className="mx-3 h-px flex-1 bg-ui-border-base"
+                  aria-hidden
+                />
+              )}
+            </li>
+          )
+        })}
+      </ol>
+    </div>
+  )
+}
+
+export default CheckoutProgress

--- a/src/modules/checkout/components/shipping-address/index.tsx
+++ b/src/modules/checkout/components/shipping-address/index.tsx
@@ -40,13 +40,19 @@ const ShippingAddress = ({
     [cart?.region]
   )
 
-  // check if customer has saved addresses that are in the current region
   const addressesInRegion = useMemo(
     () =>
       customer?.addresses.filter(
         (a) => a.country_code && countriesInRegion?.includes(a.country_code)
-      ),
+      ) || [],
     [customer?.addresses, countriesInRegion]
+  )
+
+  const defaultShippingAddress = useMemo(
+    () =>
+      addressesInRegion.find((address) => address.is_default_shipping) ||
+      addressesInRegion[0],
+    [addressesInRegion]
   )
 
   const setFormAddress = (
@@ -70,20 +76,35 @@ const ShippingAddress = ({
     email &&
       setFormData((prevState: Record<string, any>) => ({
         ...prevState,
-        email: email,
+        email,
       }))
   }
 
   useEffect(() => {
-    // Ensure cart is not null and has a shipping_address before setting form data
-    if (cart && cart.shipping_address) {
-      setFormAddress(cart?.shipping_address, cart?.email)
+    if (cart?.shipping_address) {
+      setFormAddress(cart.shipping_address, cart?.email)
     }
 
     if (cart && !cart.email && customer?.email) {
       setFormAddress(undefined, customer.email)
     }
-  }, [cart]) // Add cart as a dependency
+  }, [cart, customer?.email])
+
+  useEffect(() => {
+    const hasShippingAddress = !!cart?.shipping_address?.address_1
+
+    if (!hasShippingAddress && customer && defaultShippingAddress) {
+      setFormAddress(
+        defaultShippingAddress as HttpTypes.StoreCartAddress,
+        cart?.email || customer.email
+      )
+    }
+  }, [
+    cart?.shipping_address?.address_1,
+    cart?.email,
+    customer,
+    defaultShippingAddress,
+  ])
 
   const handleChange = (
     e: React.ChangeEvent<
@@ -98,13 +119,11 @@ const ShippingAddress = ({
 
   return (
     <>
-      {customer && (addressesInRegion?.length || 0) > 0 && (
+      {customer && addressesInRegion.length > 0 && (
         <Container className="mb-6 flex flex-col gap-y-4 p-5">
-          <p className="text-small-regular">
-            {`Hi ${customer.first_name}, do you want to use one of your saved addresses?`}
-          </p>
+          <p className="text-small-regular">{t("useSavedAddress")}</p>
           <AddressSelect
-            addresses={customer.addresses}
+            addresses={addressesInRegion}
             addressInput={
               mapKeys(formData, (_, key) =>
                 key.replace("shipping_address.", "")

--- a/src/modules/checkout/templates/checkout-form/index.tsx
+++ b/src/modules/checkout/templates/checkout-form/index.tsx
@@ -3,6 +3,7 @@ import { listCartPaymentMethods } from "@lib/data/payment"
 import { HttpTypes } from "@medusajs/types"
 import Addresses from "@modules/checkout/components/addresses"
 import Payment from "@modules/checkout/components/payment"
+import CheckoutProgress from "@modules/checkout/components/checkout-progress"
 import Review from "@modules/checkout/components/review"
 import Shipping from "@modules/checkout/components/shipping"
 
@@ -26,6 +27,7 @@ export default async function CheckoutForm({
 
   return (
     <div className="w-full grid grid-cols-1 gap-y-8">
+      <CheckoutProgress cart={cart} />
       <Addresses cart={cart} customer={customer} />
 
       <Shipping cart={cart} availableShippingMethods={shippingMethods} />


### PR DESCRIPTION
### Motivation
- Improve checkout UX by giving users clear step feedback and reducing form friction when they have saved addresses.
- Surface progress (Shipping → Payment → Review) and automatically reuse a customer's saved default shipping address when appropriate.

### Description
- Added a new client component `CheckoutProgress` at `src/modules/checkout/components/checkout-progress/index.tsx` that implements a three-step indicator with current-step highlighting, completed-step check marks, responsive mobile view, and `next-intl` labels.
- Integrated the progress indicator into the checkout template at `src/modules/checkout/templates/checkout-form/index.tsx` (renders above addresses/shipping/payment/review sections).
- Enhanced shipping address UX in `src/modules/checkout/components/shipping-address/index.tsx` to: limit saved-address choices to addresses in the cart region, expose a localized "use saved address" selector, and auto-fill the cart form with the customer's default saved shipping address when the cart has no shipping address.
- Added localized copy under the `checkout` section in `messages/en.json` and `messages/zh.json` for `progress.*` keys and `useSavedAddress`.
- Explicitly avoided changes to `payment-button`, `payment-error`, `stripe-wrapper.tsx`, and `customer.ts` as requested.

### Testing
- Ran formatting checks with Prettier (`npx prettier --check ...`) and fixed style issues (`npx prettier --write`), final Prettier check passed.
- Started the dev server (`NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY=dummy yarn dev`) and verified the checkout page renders; captured a screenshot of the checkout page with the new progress indicator (artifact produced).
- Ran `yarn lint` which failed due to an existing repo ESLint/runtime configuration issue related to `@next/next/no-html-link-for-pages` (not caused by these changes).
- Ran TypeScript checks (`npx tsc --noEmit`) which reported pre-existing type errors elsewhere in the repository unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69abddcbadac8333a2a5c4adab27c66a)