### PR TITLE
[C-021-fix] 修复结账错误文案、刷新链接与支付卡品牌显示

### DIFF
--- a/src/modules/checkout/templates/checkout-form/index.tsx
+++ b/src/modules/checkout/templates/checkout-form/index.tsx
@@ -34,12 +34,12 @@ const CheckoutErrorBoundary = async () => {
       </p>
       <p className="mt-1 text-xs text-rose-500">
         {isZh
-          ? "Payment service is temporarily unavailable. Please refresh and try again."
-          : "支付服务暂时不可用，请刷新页面后重试。"}
+          ? "支付服务暂时不可用，请刷新页面后重试。"
+          : "Payment service is temporarily unavailable. Please refresh and try again."}
       </p>
 
       <a
-        href=""
+        href="."
         className="mt-6 inline-block rounded-md bg-rose-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-rose-700"
       >
         {t.has("errors.refresh") ? t("errors.refresh") : "Refresh"}

--- a/src/modules/order/templates/order-completed-template.tsx
+++ b/src/modules/order/templates/order-completed-template.tsx
@@ -23,7 +23,8 @@ const getPaymentSummary = (order: HttpTypes.StoreOrder, t: any) => {
   const last4 = (payment.data as Record<string, string> | undefined)?.card_last4
 
   if (last4) {
-    return `Visa ${t.has("cardEnding") ? t("cardEnding", { last4 }) : `ending ${last4}`}`
+    const brand = (payment.data as Record<string, string> | undefined)?.card_brand || "Card"
+    return `${brand} ${t.has("cardEnding") ? t("cardEnding", { last4 }) : `ending ${last4}`}`
   }
 
   return t.has("manualPayment") ? t("manualPayment") : "Manual payment"


### PR DESCRIPTION
### Motivation
- 修复 checkout 页面错误提示中英文写反的问题以确保中文环境显示中文提示且英文环境显示英文提示。
- 修复刷新按钮无效的问题以便用户能够通过界面刷新页面。
- 修复订单完成页支付摘要中卡品牌被硬编码为 `Visa` 的问题以正确显示实际卡品牌或回退到通用 `Card`。

### Description
- 在 `src/modules/checkout/templates/checkout-form/index.tsx` 中调整 `isZh` 分支文案，使 `isZh` 为真时显示中文文本，非中文显示英文文本。 
- 在 `src/modules/checkout/templates/checkout-form/index.tsx` 中将刷新链接从 `href=""` 改为 `href="."` 以使按钮可用。 
- 在 `src/modules/order/templates/order-completed-template.tsx` 的 `getPaymentSummary` 中改为从 `payment.data.card_brand` 读取卡品牌并在缺省时回退到 `"Card"`，再拼接卡尾四位显示。 
- 已在当前本地分支提交修改，提交信息为 `fix: correct checkout error copy and payment card brand`。

### Testing
- 运行 `yarn eslint src/modules/checkout/templates/checkout-form/index.tsx src/modules/order/templates/order-completed-template.tsx` 报错并失败，原因是环境中 Next ESLint 规则 `@next/next/no-html-link-for-pages` 加载时出现配置路径相关错误。 
- 运行 `yarn dev` 无法启动并失败，原因是缺少必需环境变量 `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY`，因此无法在本环境中进行页面级手动验证。 
- 已成功将修改以 1 次 commit 应用到本地分支，但在当前环境未配置远程仓库，无法完成 `git push`。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ac4f3feba48333ba7bcfabea40505d)