### PR TITLE
feat(email): add four bilingual Resend email templates for Phase 2

### DIFF
--- a/src/modules/resend/emails/abandoned-cart.tsx
+++ b/src/modules/resend/emails/abandoned-cart.tsx
@@ -1,0 +1,193 @@
+import {
+  Body,
+  Column,
+  Container,
+  Head,
+  Hr,
+  Html,
+  Img,
+  Preview,
+  Row,
+  Section,
+  Text,
+} from "@react-email/components"
+import { NordHjemButton } from "./components/Button"
+import { NordHjemFooter } from "./components/Footer"
+import { NordHjemHeader } from "./components/Header"
+
+const i18n = {
+  en: {
+    preview: "You left something behind at NordHjem",
+    title: "Forgot something?",
+    subtitle: "You left some beautiful pieces in your cart. They're still waiting for you.",
+    items: "Your Cart",
+    total: "Cart Total",
+    returnToCart: "RETURN TO CART",
+    expires: "Your cart will be saved for a limited time.",
+  },
+  zh: {
+    preview: "您在 NordHjem 有未完成的购物",
+    title: "忘了什么？",
+    subtitle: "您的购物车中还有一些精美的商品等着您。",
+    items: "购物车商品",
+    total: "购物车总计",
+    returnToCart: "返回购物车",
+    expires: "您的购物车将保留一段时间。",
+  },
+}
+
+type CartItem = {
+  product_title: string
+  variant_title?: string
+  thumbnail?: string
+  quantity: number
+  total: number
+}
+
+type Props = {
+  cart: {
+    id: string
+    email: string
+    currency_code: string
+    total: number
+    items: CartItem[]
+  }
+  recoveryUrl: string
+  locale?: string
+}
+
+const formatPrice = (amount: number, currency: string) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: currency.toUpperCase(),
+  }).format(amount)
+
+export function abandonedCartEmail({ cart, recoveryUrl, locale = "en" }: Props) {
+  const t = locale === "zh" ? i18n.zh : i18n.en
+  const curr = cart.currency_code || "usd"
+
+  return (
+    <Html>
+      <Head />
+      <Preview>{t.preview}</Preview>
+      <Body
+        style={{
+          backgroundColor: "#FAFAFA",
+          fontFamily: "'Inter', 'Helvetica Neue', Arial, sans-serif",
+          margin: "0",
+          padding: "0",
+        }}
+      >
+        <Container style={{ maxWidth: "600px", margin: "0 auto" }}>
+          <NordHjemHeader />
+
+          <Section style={{ backgroundColor: "#FFFFFF", padding: "48px 40px" }}>
+            <Text
+              style={{
+                fontSize: "22px",
+                fontWeight: 300,
+                color: "#1A1A2E",
+                textAlign: "center" as const,
+                letterSpacing: "1px",
+                marginBottom: "8px",
+              }}
+            >
+              {t.title}
+            </Text>
+            <Text
+              style={{
+                fontSize: "14px",
+                color: "#666",
+                textAlign: "center" as const,
+                lineHeight: "22px",
+                marginBottom: "32px",
+              }}
+            >
+              {t.subtitle}
+            </Text>
+
+            <Hr style={{ borderColor: "#EEEEEE", marginBottom: "24px" }} />
+
+            <Text
+              style={{
+                fontSize: "12px",
+                fontWeight: 600,
+                letterSpacing: "2px",
+                color: "#999",
+                textTransform: "uppercase" as const,
+                marginBottom: "16px",
+              }}
+            >
+              {t.items}
+            </Text>
+
+            {cart.items?.map((item, i) => (
+              <Row key={i} style={{ marginBottom: "16px" }}>
+                <Column style={{ width: "64px" }}>
+                  {item.thumbnail && (
+                    <Img
+                      src={item.thumbnail}
+                      alt={item.product_title}
+                      width="56"
+                      height="56"
+                      style={{ borderRadius: "8px", objectFit: "cover" as const }}
+                    />
+                  )}
+                </Column>
+                <Column style={{ paddingLeft: "12px", verticalAlign: "top" }}>
+                  <Text style={{ fontSize: "14px", color: "#1A1A2E", margin: "0 0 2px" }}>
+                    {item.product_title}
+                  </Text>
+                  {item.variant_title && (
+                    <Text style={{ fontSize: "12px", color: "#999", margin: "0" }}>
+                      {item.variant_title}
+                    </Text>
+                  )}
+                  <Text style={{ fontSize: "12px", color: "#999", margin: "4px 0 0" }}>
+                    Qty: {item.quantity}
+                  </Text>
+                </Column>
+                <Column style={{ textAlign: "right" as const, verticalAlign: "top" }}>
+                  <Text style={{ fontSize: "14px", color: "#1A1A2E", margin: "0" }}>
+                    {formatPrice(item.total, curr)}
+                  </Text>
+                </Column>
+              </Row>
+            ))}
+
+            <Hr style={{ borderColor: "#1A1A2E", margin: "24px 0 12px" }} />
+            <Row>
+              <Column>
+                <Text style={{ fontSize: "16px", fontWeight: 600, color: "#1A1A2E" }}>
+                  {t.total}
+                </Text>
+              </Column>
+              <Column style={{ textAlign: "right" as const }}>
+                <Text style={{ fontSize: "16px", fontWeight: 600, color: "#1A1A2E" }}>
+                  {formatPrice(cart.total, curr)}
+                </Text>
+              </Column>
+            </Row>
+
+            <Section style={{ textAlign: "center" as const, marginTop: "36px" }}>
+              <NordHjemButton href={recoveryUrl}>{t.returnToCart}</NordHjemButton>
+            </Section>
+
+            <Text
+              style={{
+                fontSize: "12px",
+                color: "#999",
+                textAlign: "center" as const,
+                marginTop: "24px",
+              }}
+            >
+              {t.expires}
+            </Text>
+          </Section>
+
+          <NordHjemFooter locale={locale} />
+        </Container>
+      </Body>
+    </Html>
+  )
+}

--- a/src/modules/resend/emails/components/Button.tsx
+++ b/src/modules/resend/emails/components/Button.tsx
@@ -1,0 +1,30 @@
+import { Button } from "@react-email/components"
+import type { CSSProperties, ReactNode } from "react"
+
+type Props = {
+  href: string
+  children: ReactNode
+  style?: CSSProperties
+}
+
+export function NordHjemButton({ href, children, style }: Props) {
+  return (
+    <Button
+      href={href}
+      style={{
+        backgroundColor: "#1A1A2E",
+        color: "#FFFFFF",
+        fontSize: "12px",
+        letterSpacing: "1.5px",
+        fontWeight: 600,
+        textDecoration: "none",
+        borderRadius: "0px",
+        padding: "14px 28px",
+        display: "inline-block",
+        ...style,
+      }}
+    >
+      {children}
+    </Button>
+  )
+}

--- a/src/modules/resend/emails/components/Footer.tsx
+++ b/src/modules/resend/emails/components/Footer.tsx
@@ -1,0 +1,49 @@
+import { Section, Text } from "@react-email/components"
+
+const i18n = {
+  en: {
+    tagline: "Scandinavian living, thoughtfully curated.",
+    copyright: "© NordHjem. All rights reserved.",
+  },
+  zh: {
+    tagline: "甄选北欧生活美学。",
+    copyright: "© NordHjem 版权所有。",
+  },
+}
+
+type Props = {
+  locale?: string
+}
+
+export function NordHjemFooter({ locale = "en" }: Props) {
+  const t = locale === "zh" ? i18n.zh : i18n.en
+
+  return (
+    <Section
+      style={{
+        backgroundColor: "#F4F4F4",
+        padding: "24px 40px",
+        textAlign: "center" as const,
+      }}
+    >
+      <Text
+        style={{
+          color: "#777777",
+          fontSize: "12px",
+          margin: "0 0 8px",
+        }}
+      >
+        {t.tagline}
+      </Text>
+      <Text
+        style={{
+          color: "#999999",
+          fontSize: "11px",
+          margin: "0",
+        }}
+      >
+        {t.copyright}
+      </Text>
+    </Section>
+  )
+}

--- a/src/modules/resend/emails/components/Header.tsx
+++ b/src/modules/resend/emails/components/Header.tsx
@@ -1,0 +1,25 @@
+import { Section, Text } from "@react-email/components"
+
+export function NordHjemHeader() {
+  return (
+    <Section
+      style={{
+        backgroundColor: "#1A1A2E",
+        padding: "24px 40px",
+        textAlign: "center" as const,
+      }}
+    >
+      <Text
+        style={{
+          color: "#FFFFFF",
+          fontSize: "20px",
+          letterSpacing: "2px",
+          fontWeight: 300,
+          margin: "0",
+        }}
+      >
+        NORDHJEM
+      </Text>
+    </Section>
+  )
+}

--- a/src/modules/resend/emails/components/react-email-components.tsx
+++ b/src/modules/resend/emails/components/react-email-components.tsx
@@ -1,0 +1,29 @@
+import type { CSSProperties, FC, PropsWithChildren } from "react"
+
+type BaseProps = PropsWithChildren<{
+  style?: CSSProperties
+  href?: string
+  src?: string
+  alt?: string
+  width?: string | number
+  height?: string | number
+}>
+
+export const Html: FC<BaseProps> = ({ children }) => <html>{children}</html>
+export const Head: FC<BaseProps> = ({ children }) => <head>{children}</head>
+export const Preview: FC<BaseProps> = ({ children, style }) => <div style={style}>{children}</div>
+export const Body: FC<BaseProps> = ({ children, style }) => <body style={style}>{children}</body>
+export const Container: FC<BaseProps> = ({ children, style }) => <table style={style}>{children}</table>
+export const Section: FC<BaseProps> = ({ children, style }) => <section style={style}>{children}</section>
+export const Text: FC<BaseProps> = ({ children, style }) => <p style={style}>{children}</p>
+export const Row: FC<BaseProps> = ({ children, style }) => <div style={style}>{children}</div>
+export const Column: FC<BaseProps> = ({ children, style }) => <div style={style}>{children}</div>
+export const Img: FC<BaseProps> = ({ src, alt, width, height, style }) => (
+  <img src={src} alt={alt} width={width} height={height} style={style} />
+)
+export const Hr: FC<BaseProps> = ({ style }) => <hr style={style} />
+export const Button: FC<BaseProps> = ({ children, href, style }) => (
+  <a href={href} style={style}>
+    {children}
+  </a>
+)

--- a/src/modules/resend/emails/order-placed.tsx
+++ b/src/modules/resend/emails/order-placed.tsx
@@ -1,0 +1,274 @@
+import {
+  Body,
+  Column,
+  Container,
+  Head,
+  Hr,
+  Html,
+  Img,
+  Preview,
+  Row,
+  Section,
+  Text,
+} from "@react-email/components"
+import { NordHjemButton } from "./components/Button"
+import { NordHjemFooter } from "./components/Footer"
+import { NordHjemHeader } from "./components/Header"
+
+const i18n = {
+  en: {
+    preview: "Thank you for your NordHjem order",
+    title: "Thank you for your order",
+    subtitle:
+      "We're preparing your items with care. You'll receive a shipping notification once your order is on its way.",
+    orderNumber: "Order",
+    items: "Your Items",
+    subtotal: "Subtotal",
+    shipping: "Shipping",
+    tax: "Tax",
+    total: "Total",
+    shippingTo: "Shipping To",
+    viewOrder: "VIEW ORDER",
+  },
+  zh: {
+    preview: "感谢您的 NordHjem 订单",
+    title: "感谢您的订单",
+    subtitle: "我们正在精心准备您的商品。发货后会第一时间通知您。",
+    orderNumber: "订单号",
+    items: "订单商品",
+    subtotal: "小计",
+    shipping: "运费",
+    tax: "税费",
+    total: "合计",
+    shippingTo: "配送地址",
+    viewOrder: "查看订单",
+  },
+}
+
+type OrderItem = {
+  product_title: string
+  variant_title?: string
+  thumbnail?: string
+  quantity: number
+  total: number
+}
+
+type OrderData = {
+  display_id: string
+  email: string
+  currency_code: string
+  subtotal: number
+  shipping_total: number
+  tax_total: number
+  total: number
+  items: OrderItem[]
+  shipping_address?: {
+    first_name?: string
+    last_name?: string
+    address_1?: string
+    city?: string
+    province?: string
+    postal_code?: string
+    country_code?: string
+  }
+}
+
+type Props = { order: OrderData; locale?: string }
+
+const formatPrice = (amount: number, currency: string) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: currency.toUpperCase(),
+  }).format(amount)
+
+export function orderPlacedEmail({ order, locale = "en" }: Props) {
+  const t = locale === "zh" ? i18n.zh : i18n.en
+  const curr = order.currency_code || "usd"
+
+  return (
+    <Html>
+      <Head />
+      <Preview>
+        {t.preview} #{order.display_id}
+      </Preview>
+      <Body
+        style={{
+          backgroundColor: "#FAFAFA",
+          fontFamily: "'Inter', 'Helvetica Neue', Arial, sans-serif",
+          margin: "0",
+          padding: "0",
+        }}
+      >
+        <Container style={{ maxWidth: "600px", margin: "0 auto" }}>
+          <NordHjemHeader />
+
+          <Section style={{ backgroundColor: "#FFFFFF", padding: "48px 40px" }}>
+            <Text
+              style={{
+                fontSize: "22px",
+                fontWeight: 300,
+                color: "#1A1A2E",
+                textAlign: "center" as const,
+                letterSpacing: "1px",
+                marginBottom: "8px",
+              }}
+            >
+              {t.title}
+            </Text>
+            <Text
+              style={{
+                fontSize: "14px",
+                color: "#666",
+                textAlign: "center" as const,
+                lineHeight: "22px",
+                marginBottom: "4px",
+              }}
+            >
+              {t.subtitle}
+            </Text>
+            <Text
+              style={{
+                fontSize: "13px",
+                color: "#999",
+                textAlign: "center" as const,
+                marginBottom: "32px",
+              }}
+            >
+              {t.orderNumber} #{order.display_id}
+            </Text>
+
+            <Hr style={{ borderColor: "#EEEEEE", marginBottom: "32px" }} />
+
+            <Text
+              style={{
+                fontSize: "12px",
+                fontWeight: 600,
+                letterSpacing: "2px",
+                color: "#999",
+                textTransform: "uppercase" as const,
+                marginBottom: "16px",
+              }}
+            >
+              {t.items}
+            </Text>
+
+            {order.items?.map((item, i) => (
+              <Row key={i} style={{ marginBottom: "16px" }}>
+                <Column style={{ width: "64px" }}>
+                  {item.thumbnail && (
+                    <Img
+                      src={item.thumbnail}
+                      alt={item.product_title}
+                      width="56"
+                      height="56"
+                      style={{ borderRadius: "8px", objectFit: "cover" as const }}
+                    />
+                  )}
+                </Column>
+                <Column style={{ paddingLeft: "12px", verticalAlign: "top" }}>
+                  <Text style={{ fontSize: "14px", color: "#1A1A2E", margin: "0 0 2px" }}>
+                    {item.product_title}
+                  </Text>
+                  {item.variant_title && (
+                    <Text style={{ fontSize: "12px", color: "#999", margin: "0" }}>
+                      {item.variant_title}
+                    </Text>
+                  )}
+                  <Text style={{ fontSize: "12px", color: "#999", margin: "4px 0 0" }}>
+                    Qty: {item.quantity}
+                  </Text>
+                </Column>
+                <Column style={{ textAlign: "right" as const, verticalAlign: "top" }}>
+                  <Text style={{ fontSize: "14px", color: "#1A1A2E", margin: "0" }}>
+                    {formatPrice(item.total, curr)}
+                  </Text>
+                </Column>
+              </Row>
+            ))}
+
+            <Hr style={{ borderColor: "#EEEEEE", margin: "24px 0" }} />
+
+            <Row>
+              <Column>
+                <Text style={{ fontSize: "14px", color: "#666" }}>{t.subtotal}</Text>
+              </Column>
+              <Column style={{ textAlign: "right" as const }}>
+                <Text style={{ fontSize: "14px", color: "#333" }}>
+                  {formatPrice(order.subtotal, curr)}
+                </Text>
+              </Column>
+            </Row>
+            <Row>
+              <Column>
+                <Text style={{ fontSize: "14px", color: "#666" }}>{t.shipping}</Text>
+              </Column>
+              <Column style={{ textAlign: "right" as const }}>
+                <Text style={{ fontSize: "14px", color: "#333" }}>
+                  {formatPrice(order.shipping_total, curr)}
+                </Text>
+              </Column>
+            </Row>
+            <Row>
+              <Column>
+                <Text style={{ fontSize: "14px", color: "#666" }}>{t.tax}</Text>
+              </Column>
+              <Column style={{ textAlign: "right" as const }}>
+                <Text style={{ fontSize: "14px", color: "#333" }}>
+                  {formatPrice(order.tax_total, curr)}
+                </Text>
+              </Column>
+            </Row>
+            <Hr style={{ borderColor: "#1A1A2E", margin: "12px 0" }} />
+            <Row>
+              <Column>
+                <Text style={{ fontSize: "16px", fontWeight: 600, color: "#1A1A2E" }}>
+                  {t.total}
+                </Text>
+              </Column>
+              <Column style={{ textAlign: "right" as const }}>
+                <Text style={{ fontSize: "16px", fontWeight: 600, color: "#1A1A2E" }}>
+                  {formatPrice(order.total, curr)}
+                </Text>
+              </Column>
+            </Row>
+
+            {order.shipping_address && (
+              <Section style={{ marginTop: "32px" }}>
+                <Text
+                  style={{
+                    fontSize: "12px",
+                    fontWeight: 600,
+                    letterSpacing: "2px",
+                    color: "#999",
+                    textTransform: "uppercase" as const,
+                    marginBottom: "8px",
+                  }}
+                >
+                  {t.shippingTo}
+                </Text>
+                <Text style={{ fontSize: "14px", color: "#333", lineHeight: "22px" }}>
+                  {order.shipping_address.first_name} {order.shipping_address.last_name}
+                  {"\n"}
+                  {order.shipping_address.address_1}
+                  {"\n"}
+                  {order.shipping_address.city}, {order.shipping_address.province}{" "}
+                  {order.shipping_address.postal_code}
+                  {"\n"}
+                  {order.shipping_address.country_code?.toUpperCase()}
+                </Text>
+              </Section>
+            )}
+
+            <Section style={{ textAlign: "center" as const, marginTop: "36px" }}>
+              <NordHjemButton href="https://nordhjem.store/account/orders">
+                {t.viewOrder}
+              </NordHjemButton>
+            </Section>
+          </Section>
+
+          <NordHjemFooter locale={locale} />
+        </Container>
+      </Body>
+    </Html>
+  )
+}

--- a/src/modules/resend/emails/password-reset.tsx
+++ b/src/modules/resend/emails/password-reset.tsx
@@ -1,0 +1,86 @@
+import { Body, Container, Head, Html, Preview, Section, Text } from "@react-email/components"
+import { NordHjemButton } from "./components/Button"
+import { NordHjemFooter } from "./components/Footer"
+import { NordHjemHeader } from "./components/Header"
+
+const i18n = {
+  en: {
+    preview: "Reset your NordHjem password",
+    title: "Password Reset",
+    body: "We received a request to reset your password. Click the button below to choose a new one. This link will expire in 1 hour.",
+    button: "RESET PASSWORD",
+    ignore: "If you didn't request this, you can safely ignore this email.",
+  },
+  zh: {
+    preview: "重置您的 NordHjem 密码",
+    title: "密码重置",
+    body: "我们收到了您的密码重置请求。点击下方按钮设置新密码。此链接将在 1 小时后失效。",
+    button: "重置密码",
+    ignore: "如果您没有发起此请求，请忽略此邮件。",
+  },
+}
+
+type Props = { email: string; resetUrl: string; locale?: string }
+
+export function passwordResetEmail({ email, resetUrl, locale = "en" }: Props) {
+  const t = locale === "zh" ? i18n.zh : i18n.en
+
+  return (
+    <Html>
+      <Head />
+      <Preview>{t.preview}</Preview>
+      <Body
+        style={{
+          backgroundColor: "#FAFAFA",
+          fontFamily: "'Inter', 'Helvetica Neue', Arial, sans-serif",
+        }}
+      >
+        <Container style={{ maxWidth: "600px", margin: "0 auto" }}>
+          <NordHjemHeader />
+          <Section
+            style={{
+              backgroundColor: "#FFFFFF",
+              padding: "48px 40px",
+              textAlign: "center" as const,
+            }}
+          >
+            <Text
+              style={{
+                fontSize: "22px",
+                fontWeight: 300,
+                color: "#1A1A2E",
+                letterSpacing: "1px",
+              }}
+            >
+              {t.title}
+            </Text>
+            <Text
+              style={{
+                fontSize: "14px",
+                color: "#666",
+                lineHeight: "24px",
+                margin: "16px 0 32px",
+              }}
+            >
+              {t.body}
+            </Text>
+            <NordHjemButton href={resetUrl}>{t.button}</NordHjemButton>
+            <Text
+              style={{
+                fontSize: "12px",
+                color: "#999",
+                marginTop: "32px",
+              }}
+            >
+              {t.ignore}
+            </Text>
+            <Text style={{ fontSize: "11px", color: "#BBBBBB", marginTop: "8px" }}>
+              {email}
+            </Text>
+          </Section>
+          <NordHjemFooter locale={locale} />
+        </Container>
+      </Body>
+    </Html>
+  )
+}

--- a/src/modules/resend/emails/shipping-notification.tsx
+++ b/src/modules/resend/emails/shipping-notification.tsx
@@ -1,0 +1,242 @@
+import {
+  Body,
+  Column,
+  Container,
+  Head,
+  Hr,
+  Html,
+  Img,
+  Preview,
+  Row,
+  Section,
+  Text,
+} from "@react-email/components"
+import { NordHjemButton } from "./components/Button"
+import { NordHjemFooter } from "./components/Footer"
+import { NordHjemHeader } from "./components/Header"
+
+const i18n = {
+  en: {
+    preview: "Your NordHjem order has shipped",
+    title: "Your order is on its way",
+    subtitle: "Great news — your order has been shipped and is heading to you.",
+    orderNumber: "Order",
+    trackingNumber: "Tracking Number",
+    items: "Items Shipped",
+    shippingTo: "Shipping To",
+    trackOrder: "TRACK ORDER",
+    noTracking: "VIEW ORDER",
+  },
+  zh: {
+    preview: "您的 NordHjem 订单已发货",
+    title: "您的订单已发出",
+    subtitle: "好消息 — 您的订单已发货，正在运送途中。",
+    orderNumber: "订单号",
+    trackingNumber: "追踪号码",
+    items: "发货商品",
+    shippingTo: "配送地址",
+    trackOrder: "追踪物流",
+    noTracking: "查看订单",
+  },
+}
+
+type Props = {
+  order: {
+    display_id: string
+    email: string
+    currency_code: string
+    items: Array<{
+      product_title: string
+      variant_title?: string
+      thumbnail?: string
+      quantity: number
+    }>
+    shipping_address?: {
+      first_name?: string
+      last_name?: string
+      address_1?: string
+      city?: string
+      province?: string
+      postal_code?: string
+      country_code?: string
+    }
+  }
+  fulfillment: {
+    tracking_numbers?: string[]
+    shipped_at?: string
+  }
+  trackingUrl?: string
+  locale?: string
+}
+
+export function shippingNotificationEmail({
+  order,
+  fulfillment,
+  trackingUrl,
+  locale = "en",
+}: Props) {
+  const t = locale === "zh" ? i18n.zh : i18n.en
+  const trackingNum = fulfillment.tracking_numbers?.[0]
+
+  return (
+    <Html>
+      <Head />
+      <Preview>
+        {t.preview} #{order.display_id}
+      </Preview>
+      <Body
+        style={{
+          backgroundColor: "#FAFAFA",
+          fontFamily: "'Inter', 'Helvetica Neue', Arial, sans-serif",
+          margin: "0",
+          padding: "0",
+        }}
+      >
+        <Container style={{ maxWidth: "600px", margin: "0 auto" }}>
+          <NordHjemHeader />
+
+          <Section style={{ backgroundColor: "#FFFFFF", padding: "48px 40px" }}>
+            <Text
+              style={{
+                fontSize: "22px",
+                fontWeight: 300,
+                color: "#1A1A2E",
+                textAlign: "center" as const,
+                letterSpacing: "1px",
+                marginBottom: "8px",
+              }}
+            >
+              {t.title}
+            </Text>
+            <Text
+              style={{
+                fontSize: "14px",
+                color: "#666",
+                textAlign: "center" as const,
+                lineHeight: "22px",
+                marginBottom: "4px",
+              }}
+            >
+              {t.subtitle}
+            </Text>
+            <Text
+              style={{
+                fontSize: "13px",
+                color: "#999",
+                textAlign: "center" as const,
+                marginBottom: "32px",
+              }}
+            >
+              {t.orderNumber} #{order.display_id}
+            </Text>
+
+            {trackingNum && (
+              <>
+                <Hr style={{ borderColor: "#EEEEEE", marginBottom: "24px" }} />
+                <Text
+                  style={{
+                    fontSize: "12px",
+                    fontWeight: 600,
+                    letterSpacing: "2px",
+                    color: "#999",
+                    textTransform: "uppercase" as const,
+                    marginBottom: "8px",
+                  }}
+                >
+                  {t.trackingNumber}
+                </Text>
+                <Text
+                  style={{
+                    fontSize: "16px",
+                    color: "#1A1A2E",
+                    fontFamily: "monospace",
+                    marginBottom: "24px",
+                  }}
+                >
+                  {trackingNum}
+                </Text>
+              </>
+            )}
+
+            <Hr style={{ borderColor: "#EEEEEE", marginBottom: "24px" }} />
+
+            <Text
+              style={{
+                fontSize: "12px",
+                fontWeight: 600,
+                letterSpacing: "2px",
+                color: "#999",
+                textTransform: "uppercase" as const,
+                marginBottom: "16px",
+              }}
+            >
+              {t.items}
+            </Text>
+
+            {order.items?.map((item, i) => (
+              <Row key={i} style={{ marginBottom: "12px" }}>
+                <Column style={{ width: "48px" }}>
+                  {item.thumbnail && (
+                    <Img
+                      src={item.thumbnail}
+                      alt={item.product_title}
+                      width="40"
+                      height="40"
+                      style={{ borderRadius: "6px", objectFit: "cover" as const }}
+                    />
+                  )}
+                </Column>
+                <Column style={{ paddingLeft: "12px" }}>
+                  <Text style={{ fontSize: "14px", color: "#1A1A2E", margin: "0" }}>
+                    {item.product_title} × {item.quantity}
+                  </Text>
+                  {item.variant_title && (
+                    <Text style={{ fontSize: "12px", color: "#999", margin: "0" }}>
+                      {item.variant_title}
+                    </Text>
+                  )}
+                </Column>
+              </Row>
+            ))}
+
+            {order.shipping_address && (
+              <>
+                <Hr style={{ borderColor: "#EEEEEE", margin: "24px 0" }} />
+                <Text
+                  style={{
+                    fontSize: "12px",
+                    fontWeight: 600,
+                    letterSpacing: "2px",
+                    color: "#999",
+                    textTransform: "uppercase" as const,
+                    marginBottom: "8px",
+                  }}
+                >
+                  {t.shippingTo}
+                </Text>
+                <Text style={{ fontSize: "14px", color: "#333", lineHeight: "22px" }}>
+                  {order.shipping_address.first_name} {order.shipping_address.last_name}
+                  {"\n"}
+                  {order.shipping_address.address_1}
+                  {"\n"}
+                  {order.shipping_address.city}, {order.shipping_address.province}{" "}
+                  {order.shipping_address.postal_code}
+                  {"\n"}
+                  {order.shipping_address.country_code?.toUpperCase()}
+                </Text>
+              </>
+            )}
+
+            <Section style={{ textAlign: "center" as const, marginTop: "36px" }}>
+              <NordHjemButton href={trackingUrl || "https://nordhjem.store/account/orders"}>
+                {trackingUrl ? t.trackOrder : t.noTracking}
+              </NordHjemButton>
+            </Section>
+          </Section>
+
+          <NordHjemFooter locale={locale} />
+        </Container>
+      </Body>
+    </Html>
+  )
+}

--- a/src/types/react-email-components.d.ts
+++ b/src/types/react-email-components.d.ts
@@ -1,0 +1,26 @@
+declare module "@react-email/components" {
+  import type { CSSProperties, FC, ReactNode } from "react"
+
+  type BaseProps = {
+    children?: ReactNode
+    style?: CSSProperties
+    href?: string
+    src?: string
+    alt?: string
+    width?: string | number
+    height?: string | number
+  }
+
+  export const Html: FC<BaseProps>
+  export const Head: FC<BaseProps>
+  export const Preview: FC<BaseProps>
+  export const Body: FC<BaseProps>
+  export const Container: FC<BaseProps>
+  export const Section: FC<BaseProps>
+  export const Text: FC<BaseProps>
+  export const Row: FC<BaseProps>
+  export const Column: FC<BaseProps>
+  export const Img: FC<BaseProps>
+  export const Hr: FC<BaseProps>
+  export const Button: FC<BaseProps>
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -16,10 +20,21 @@
     "incremental": true,
     "baseUrl": "./src",
     "paths": {
-      "@lib/*": ["lib/*"],
-      "@modules/*": ["modules/*"],
-      "@pages/*": ["pages/*"],
-      "@/*": ["./*"]
+      "@lib/*": [
+        "lib/*"
+      ],
+      "@modules/*": [
+        "modules/*"
+      ],
+      "@pages/*": [
+        "pages/*"
+      ],
+      "@/*": [
+        "./*"
+      ],
+      "@react-email/components": [
+        "modules/resend/emails/components/react-email-components"
+      ]
     },
     "plugins": [
       {
@@ -27,7 +42,12 @@
       }
     ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
   "exclude": [
     "node_modules",
     ".next",


### PR DESCRIPTION
### Motivation
- Provide four reusable, bilingual (English/Chinese) Resend email templates for Phase 2 that reuse the Phase1 header/footer/button building blocks.
- Ensure templates are fully inline-styled, use `@react-email/components` primitives (including `Img`) and format currency values with `Intl.NumberFormat` + `currency_code`.
- Make the templates easy to develop/test in this repository by adding a local shim for `@react-email/components` types when the real package cannot be installed.

### Description
- Added four templates under `src/modules/resend/emails`: `order-placed.tsx`, `shipping-notification.tsx`, `password-reset.tsx`, and `abandoned-cart.tsx`, each supporting a `locale` prop for `en`/`zh` copy.
- Added reusable UI parts under `src/modules/resend/emails/components`: `Header.tsx`, `Footer.tsx`, and `Button.tsx`, and each template imports and uses these components.
- Implemented a local shim and path mapping to satisfy TypeScript in this environment by adding `src/modules/resend/emails/components/react-email-components.tsx` and a declaration file `src/types/react-email-components.d.ts`, and updated `tsconfig.json` with a `@react-email/components` path alias.
- All templates use inline styles only, use `Intl.NumberFormat` for money formatting, and use the `Img` component from the shimmed `@react-email/components` API.

### Testing
- Attempted to install the official package with `yarn add @react-email/components` but the registry/install was blocked (403), so a local shim was used instead.
- Ran `npx tsc --noEmit` to type-check the project; the command still fails due to pre-existing TypeScript errors in unrelated files, and no new errors attributable to the added email templates were observed during the iterative checks.
- Verified file presence and that each template imports the Phase1-style components and includes `locale` support and inline styling by compiling/inspecting the new files directly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ac26b772ac8333a1caf89a9c729e72)