### PR TITLE
feat: add Resend notification module provider + shared email components

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+RESEND_API_KEY=re_XXDZFq8V_6r6v9NChQ2miYoMSqpm7tB5Y
+RESEND_FROM_EMAIL=NordHjem <noreply@nordhjem.store>
+STOREFRONT_URL=https://nordhjem.store

--- a/medusa-config.ts
+++ b/medusa-config.ts
@@ -1,0 +1,22 @@
+export default {
+  modules: [
+    {
+      resolve: "@medusajs/medusa/notification",
+      options: {
+        providers: [
+          {
+            resolve: "./src/modules/resend",
+            id: "resend",
+            options: {
+              channels: ["email"],
+              api_key: process.env.RESEND_API_KEY,
+              from:
+                process.env.RESEND_FROM_EMAIL ||
+                "NordHjem <noreply@nordhjem.store>",
+            },
+          },
+        ],
+      },
+    },
+  ],
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@stripe/stripe-js": "^8.2.0",
     "lodash": "^4.17.21",
     "next": "15.3.9",
+    "next-intl": "^4.1.0",
     "pg": "^8.11.3",
     "qs": "^6.12.1",
     "react": "19.0.4",
@@ -32,7 +33,8 @@
     "server-only": "^0.0.1",
     "tailwindcss-radix": "^2.8.0",
     "webpack": "^5",
-    "next-intl": "^4.1.0"
+    "@react-email/components": "^0.5.7",
+    "resend": "^4.8.0"
   },
   "devDependencies": {
     "@babel/core": "^7.17.5",

--- a/src/modules/resend/emails/components/Button.tsx
+++ b/src/modules/resend/emails/components/Button.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from "react"
+import { Button } from "@react-email/components"
+
+type Props = { href: string; children: ReactNode }
+
+export function NordHjemButton({ href, children }: Props) {
+  return (
+    <Button
+      href={href}
+      style={{
+        backgroundColor: "#1A1A2E",
+        color: "#FFFFFF",
+        padding: "14px 36px",
+        borderRadius: "4px",
+        fontSize: "14px",
+        fontWeight: 500,
+        letterSpacing: "1px",
+        textDecoration: "none",
+        textAlign: "center" as const,
+      }}
+    >
+      {children}
+    </Button>
+  )
+}

--- a/src/modules/resend/emails/components/Footer.tsx
+++ b/src/modules/resend/emails/components/Footer.tsx
@@ -1,0 +1,39 @@
+import { Hr, Link, Section, Text } from "@react-email/components"
+
+const t = {
+  en: {
+    support: "Questions? Contact us at",
+    email: "support@nordhjem.store",
+    copyright: "© 2026 NordHjem. All rights reserved.",
+  },
+  zh: {
+    support: "有问题？联系我们",
+    email: "support@nordhjem.store",
+    copyright: "© 2026 NordHjem 版权所有",
+  },
+}
+
+export function NordHjemFooter({ locale = "en" }: { locale?: string }) {
+  const text = locale === "zh" ? t.zh : t.en
+
+  return (
+    <Section
+      style={{
+        backgroundColor: "#F5F5F5",
+        padding: "32px",
+        textAlign: "center" as const,
+      }}
+    >
+      <Hr style={{ borderColor: "#E0E0E0", margin: "0 0 20px" }} />
+      <Text style={{ color: "#888", fontSize: "13px", lineHeight: "20px" }}>
+        {text.support}{" "}
+        <Link href="mailto:support@nordhjem.store" style={{ color: "#1A1A2E" }}>
+          {text.email}
+        </Link>
+      </Text>
+      <Text style={{ color: "#BBB", fontSize: "12px", marginTop: "12px" }}>
+        {text.copyright}
+      </Text>
+    </Section>
+  )
+}

--- a/src/modules/resend/emails/components/Header.tsx
+++ b/src/modules/resend/emails/components/Header.tsx
@@ -1,0 +1,26 @@
+import { Section, Text } from "@react-email/components"
+
+export function NordHjemHeader() {
+  return (
+    <Section
+      style={{
+        backgroundColor: "#1A1A2E",
+        padding: "28px 32px",
+        textAlign: "center" as const,
+      }}
+    >
+      <Text
+        style={{
+          color: "#FFFFFF",
+          fontSize: "26px",
+          fontWeight: 300,
+          letterSpacing: "6px",
+          margin: "0",
+          fontFamily: "'Inter', 'Helvetica Neue', Arial, sans-serif",
+        }}
+      >
+        NORDHJEM
+      </Text>
+    </Section>
+  )
+}

--- a/src/modules/resend/index.ts
+++ b/src/modules/resend/index.ts
@@ -1,0 +1,6 @@
+import { ModuleProvider, Modules } from "@medusajs/framework/utils"
+import ResendNotificationProviderService from "./service"
+
+export default ModuleProvider(Modules.NOTIFICATION, {
+  services: [ResendNotificationProviderService],
+})

--- a/src/modules/resend/service.ts
+++ b/src/modules/resend/service.ts
@@ -1,0 +1,98 @@
+import {
+  AbstractNotificationProviderService,
+  MedusaError,
+} from "@medusajs/framework/utils"
+import {
+  Logger,
+  ProviderSendNotificationDTO,
+  ProviderSendNotificationResultsDTO,
+} from "@medusajs/framework/types"
+import { Resend } from "resend"
+import type { ReactNode } from "react"
+
+type ResendOptions = {
+  api_key: string
+  from: string
+}
+
+type TemplateRenderer = (props: any) => ReactNode
+
+class ResendNotificationProviderService extends AbstractNotificationProviderService {
+  static identifier = "notification-resend"
+  private resendClient: Resend
+  private options: ResendOptions
+  private logger: Logger
+  private templateMap: Record<string, TemplateRenderer> = {}
+  private subjectMap: Record<string, Record<string, string>> = {}
+
+  constructor({ logger }: { logger: Logger }, options: ResendOptions) {
+    super()
+    this.resendClient = new Resend(options.api_key)
+    this.options = options
+    this.logger = logger
+  }
+
+  static validateOptions(options: Record<any, any>) {
+    if (!options.api_key) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        "Option `api_key` is required for Resend provider."
+      )
+    }
+    if (!options.from) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        "Option `from` is required for Resend provider."
+      )
+    }
+  }
+
+  registerTemplate(
+    name: string,
+    renderer: TemplateRenderer,
+    subjects: Record<string, string>
+  ) {
+    this.templateMap[name] = renderer
+    this.subjectMap[name] = subjects
+  }
+
+  async send(
+    notification: ProviderSendNotificationDTO
+  ): Promise<ProviderSendNotificationResultsDTO> {
+    const template = this.templateMap[notification.template]
+    if (!template) {
+      this.logger.error(`[Resend] Template not found: ${notification.template}`)
+      return {}
+    }
+
+    const locale = (notification.data as any)?.locale || "en"
+    const subject =
+      this.subjectMap[notification.template]?.[locale] ||
+      this.subjectMap[notification.template]?.en ||
+      "NordHjem Notification"
+
+    try {
+      const { data, error } = await this.resendClient.emails.send({
+        from: this.options.from,
+        to: [notification.to],
+        subject,
+        react: template({ ...notification.data, locale }),
+      })
+
+      if (error) {
+        this.logger.error("[Resend] Failed to send email", error as any)
+        return {}
+      }
+
+      this.logger.info(
+        `[Resend] Email sent: ${notification.template} → ${notification.to} (id: ${data?.id})`
+      )
+      return { id: data?.id }
+    } catch (err) {
+      this.logger.error("[Resend] Send exception", err as any)
+      return {}
+    }
+  }
+}
+
+export default ResendNotificationProviderService

--- a/src/workflows/steps/send-notification.ts
+++ b/src/workflows/steps/send-notification.ts
@@ -1,0 +1,11 @@
+import { Modules } from "@medusajs/framework/utils"
+import { createStep, StepResponse } from "@medusajs/framework/workflows-sdk"
+
+export const sendNotificationStep = createStep(
+  "send-notification",
+  async (data: any[], { container }) => {
+    const service = container.resolve(Modules.NOTIFICATION)
+    const result = await service.createNotifications(data)
+    return new StepResponse(result)
+  }
+)


### PR DESCRIPTION
### Motivation
- Add a self-hosted Resend notification provider for Medusa V2 so the backend can send React-based emails without relying on external notification plugins.
- Provide reusable React Email components and a workflow step to standardize email templates and sending across the project.

### Description
- Added a custom notification provider service at `src/modules/resend/service.ts` implementing option validation, template registration, locale-aware subject selection, and Resend send logic.
- Registered the provider entrypoint at `src/modules/resend/index.ts` and wired the provider into Medusa modules via a new `medusa-config.ts` entry that configures `RESEND_API_KEY`, `RESEND_FROM_EMAIL`, and `channels`.
- Created a reusable workflow step `sendNotificationStep` at `src/workflows/steps/send-notification.ts` that resolves `Modules.NOTIFICATION` and calls `createNotifications`.
- Added three reusable React Email components with inline styles and NordHjem brand colors at `src/modules/resend/emails/components/{Header,Footer,Button}.tsx`.
- Updated `package.json` to include `resend` and `@react-email/components`, and added environment variables to `.env` (`RESEND_API_KEY`, `RESEND_FROM_EMAIL`, `STOREFRONT_URL`).

### Testing
- Attempted dependency install with `npm install resend @react-email/components`, which failed due to the environment returning `403 Forbidden` when fetching some packages.
- Attempted to run `npx medusa start` to verify provider registration, which failed because the environment could not fetch required Medusa packages (`403 Forbidden`).
- Verified file additions and dependency entries programmatically by checking created files and running a Node check against `package.json` which confirmed both `resend` and `@react-email/components` are present (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ac26a165848333b161af9cb30f7bb0)