### PR TITLE
feat/checkout-robustness-order-enhancement

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -238,7 +238,8 @@
         "incorrect_cvc": "The CVC code is incorrect. Please check and retry.",
         "processing_error": "We could not process your card. Please try again.",
         "authentication_required": "3D Secure verification is required. Please complete the popup challenge."
-      }
+      },
+      "network": "Please check your network connection and try again."
     },
     "progress": {
       "label": "Checkout progress",
@@ -247,7 +248,14 @@
       "review": "Review",
       "stepCount": "Step {current} of {total}"
     },
-    "useSavedAddress": "Use a saved address"
+    "useSavedAddress": "Use a saved address",
+    "errors": {
+      "apiUnavailable": "Payment service is temporarily unavailable",
+      "tryAgain": "Please refresh and try again",
+      "refresh": "Refresh",
+      "noPaymentForRegion": "Online payment is not available for this region yet",
+      "loadingPayment": "Loading payment methods..."
+    }
   },
   "order": {
     "thankYou": "Thank you for your order!",
@@ -270,6 +278,36 @@
       "fulfilled": "Fulfilled",
       "shipped": "Shipped",
       "canceled": "Canceled"
+    },
+    "items": "Items",
+    "quantity": "Quantity",
+    "subtotal": "Subtotal",
+    "shippingInfo": "Shipping information",
+    "paymentInfo": "Payment information",
+    "estimatedDelivery": "Estimated delivery",
+    "businessDays": "{days} business days",
+    "trackingNumber": "Tracking number",
+    "timeline": "Order timeline",
+    "cardEnding": "ending {last4}",
+    "manualPayment": "Manual payment",
+    "pendingConfirmation": "Pending confirmation",
+    "statusProgressTitle": "Order progress",
+    "timelineCreated": "Created",
+    "timelinePaid": "Paid",
+    "timelineShipped": "Shipped",
+    "timelineUpdated": "Updated",
+    "statusProgress": {
+      "pending": "Pending",
+      "processing": "Processing",
+      "shipped": "Shipped",
+      "delivered": "Delivered"
+    },
+    "paymentStatus": {
+      "authorized": "Authorized",
+      "captured": "Captured",
+      "refunded": "Refunded",
+      "pending": "Pending payment",
+      "pendingConfirmation": "Pending confirmation"
     }
   },
   "account": {

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -238,7 +238,8 @@
         "incorrect_cvc": "安全码不正确，请检查后重试。",
         "processing_error": "银行卡处理失败，请稍后重试。",
         "authentication_required": "需要完成 3D Secure 验证，请先完成弹窗挑战。"
-      }
+      },
+      "network": "请检查网络连接并重试。"
     },
     "progress": {
       "label": "结账进度",
@@ -247,7 +248,14 @@
       "review": "确认",
       "stepCount": "第 {current} / {total} 步"
     },
-    "useSavedAddress": "使用保存的地址"
+    "useSavedAddress": "使用保存的地址",
+    "errors": {
+      "apiUnavailable": "支付服务暂时不可用",
+      "tryAgain": "请刷新页面重试",
+      "refresh": "刷新",
+      "noPaymentForRegion": "该地区暂不支持在线支付",
+      "loadingPayment": "正在加载支付方式..."
+    }
   },
   "order": {
     "thankYou": "感谢您的订单！",
@@ -270,6 +278,36 @@
       "fulfilled": "已发货",
       "shipped": "运输中",
       "canceled": "已取消"
+    },
+    "items": "商品明细",
+    "quantity": "数量",
+    "subtotal": "小计",
+    "shippingInfo": "配送信息",
+    "paymentInfo": "支付信息",
+    "estimatedDelivery": "预计配送时间",
+    "businessDays": "{days} 个工作日",
+    "trackingNumber": "物流单号",
+    "timeline": "订单时间线",
+    "cardEnding": "尾号 {last4}",
+    "manualPayment": "线下支付",
+    "pendingConfirmation": "待确认",
+    "statusProgressTitle": "订单状态进度",
+    "timelineCreated": "已创建",
+    "timelinePaid": "已支付",
+    "timelineShipped": "已发货",
+    "timelineUpdated": "最近更新",
+    "statusProgress": {
+      "pending": "已下单",
+      "processing": "处理中",
+      "shipped": "已发货",
+      "delivered": "已送达"
+    },
+    "paymentStatus": {
+      "authorized": "已授权",
+      "captured": "已扣款",
+      "refunded": "已退款",
+      "pending": "待支付",
+      "pendingConfirmation": "待确认"
     }
   },
   "account": {

--- a/src/app/[locale]/[countryCode]/(main)/account/@dashboard/orders/details/[id]/page.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/account/@dashboard/orders/details/[id]/page.tsx
@@ -17,7 +17,7 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
 
   return {
     title: `Order #${order.display_id}`,
-    description: `View your order`,
+    description: `View your order timeline, shipping and payment status`,
   }
 }
 

--- a/src/modules/checkout/components/payment-button/index.tsx
+++ b/src/modules/checkout/components/payment-button/index.tsx
@@ -143,6 +143,14 @@ const StripePaymentButton = ({
         error.code === "authentication_required"
       ) {
         setErrorMessage(t("paymentErrors.authenticationRequired"))
+      } else if (
+        error.type === "api_connection_error" ||
+        error.code === "network_error" ||
+        error.code === "timeout"
+      ) {
+        setErrorMessage(
+          t("paymentErrors.network")
+        )
       } else {
         setErrorMessage(error.message || t("paymentErrors.generic"))
       }

--- a/src/modules/checkout/components/payment/index.tsx
+++ b/src/modules/checkout/components/payment/index.tsx
@@ -3,7 +3,7 @@
 import { RadioGroup } from "@headlessui/react"
 import { isStripeLike, paymentInfoMap } from "@lib/constants"
 import { initiatePaymentSession } from "@lib/data/cart"
-import { CheckCircleSolid, CreditCard } from "@medusajs/icons"
+import { CheckCircleSolid, CreditCard, Loader } from "@medusajs/icons"
 import { Button, Container, Heading, Text, clx } from "@medusajs/ui"
 import PaymentError from "@modules/checkout/components/payment-error"
 import PaymentContainer, {
@@ -33,6 +33,7 @@ const Payment = ({
   const [selectedPaymentMethod, setSelectedPaymentMethod] = useState(
     activeSession?.provider_id ?? ""
   )
+  const [isSwitchingMethod, setIsSwitchingMethod] = useState(false)
 
   const searchParams = useSearchParams()
   const router = useRouter()
@@ -84,10 +85,21 @@ const Payment = ({
   const setPaymentMethod = async (method: string) => {
     setError(null)
     setSelectedPaymentMethod(method)
-    if (isStripeLike(method)) {
+
+    if (!isStripeLike(method)) {
+      return
+    }
+
+    setIsSwitchingMethod(true)
+
+    try {
       await initiatePaymentSession(cart, {
         provider_id: method,
       })
+    } catch {
+      setError(t.has("errors.apiUnavailable") ? t("errors.apiUnavailable") : "Payment service is temporarily unavailable, please refresh and try again")
+    } finally {
+      setIsSwitchingMethod(false)
     }
   }
 
@@ -137,7 +149,12 @@ const Payment = ({
         )
       }
     } catch (err: any) {
-      setError(err.message)
+      setError(
+        err?.message ||
+          (t.has("errors.apiUnavailable")
+            ? t("errors.apiUnavailable")
+            : "Payment service is temporarily unavailable, please refresh and try again")
+      )
     } finally {
       setIsLoading(false)
     }
@@ -177,6 +194,13 @@ const Payment = ({
       </div>
       <div>
         <div className={isOpen ? "block" : "hidden"}>
+          {!paidByGiftcard && isSwitchingMethod && (
+            <div className="mt-4 flex items-center gap-2 text-ui-fg-subtle" data-testid="payment-method-loading">
+              <Loader className="animate-spin" />
+              <Text>{t.has("errors.loadingPayment") ? t("errors.loadingPayment") : "Loading payment methods..."}</Text>
+            </div>
+          )}
+
           {!paidByGiftcard && availablePaymentMethods?.length > 0 && (
             <>
               <RadioGroup
@@ -213,7 +237,7 @@ const Payment = ({
               data-testid="payment-methods-empty-state"
             >
               <Text className="txt-medium-plus text-ui-fg-base">
-                {t("noPaymentMethodsTitle")}
+                {t.has("errors.noPaymentForRegion") ? t("errors.noPaymentForRegion") : t("noPaymentMethodsTitle")}
               </Text>
               <Text className="txt-medium text-ui-fg-subtle mt-1">
                 {t("noPaymentMethodsDescription")}

--- a/src/modules/checkout/templates/checkout-form/index.tsx
+++ b/src/modules/checkout/templates/checkout-form/index.tsx
@@ -6,6 +6,47 @@ import Payment from "@modules/checkout/components/payment"
 import CheckoutProgress from "@modules/checkout/components/checkout-progress"
 import Review from "@modules/checkout/components/review"
 import Shipping from "@modules/checkout/components/shipping"
+import { ExclamationCircleSolid } from "@medusajs/icons"
+import { getLocale, getTranslations } from "next-intl/server"
+
+const CheckoutErrorBoundary = async () => {
+  const [t, locale] = await Promise.all([
+    getTranslations("checkout"),
+    getLocale(),
+  ])
+
+  const isZh = locale.startsWith("zh")
+
+  return (
+    <div className="w-full rounded-lg border border-rose-200 bg-rose-50 px-6 py-8 text-center">
+      <div className="mb-4 flex justify-center text-rose-500">
+        <ExclamationCircleSolid className="h-8 w-8" />
+      </div>
+      <p className="text-lg font-semibold text-rose-700">
+        {t.has("errors.apiUnavailable")
+          ? t("errors.apiUnavailable")
+          : "Payment service is temporarily unavailable"}
+      </p>
+      <p className="mt-2 text-sm text-rose-600">
+        {t.has("errors.tryAgain")
+          ? t("errors.tryAgain")
+          : "Please refresh and try again."}
+      </p>
+      <p className="mt-1 text-xs text-rose-500">
+        {isZh
+          ? "Payment service is temporarily unavailable. Please refresh and try again."
+          : "支付服务暂时不可用，请刷新页面后重试。"}
+      </p>
+
+      <a
+        href=""
+        className="mt-6 inline-block rounded-md bg-rose-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-rose-700"
+      >
+        {t.has("errors.refresh") ? t("errors.refresh") : "Refresh"}
+      </a>
+    </div>
+  )
+}
 
 export default async function CheckoutForm({
   cart,
@@ -18,11 +59,18 @@ export default async function CheckoutForm({
     return null
   }
 
-  const shippingMethods = await listCartShippingMethods(cart.id)
-  const paymentMethods = await listCartPaymentMethods(cart.region?.id ?? "")
+  let shippingMethods
+  let paymentMethods
+
+  try {
+    shippingMethods = await listCartShippingMethods(cart.id)
+    paymentMethods = await listCartPaymentMethods(cart.region?.id ?? "")
+  } catch {
+    return <CheckoutErrorBoundary />
+  }
 
   if (!shippingMethods || !paymentMethods) {
-    return null
+    return <CheckoutErrorBoundary />
   }
 
   return (

--- a/src/modules/order/templates/order-completed-template.tsx
+++ b/src/modules/order/templates/order-completed-template.tsx
@@ -1,18 +1,32 @@
-import { Heading } from "@medusajs/ui"
-import { cookies as nextCookies } from "next/headers"
-import { getLocale, getTranslations } from "next-intl/server"
-
+import { convertToLocale } from "@lib/util/money"
+import { HttpTypes } from "@medusajs/types"
+import { Button, Heading, Text } from "@medusajs/ui"
+import LocalizedClientLink from "@modules/common/components/localized-client-link"
 import CartTotals from "@modules/common/components/cart-totals"
 import Help from "@modules/order/components/help"
 import Items from "@modules/order/components/items"
 import OnboardingCta from "@modules/order/components/onboarding-cta"
-import ShippingDetails from "@modules/order/components/shipping-details"
-import PaymentDetails from "@modules/order/components/payment-details"
-import { HttpTypes } from "@medusajs/types"
-import { convertToLocale } from "@lib/util/money"
+import { cookies as nextCookies } from "next/headers"
+import { getLocale, getTranslations } from "next-intl/server"
 
 type OrderCompletedTemplateProps = {
   order: HttpTypes.StoreOrder
+}
+
+const getPaymentSummary = (order: HttpTypes.StoreOrder, t: any) => {
+  const payment = order.payment_collections?.[0]?.payments?.[0]
+
+  if (!payment) {
+    return t.has("manualPayment") ? t("manualPayment") : "Manual payment"
+  }
+
+  const last4 = (payment.data as Record<string, string> | undefined)?.card_last4
+
+  if (last4) {
+    return `Visa ${t.has("cardEnding") ? t("cardEnding", { last4 }) : `ending ${last4}`}`
+  }
+
+  return t.has("manualPayment") ? t("manualPayment") : "Manual payment"
 }
 
 export default async function OrderCompletedTemplate({
@@ -30,17 +44,20 @@ export default async function OrderCompletedTemplate({
       ? order.status
       : "pending"
 
+  const shippingMethod = order.shipping_methods?.[0]
+  const estimatedDays = (shippingMethod?.data as Record<string, unknown> | undefined)?.estimated_days as string | number | undefined
+
   return (
     <div className="py-6 min-h-[calc(100vh-64px)]">
       <div className="content-container flex flex-col justify-center items-center gap-y-10 max-w-4xl h-full w-full">
         {isOnboarding && <OnboardingCta orderId={order.id} />}
         <div
-          className="flex flex-col gap-4 max-w-4xl h-full bg-white w-full py-10"
+          className="flex flex-col gap-6 max-w-4xl h-full bg-white w-full py-10"
           data-testid="order-complete-container"
         >
           <Heading
             level="h1"
-            className="flex flex-col gap-y-3 text-ui-fg-base text-3xl mb-4"
+            className="flex flex-col gap-y-3 text-ui-fg-base text-3xl mb-2"
           >
             <span>{t("thankYou")}</span>
             <span>{t("orderConfirmed")}</span>
@@ -72,21 +89,47 @@ export default async function OrderCompletedTemplate({
             </div>
           </div>
 
-          <Heading level="h2" className="flex flex-row text-3xl-regular">
-            {t("orderConfirmed")}
-          </Heading>
-          <Items order={order} />
+          <div>
+            <Heading level="h2" className="flex flex-row text-3xl-regular mb-4">
+              {t.has("items") ? t("items") : "Items"}
+            </Heading>
+            <Items order={order} />
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="rounded-lg border border-ui-border-base p-4">
+              <Text className="txt-medium-plus mb-2">{t.has("shippingInfo") ? t("shippingInfo") : t("shippingAddress")}</Text>
+              <Text className="txt-medium text-ui-fg-subtle">
+                {order.shipping_address?.first_name} {order.shipping_address?.last_name}
+              </Text>
+              <Text className="txt-medium text-ui-fg-subtle">{order.shipping_address?.address_1}</Text>
+              <Text className="txt-medium text-ui-fg-subtle">
+                {order.shipping_address?.postal_code} {order.shipping_address?.city}
+              </Text>
+              {estimatedDays && (
+                <Text className="txt-medium text-ui-fg-subtle mt-2" data-testid="estimated-delivery">
+                  {t.has("estimatedDelivery") ? t("estimatedDelivery") : "Estimated delivery"}: {t.has("businessDays") ? t("businessDays", { days: estimatedDays }) : `${estimatedDays} business days`}
+                </Text>
+              )}
+            </div>
+            <div className="rounded-lg border border-ui-border-base p-4">
+              <Text className="txt-medium-plus mb-2">{t.has("paymentInfo") ? t("paymentInfo") : t("paymentMethod")}</Text>
+              <Text className="txt-medium text-ui-fg-subtle" data-testid="payment-summary">
+                {getPaymentSummary(order, t)}
+              </Text>
+            </div>
+          </div>
+
           <CartTotals totals={order} />
 
-          <Heading level="h2" className="flex flex-row text-3xl-regular">
-            {t("shippingAddress")}
-          </Heading>
-          <ShippingDetails order={order} />
+          <div className="pt-2">
+            <LocalizedClientLink href="/store">
+              <Button size="large" data-testid="continue-shopping-button">
+                {t("continueShopping")}
+              </Button>
+            </LocalizedClientLink>
+          </div>
 
-          <Heading level="h2" className="flex flex-row text-3xl-regular">
-            {t("paymentMethod")}
-          </Heading>
-          <PaymentDetails order={order} />
           <Help />
         </div>
       </div>

--- a/src/modules/order/templates/order-details-template.tsx
+++ b/src/modules/order/templates/order-details-template.tsx
@@ -2,6 +2,7 @@
 
 import { XMark } from "@medusajs/icons"
 import { HttpTypes } from "@medusajs/types"
+import { Badge, Text } from "@medusajs/ui"
 import LocalizedClientLink from "@modules/common/components/localized-client-link"
 import Help from "@modules/order/components/help"
 import Items from "@modules/order/components/items"
@@ -9,16 +10,74 @@ import OrderDetails from "@modules/order/components/order-details"
 import OrderSummary from "@modules/order/components/order-summary"
 import ShippingDetails from "@modules/order/components/shipping-details"
 import React from "react"
-import { useTranslations } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 
 type OrderDetailsTemplateProps = {
   order: HttpTypes.StoreOrder
+}
+
+const statusSteps = ["pending", "processing", "shipped", "delivered"] as const
+
+const getProgressStatus = (order: HttpTypes.StoreOrder) => {
+  if (order.fulfillment_status === "delivered") {
+    return "delivered"
+  }
+
+  if (
+    order.fulfillment_status === "fulfilled" ||
+    order.fulfillment_status === "shipped"
+  ) {
+    return "shipped"
+  }
+
+  if (order.payment_status === "captured") {
+    return "processing"
+  }
+
+  return "pending"
+}
+
+const getPaymentStatusKey = (status?: string | null) => {
+  if (!status) {
+    return "pending"
+  }
+
+  if (["authorized", "captured", "refunded", "pending"].includes(status)) {
+    return status
+  }
+
+  return "pendingConfirmation"
 }
 
 const OrderDetailsTemplate: React.FC<OrderDetailsTemplateProps> = ({
   order,
 }) => {
   const t = useTranslations("order")
+  const locale = useLocale()
+
+  const currentStatus = getProgressStatus(order)
+  const currentStepIndex = statusSteps.indexOf(currentStatus)
+  const trackingNumber = (order.fulfillments?.[0] as any)?.tracking_number
+  const payment = order.payment_collections?.[0]?.payments?.[0]
+
+  const timeline = [
+    {
+      label: t.has("timelineCreated") ? t("timelineCreated") : "Created",
+      date: order.created_at,
+    },
+    {
+      label: t.has("timelinePaid") ? t("timelinePaid") : "Paid",
+      date: payment?.created_at,
+    },
+    {
+      label: t.has("timelineShipped") ? t("timelineShipped") : "Shipped",
+      date: order.fulfillments?.[0]?.created_at,
+    },
+    {
+      label: t.has("timelineUpdated") ? t("timelineUpdated") : "Last update",
+      date: order.updated_at,
+    },
+  ].filter((entry) => entry.date)
 
   return (
     <div className="flex flex-col justify-center gap-y-4">
@@ -37,6 +96,51 @@ const OrderDetailsTemplate: React.FC<OrderDetailsTemplateProps> = ({
         data-testid="order-details-container"
       >
         <OrderDetails order={order} showStatus />
+
+        <div className="rounded-lg border border-ui-border-base p-4">
+          <Text className="txt-medium-plus mb-3">{t.has("statusProgressTitle") ? t("statusProgressTitle") : t("statusProgress.pending")}</Text>
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            {statusSteps.map((step, idx) => (
+              <div key={step} className="flex items-center gap-2">
+                <span
+                  className={`h-3 w-3 rounded-full ${idx <= currentStepIndex ? "bg-ui-fg-interactive" : "bg-ui-border-base"}`}
+                />
+                <Text className={idx <= currentStepIndex ? "text-ui-fg-base" : "text-ui-fg-muted"}>
+                  {t.has(`statusProgress.${step}`) ? t(`statusProgress.${step}`) : step}
+                </Text>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {trackingNumber && (
+          <div className="rounded-lg border border-ui-border-base p-4">
+            <Text className="txt-medium-plus">{t.has("trackingNumber") ? t("trackingNumber") : "Tracking number"}</Text>
+            <Text className="text-ui-fg-subtle" data-testid="tracking-number">{trackingNumber}</Text>
+          </div>
+        )}
+
+        <div className="rounded-lg border border-ui-border-base p-4">
+          <Text className="txt-medium-plus mb-2">{t.has("paymentInfo") ? t("paymentInfo") : "Payment"}</Text>
+          <Badge>
+            {t.has(`paymentStatus.${getPaymentStatusKey(order.payment_status)}`)
+              ? t(`paymentStatus.${getPaymentStatusKey(order.payment_status)}`)
+              : t("paymentStatus.pending")}
+          </Badge>
+        </div>
+
+        <div className="rounded-lg border border-ui-border-base p-4">
+          <Text className="txt-medium-plus mb-3">{t.has("timeline") ? t("timeline") : "Timeline"}</Text>
+          <div className="space-y-2">
+            {timeline.map((entry) => (
+              <div key={entry.label} className="flex items-center justify-between text-sm">
+                <Text className="text-ui-fg-subtle">{entry.label}</Text>
+                <Text>{new Date(entry.date as string).toLocaleString(locale)}</Text>
+              </div>
+            ))}
+          </div>
+        </div>
+
         <Items order={order} />
         <ShippingDetails order={order} />
         <OrderSummary order={order} />


### PR DESCRIPTION
### Motivation
- Prevent blank/white screens when Medusa/ payment APIs are unavailable and improve payment UX during failures and method switches.
- Surface richer order information (items, shipping, payment summary, timeline, tracking) on confirmation and details pages to improve post-purchase clarity.

### Description
- Added a checkout-level fallback UI component used by `src/modules/checkout/templates/checkout-form/index.tsx` that renders a bilingual friendly error page and a refresh action when fetching shipping/payment methods fails using `getTranslations`/`getLocale`.
- Hardened payment flow in `src/modules/checkout/components/payment/index.tsx` by adding `isSwitchingMethod` state, a loading spinner while switching methods, and explicit API-unavailable messages when `initiatePaymentSession` fails; also show a regional-no-payment message when `availablePaymentMethods` is an empty array.
- Improved Stripe confirmation error handling in `src/modules/checkout/components/payment-button/index.tsx` to surface network/timeout guidance for `api_connection_error` / `network_error` / `timeout` cases.
- Enhanced order confirmation UI in `src/modules/order/templates/order-completed-template.tsx` to display item list, shipping address card, payment summary (card last4 or manual), estimated delivery from shipping metadata, and a `Continue shopping` CTA to `/store` (all bilingual-aware via `next-intl`).
- Enhanced order details UI in `src/modules/order/templates/order-details-template.tsx` with a status progress indicator, conditional tracking section, payment status badge with null/unknown fallback, and an order timeline (created/paid/shipped/updated) using localized strings.
- Added/extended i18n keys in `messages/en.json` and `messages/zh.json` under the `checkout` and `order` namespaces to support the new copy and error messages.
- Minor metadata update: order details page description updated to reflect timeline/shipping/payment status view.

### Testing
- Started the dev server with `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY=dummy yarn dev` and captured a UI screenshot of the checkout page (`artifacts/checkout-robustness.png`) to validate the fallback UI renders in the running app; dev server started successfully.
- Ran focused TypeScript checks for the modified files (`yarn tsc --noEmit` with filters for the changed modules) and resolved type issues introduced by the changes; modified files show no type errors in the targeted checks.
- `yarn lint` failed in this environment due to rule-loading and environment-specific lint constraints (`@next/next/no-html-link-for-pages` path error), so full linting could not be validated here.
- `yarn build` failed in this environment due to Google Fonts fetch/network errors when building (external network/font fetch blocked), so full production build validation could not be completed here.

Please review the changes and run CI/QA (including real backend and Stripe test flows) to validate normal and failure scenarios listed in the PR notes before merging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ac494c675883338aa8f42e21324922)