### PR TITLE
fix: show zero-value shipping and taxes in order summary

### DIFF
--- a/src/modules/order/components/order-summary/index.tsx
+++ b/src/modules/order/components/order-summary/index.tsx
@@ -7,7 +7,7 @@ type OrderSummaryProps = {
 
 const OrderSummary = ({ order }: OrderSummaryProps) => {
   const getAmount = (amount?: number | null) => {
-    if (!amount) {
+    if (amount == null) {
       return
     }
 


### PR DESCRIPTION
### Motivation
- Fix a UI bug where `Shipping` and `Taxes` displayed blank when their amounts were `0` because `getAmount` used a falsy check that excluded `0`.

### Description
- Change the check in `src/modules/order/components/order-summary/index.tsx` from `if (!amount)` to `if (amount == null)` so `0` is preserved and formatted by `convertToLocale`.

### Testing
- Attempted `npx next build`, but the build could not be validated here because it failed with a missing environment variable `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ace438647c83339c458eba20e8ad84)