### PR TITLE
fix: localize cart and account hardcoded support text

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -167,7 +167,14 @@
     "couponApplied": "Coupon applied",
     "couponInvalid": "Invalid coupon code",
     "updateCart": "Update Cart",
-    "freeShippingNudge": "Add {amount} more for free shipping"
+    "freeShippingNudge": "Add {amount} more for free shipping",
+    "price": "Price",
+    "summary": "Summary",
+    "alreadyHaveAccount": "Already have an account?",
+    "signInBenefit": "Sign in for a better experience.",
+    "signIn": "Sign in",
+    "emptyMessage": "You don't have anything in your cart. Let's change that, use the link below to start browsing our products.",
+    "exploreProducts": "Explore products"
   },
   "checkout": {
     "title": "Checkout",
@@ -400,7 +407,10 @@
       "paid": "Paid",
       "partiallyRefunded": "Partially refunded",
       "refunded": "Refunded"
-    }
+    },
+    "gotQuestions": "Got questions?",
+    "gotQuestionsDescription": "You can find frequently asked questions and answers on our customer service page.",
+    "customerService": "Customer Service"
   },
   "auth": {
     "login": "Login",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -167,7 +167,14 @@
     "couponApplied": "优惠券已使用",
     "couponInvalid": "无效的优惠码",
     "updateCart": "更新购物车",
-    "freeShippingNudge": "再添加 {amount} 即可享受免运费"
+    "freeShippingNudge": "再添加 {amount} 即可享受免运费",
+    "price": "单价",
+    "summary": "订单汇总",
+    "alreadyHaveAccount": "已有账户？",
+    "signInBenefit": "登录以获得更好的体验。",
+    "signIn": "登录",
+    "emptyMessage": "您的购物车中还没有商品。点击下方链接开始浏览我们的产品吧。",
+    "exploreProducts": "浏览商品"
   },
   "checkout": {
     "title": "结算",
@@ -400,7 +407,10 @@
       "paid": "已支付",
       "partiallyRefunded": "部分退款",
       "refunded": "已退款"
-    }
+    },
+    "gotQuestions": "有疑问？",
+    "gotQuestionsDescription": "您可以在我们的客户服务页面找到常见问题和答案。",
+    "customerService": "客户服务"
   },
   "auth": {
     "login": "登录",

--- a/src/modules/account/templates/account-layout.tsx
+++ b/src/modules/account/templates/account-layout.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { getTranslations } from "next-intl/server"
 
 import UnderlineLink from "@modules/common/components/interactive-link"
 
@@ -10,10 +11,12 @@ interface AccountLayoutProps {
   children: React.ReactNode
 }
 
-const AccountLayout: React.FC<AccountLayoutProps> = ({
+const AccountLayout: React.FC<AccountLayoutProps> = async ({
   customer,
   children,
 }) => {
+  const t = await getTranslations("account")
+
   return (
     <div className="flex-1 small:py-12" data-testid="account-page">
       <div className="flex-1 content-container h-full max-w-5xl mx-auto bg-white flex flex-col">
@@ -23,15 +26,14 @@ const AccountLayout: React.FC<AccountLayoutProps> = ({
         </div>
         <div className="flex flex-col small:flex-row items-end justify-between small:border-t border-gray-200 py-12 gap-8">
           <div>
-            <h3 className="text-xl-semi mb-4">Got questions?</h3>
+            <h3 className="text-xl-semi mb-4">{t("gotQuestions")}</h3>
             <span className="txt-medium">
-              You can find frequently asked questions and answers on our
-              customer service page.
+              {t("gotQuestionsDescription")}
             </span>
           </div>
           <div>
             <UnderlineLink href="/customer-service">
-              Customer Service
+              {t("customerService")}
             </UnderlineLink>
           </div>
         </div>

--- a/src/modules/cart/components/empty-cart-message/index.tsx
+++ b/src/modules/cart/components/empty-cart-message/index.tsx
@@ -1,22 +1,24 @@
 import { Heading, Text } from "@medusajs/ui"
 
 import InteractiveLink from "@modules/common/components/interactive-link"
+import { getTranslations } from "next-intl/server"
 
-const EmptyCartMessage = () => {
+const EmptyCartMessage = async () => {
+  const t = await getTranslations("cart")
+
   return (
     <div className="py-48 px-2 flex flex-col justify-center items-start" data-testid="empty-cart-message">
       <Heading
         level="h1"
         className="flex flex-row text-3xl-regular gap-x-2 items-baseline"
       >
-        Cart
+        {t("title")}
       </Heading>
       <Text className="text-base-regular mt-4 mb-6 max-w-[32rem]">
-        You don&apos;t have anything in your cart. Let&apos;s change that, use
-        the link below to start browsing our products.
+        {t("emptyMessage")}
       </Text>
       <div>
-        <InteractiveLink href="/store">Explore products</InteractiveLink>
+        <InteractiveLink href="/store">{t("exploreProducts")}</InteractiveLink>
       </div>
     </div>
   )

--- a/src/modules/cart/components/sign-in-prompt/index.tsx
+++ b/src/modules/cart/components/sign-in-prompt/index.tsx
@@ -1,21 +1,24 @@
 import { Button, Heading, Text } from "@medusajs/ui"
 import LocalizedClientLink from "@modules/common/components/localized-client-link"
+import { getTranslations } from "next-intl/server"
 
-const SignInPrompt = () => {
+const SignInPrompt = async () => {
+  const t = await getTranslations("cart")
+
   return (
     <div className="bg-white flex items-center justify-between">
       <div>
         <Heading level="h2" className="txt-xlarge">
-          Already have an account?
+          {t("alreadyHaveAccount")}
         </Heading>
         <Text className="txt-medium text-ui-fg-subtle mt-2">
-          Sign in for a better experience.
+          {t("signInBenefit")}
         </Text>
       </div>
       <div>
         <LocalizedClientLink href="/account">
           <Button variant="secondary" className="h-10" data-testid="sign-in-button">
-            Sign in
+            {t("signIn")}
           </Button>
         </LocalizedClientLink>
       </div>

--- a/src/modules/cart/templates/items.tsx
+++ b/src/modules/cart/templates/items.tsx
@@ -1,6 +1,7 @@
 import repeat from "@lib/util/repeat"
 import { HttpTypes } from "@medusajs/types"
 import { Heading, Table } from "@medusajs/ui"
+import { getTranslations } from "next-intl/server"
 
 import Item from "@modules/cart/components/item"
 import SkeletonLineItem from "@modules/skeletons/components/skeleton-line-item"
@@ -9,24 +10,25 @@ type ItemsTemplateProps = {
   cart?: HttpTypes.StoreCart
 }
 
-const ItemsTemplate = ({ cart }: ItemsTemplateProps) => {
+const ItemsTemplate = async ({ cart }: ItemsTemplateProps) => {
+  const t = await getTranslations("cart")
   const items = cart?.items
   return (
     <div>
       <div className="pb-3 flex items-center">
-        <Heading className="text-[2rem] leading-[2.75rem]">Cart</Heading>
+        <Heading className="text-[2rem] leading-[2.75rem]">{t("title")}</Heading>
       </div>
       <Table>
         <Table.Header className="border-t-0">
           <Table.Row className="text-ui-fg-subtle txt-medium-plus">
-            <Table.HeaderCell className="!pl-0">Item</Table.HeaderCell>
+            <Table.HeaderCell className="!pl-0">{t("item")}</Table.HeaderCell>
             <Table.HeaderCell></Table.HeaderCell>
-            <Table.HeaderCell>Quantity</Table.HeaderCell>
+            <Table.HeaderCell>{t("quantity")}</Table.HeaderCell>
             <Table.HeaderCell className="hidden small:table-cell">
-              Price
+              {t("price")}
             </Table.HeaderCell>
             <Table.HeaderCell className="!pr-0 text-right">
-              Total
+              {t("total")}
             </Table.HeaderCell>
           </Table.Row>
         </Table.Header>

--- a/src/modules/cart/templates/summary.tsx
+++ b/src/modules/cart/templates/summary.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { Button, Heading } from "@medusajs/ui"
+import { useTranslations } from "next-intl"
 
 import CartTotals from "@modules/common/components/cart-totals"
 import Divider from "@modules/common/components/divider"
@@ -25,12 +26,13 @@ function getCheckoutStep(cart: HttpTypes.StoreCart) {
 }
 
 const Summary = ({ cart }: SummaryProps) => {
+  const t = useTranslations("cart")
   const step = getCheckoutStep(cart)
 
   return (
     <div className="flex flex-col gap-y-4">
       <Heading level="h2" className="text-[2rem] leading-[2.75rem]">
-        Summary
+        {t("summary")}
       </Heading>
       <DiscountCode cart={cart} />
       <Divider />
@@ -39,7 +41,7 @@ const Summary = ({ cart }: SummaryProps) => {
         href={"/checkout?step=" + step}
         data-testid="checkout-button"
       >
-        <Button className="w-full h-10">Go to checkout</Button>
+        <Button className="w-full h-10">{t("checkout")}</Button>
       </LocalizedClientLink>
     </div>
   )


### PR DESCRIPTION
### Motivation
- Replace remaining hardcoded English strings in the cart and account UI with i18n lookups so the pages use the existing `messages/en.json` and `messages/zh.json` namespaces and support localization.

### Description
- Converted cart items, sign-in prompt, empty-cart message and account layout to use `next-intl` translations (server components use `getTranslations(...)`, client summary uses `useTranslations(...)`) and replaced hardcoded strings with the appropriate keys.
- Updated `messages/en.json` and `messages/zh.json` to add the missing keys under the `cart` and `account` namespaces (`price`, `summary`, `alreadyHaveAccount`, `signInBenefit`, `signIn`, `emptyMessage`, `exploreProducts`, `gotQuestions`, `gotQuestionsDescription`, `customerService`).
- Files updated: `src/modules/cart/templates/items.tsx`, `src/modules/cart/templates/summary.tsx`, `src/modules/cart/components/sign-in-prompt/index.tsx`, `src/modules/cart/components/empty-cart-message/index.tsx`, `src/modules/account/templates/account-layout.tsx`, `messages/en.json`, `messages/zh.json`.

### Testing
- Ran `node -e "JSON.parse(require('fs').readFileSync('messages/en.json','utf8'));JSON.parse(require('fs').readFileSync('messages/zh.json','utf8'));console.log('json ok')"` which succeeded to validate JSON.
- Ran `npx next build` which failed in this environment due to a missing required env var `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY` (environment issue, not a code error).
- Started the dev server with a dummy key and ran an automated Playwright script that visited `/en/account` and `/en/cart` and saved `account-i18n.png` and `cart-i18n.png` to verify the translated strings rendered (screenshots captured successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69acef6281cc8333a24fecb68c39a819)