### PR TITLE
C-015: complete zh i18n coverage and add header language switcher

### DIFF
--- a/messages/zh.json
+++ b/messages/zh.json
@@ -377,7 +377,7 @@
     "seeAll": "查看全部",
     "language": "语言",
     "currency": "货币",
-    "english": "English",
+    "english": "英文",
     "chinese": "中文"
   },
   "store": {

--- a/src/modules/layout/components/language-switcher/index.tsx
+++ b/src/modules/layout/components/language-switcher/index.tsx
@@ -1,0 +1,35 @@
+"use client"
+
+import { useLocale } from "next-intl"
+import { usePathname, useRouter } from "next/navigation"
+
+const localeLabel: Record<string, string> = {
+  en: "EN",
+  zh: "中文",
+}
+
+export default function LanguageSwitcher() {
+  const locale = useLocale()
+  const pathname = usePathname()
+  const router = useRouter()
+
+  const nextLocale = locale === "zh" ? "en" : "zh"
+
+  const handleSwitch = () => {
+    const segments = pathname.split("/")
+    segments[1] = nextLocale
+    router.push(segments.join("/"))
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleSwitch}
+      className="hover:text-brass transition-colors"
+      aria-label={`Switch language to ${localeLabel[nextLocale]}`}
+      data-testid="nav-language-switcher"
+    >
+      {localeLabel[locale] ?? locale.toUpperCase()}
+    </button>
+  )
+}

--- a/src/modules/layout/templates/nav/index.tsx
+++ b/src/modules/layout/templates/nav/index.tsx
@@ -7,6 +7,7 @@ import { getLocale } from "@lib/data/locale-actions"
 import { StoreRegion } from "@medusajs/types"
 import LocalizedClientLink from "@modules/common/components/localized-client-link"
 import CartButton from "@modules/layout/components/cart-button"
+import LanguageSwitcher from "@modules/layout/components/language-switcher"
 import SideMenu from "@modules/layout/components/side-menu"
 
 export default async function Nav() {
@@ -51,6 +52,7 @@ export default async function Nav() {
               >
                 {t("account")}
               </LocalizedClientLink>
+              <LanguageSwitcher />
             </div>
             <Suspense
               fallback={


### PR DESCRIPTION
### Motivation
- Ensure Chinese translations fully cover the English messages and read naturally.
- Provide a simple, user-visible language switcher in the header so users can toggle locales without digging into settings.

### Description
- Audited `messages/en.json` vs `messages/zh.json` and confirmed parity of translation keys with no missing keys in `zh.json`.
- Refined Chinese wording for `common.english` from `English` to `英文` for a more natural localization.
- Added a new client component `src/modules/layout/components/language-switcher/index.tsx` that displays the current locale as `EN` / `中文` and toggles the locale route segment (`en` ↔ `zh`) using `next-intl` + Next router hooks.
- Integrated the `LanguageSwitcher` into the header `Nav` on the right side next to the Account link and applied the existing simple text-link styling (`hover:text-brass transition-colors`).

### Testing
- Ran a parity audit script (`python` flatten/compare) confirming `missing_keys=0` between `en.json` and `zh.json`.
- Ran `yarn prettier --check` on modified files and it passed formatting checks.
- Attempted `yarn eslint` on the updated files but the environment-level ESLint/Next rule configuration raised an unrelated `@next/next/no-html-link-for-pages` path error that prevented a clean lint run.
- Attempted to start the dev server (`yarn dev`) but the environment lacked required env vars (e.g. `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY`), so a full runtime smoke test could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69abddd814ec833382833f6a252254a1)