### PR TITLE
feat(product): add related products and recently viewed sections on PDP

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -86,6 +86,8 @@
     "noReviews": "No reviews yet",
     "writeReview": "Write a Review",
     "relatedProducts": "You May Also Like",
+    "relatedProductsHeading": "You may also like",
+    "recentlyViewedHeading": "Recently Viewed",
     "share": "Share",
     "shippingInfo": "Shipping Information",
     "returnPolicy": "Return Policy",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -86,6 +86,8 @@
     "noReviews": "暂无评价",
     "writeReview": "撰写评价",
     "relatedProducts": "猜你喜欢",
+    "relatedProductsHeading": "你可能也喜欢",
+    "recentlyViewedHeading": "最近浏览",
     "share": "分享",
     "shippingInfo": "配送信息",
     "returnPolicy": "退换政策",

--- a/src/app/[locale]/[countryCode]/(main)/products/[handle]/page.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/products/[handle]/page.tsx
@@ -8,6 +8,8 @@ import {
   generateProductJsonLd,
 } from "@lib/util/structured-data"
 import { HttpTypes } from "@medusajs/types"
+import RelatedProducts from "@modules/products/components/related-products"
+import RecentlyViewed from "@modules/products/components/recently-viewed"
 
 export const dynamic = "force-dynamic"
 export const revalidate = 300 // 5 minutes
@@ -120,6 +122,14 @@ export default async function ProductPage(props: Props) {
         region={region}
         countryCode={params.countryCode}
         images={images}
+      />
+      <RelatedProducts
+        product={pricedProduct}
+        countryCode={params.countryCode}
+      />
+      <RecentlyViewed
+        handle={pricedProduct.handle}
+        countryCode={params.countryCode}
       />
     </>
   )

--- a/src/app/api/products/by-handles/route.ts
+++ b/src/app/api/products/by-handles/route.ts
@@ -1,0 +1,33 @@
+import { listProducts } from "@lib/data/products"
+import { NextRequest, NextResponse } from "next/server"
+
+export async function GET(request: NextRequest) {
+  const countryCode = request.nextUrl.searchParams.get("countryCode")
+  const handles = request.nextUrl.searchParams
+    .get("handles")
+    ?.split(",")
+    .map((handle) => handle.trim())
+    .filter(Boolean)
+    .slice(0, 8)
+
+  if (!countryCode || !handles?.length) {
+    return NextResponse.json({ products: [] })
+  }
+
+  const products = await listProducts({
+    countryCode,
+    queryParams: {
+      handle: handles,
+      limit: handles.length,
+      is_giftcard: false,
+    },
+  }).then(({ response }) => {
+    const productsByHandle = new Map(
+      response.products.map((product) => [product.handle, product])
+    )
+
+    return handles.map((handle) => productsByHandle.get(handle)).filter(Boolean)
+  })
+
+  return NextResponse.json({ products })
+}

--- a/src/modules/products/components/recently-viewed/index.tsx
+++ b/src/modules/products/components/recently-viewed/index.tsx
@@ -1,0 +1,100 @@
+"use client"
+
+import { HttpTypes } from "@medusajs/types"
+import LocalizedClientLink from "@modules/common/components/localized-client-link"
+import { useTranslations } from "next-intl"
+import Image from "next/image"
+import { useEffect, useState } from "react"
+
+const STORAGE_KEY = "recently-viewed-products"
+const MAX_RECENT_PRODUCTS = 8
+
+type RecentlyViewedProps = {
+  handle: string
+  countryCode: string
+}
+
+export default function RecentlyViewed({
+  handle,
+  countryCode,
+}: RecentlyViewedProps) {
+  const t = useTranslations("product")
+  const [products, setProducts] = useState<HttpTypes.StoreProduct[]>([])
+
+  useEffect(() => {
+    const storedRaw = localStorage.getItem(STORAGE_KEY)
+    const storedHandles = storedRaw ? (JSON.parse(storedRaw) as string[]) : []
+
+    const filteredHandles = storedHandles
+      .filter((storedHandle) => storedHandle && storedHandle !== handle)
+      .slice(0, MAX_RECENT_PRODUCTS)
+
+    const nextHandles = [handle, ...filteredHandles].slice(
+      0,
+      MAX_RECENT_PRODUCTS
+    )
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(nextHandles))
+
+    if (!filteredHandles.length) {
+      return
+    }
+
+    const controller = new AbortController()
+
+    fetch(
+      `/api/products/by-handles?countryCode=${countryCode}&handles=${filteredHandles.join(
+        ","
+      )}`,
+      {
+        signal: controller.signal,
+      }
+    )
+      .then((response) => response.json())
+      .then((data) => setProducts(data.products || []))
+      .catch(() => {
+        setProducts([])
+      })
+
+    return () => {
+      controller.abort()
+    }
+  }, [countryCode, handle])
+
+  if (!products.length) {
+    return null
+  }
+
+  return (
+    <div className="product-page-constraint">
+      <h2 className="text-2xl-regular text-ui-fg-base mb-8 text-center">
+        {t("recentlyViewedHeading")}
+      </h2>
+
+      <ul className="grid grid-cols-2 medium:grid-cols-4 gap-x-6 gap-y-8">
+        {products.map((product) => (
+          <li key={product.id}>
+            <LocalizedClientLink
+              href={`/products/${product.handle}`}
+              className="group"
+            >
+              <div className="relative aspect-[11/14] w-full overflow-hidden bg-ui-bg-subtle">
+                {product.thumbnail ? (
+                  <Image
+                    src={product.thumbnail}
+                    alt={product.title}
+                    fill
+                    sizes="(min-width: 1024px) 25vw, 50vw"
+                    className="object-cover"
+                  />
+                ) : null}
+              </div>
+              <p className="text-base-regular text-ui-fg-subtle mt-4">
+                {product.title}
+              </p>
+            </LocalizedClientLink>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/modules/products/components/related-products/index.tsx
+++ b/src/modules/products/components/related-products/index.tsx
@@ -1,7 +1,7 @@
 import { listProducts } from "@lib/data/products"
 import { getRegion } from "@lib/data/regions"
 import { HttpTypes } from "@medusajs/types"
-import Product from "../product-preview"
+import ProductPreview from "../product-preview"
 import { getTranslations } from "next-intl/server"
 
 type RelatedProductsProps = {
@@ -16,33 +16,22 @@ export default async function RelatedProducts({
   const t = await getTranslations("product")
   const region = await getRegion(countryCode)
 
-  if (!region) {
+  if (!region || !product.collection_id) {
     return null
   }
 
-  // edit this function to define your related products logic
-  const queryParams: HttpTypes.StoreProductListParams = {}
-  if (region?.id) {
-    queryParams.region_id = region.id
-  }
-  if (product.collection_id) {
-    queryParams.collection_id = [product.collection_id]
-  }
-  if (product.tags) {
-    queryParams.tag_id = product.tags
-      .map((t) => t.id)
-      .filter(Boolean) as string[]
-  }
-  queryParams.is_giftcard = false
-
   const products = await listProducts({
-    queryParams,
+    queryParams: {
+      collection_id: [product.collection_id],
+      is_giftcard: false,
+      limit: 5,
+    },
     countryCode,
-  }).then(({ response }) => {
-    return response.products.filter(
-      (responseProduct) => responseProduct.id !== product.id
-    )
-  })
+  }).then(({ response }) =>
+    response.products
+      .filter((responseProduct) => responseProduct.id !== product.id)
+      .slice(0, 4)
+  )
 
   if (!products.length) {
     return null
@@ -50,19 +39,14 @@ export default async function RelatedProducts({
 
   return (
     <div className="product-page-constraint">
-      <div className="flex flex-col items-center text-center mb-16">
-        <span className="text-base-regular text-gray-600 mb-6">
-          {t("relatedProductsTitle")}
-        </span>
-        <p className="text-2xl-regular text-ui-fg-base max-w-lg">
-          {t("relatedProductsDescription")}
-        </p>
-      </div>
+      <h2 className="text-2xl-regular text-ui-fg-base mb-8 text-center">
+        {t("relatedProductsHeading")}
+      </h2>
 
-      <ul className="grid grid-cols-2 small:grid-cols-3 medium:grid-cols-4 gap-x-6 gap-y-8">
-        {products.map((product) => (
-          <li key={product.id}>
-            <Product region={region} product={product} />
+      <ul className="grid grid-cols-2 medium:grid-cols-4 gap-x-6 gap-y-8">
+        {products.map((relatedProduct) => (
+          <li key={relatedProduct.id}>
+            <ProductPreview region={region} product={relatedProduct} />
           </li>
         ))}
       </ul>


### PR DESCRIPTION
### Motivation
- Improve product page conversion by surfacing related items from the same collection and showing recently viewed products for user re-engagement.
- Provide a responsive, localized UI that reuses existing preview components and keeps product-template/metadata unchanged.

### Description
- Add/modify `RelatedProducts` at `src/modules/products/components/related-products/index.tsx` to fetch other products in the same collection (exclude current product) and render up to 4 items using the existing `ProductPreview` in a responsive grid (mobile 2-col, desktop 4-col) with i18n key `product.relatedProductsHeading`.
- Add a client-side `RecentlyViewed` component at `src/modules/products/components/recently-viewed/index.tsx` that stores product handles in `localStorage` (max 8), fetches product data by handle, and renders a responsive grid under related products with i18n key `product.recentlyViewedHeading`.
- Add API route `src/app/api/products/by-handles/route.ts` to resolve a list of handles to product data while preserving handle order for the recently viewed UI.
- Integrate both components into the product page `src/app/[locale]/[countryCode]/(main)/products/[handle]/page.tsx` directly below `ProductTemplate` and add new i18n entries in `messages/en.json` and `messages/zh.json`.

### Testing
- `yarn prettier --check` and subsequent `--write` were run on changed files and final Prettier check passed for the modified files.
- `yarn lint` failed due to missing required environment variable `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY` and `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY=dummy yarn lint` surfaced an existing ESLint rule loading issue (`@next/next/no-html-link-for-pages`) unrelated to these changes.
- `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY=dummy yarn tsc --noEmit` failed due to pre-existing TypeScript errors in the repository that were not introduced by this PR.
- A development server was started and an automated Playwright script navigated to a product page and produced a screenshot artifact to validate the integrated UI visually (artifact: product-page-enhancement.png), and the changes were committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69abddec19a8833394061a494d47669c)