### PR TITLE
feat: add storefront abandoned cart recovery route

### DIFF
--- a/src/app/[locale]/[countryCode]/(main)/cart/recover/[id]/route.ts
+++ b/src/app/[locale]/[countryCode]/(main)/cart/recover/[id]/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest } from "next/server"
+import { retrieveCart } from "@lib/data/cart"
+import { setCartId } from "@lib/data/cookies"
+import { notFound, redirect } from "next/navigation"
+
+type Params = Promise<{ id: string; countryCode: string }>
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Params }
+) {
+  const { id, countryCode } = await params
+
+  try {
+    const cart = await retrieveCart(id)
+
+    if (!cart) {
+      return notFound()
+    }
+
+    await setCartId(id)
+    redirect(`/${countryCode}/cart`)
+  } catch {
+    return notFound()
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a storefront endpoint for abandoned-cart recovery so users arriving from abandoned-cart emails can load the cart and be redirected to the storefront cart page.

### Description
- Add `src/app/[locale]/[countryCode]/(main)/cart/recover/[id]/route.ts` which implements a `GET` handler that reads `id` and `countryCode` from params, calls `retrieveCart(id)`, sets the `_medusa_cart_id` via `setCartId`, redirects to `/{countryCode}/cart`, and returns `notFound()` when the cart is missing or an error occurs.

### Testing
- Ran `npx tsc --noEmit` which failed due to pre-existing TypeScript errors unrelated to this change.
- Ran `npx eslint 'src/app/[locale]/[countryCode]/(main)/cart/recover/[id]/route.ts'` which failed due to an existing Next ESLint rule configuration issue in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ac26c3ee448333953b7fb715242323)