### PR TITLE
feat: locale-aware SEO metadata for product, category, and store pages

### DIFF
--- a/src/app/[locale]/[countryCode]/(main)/categories/[...category]/page.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/categories/[...category]/page.tsx
@@ -10,7 +10,7 @@ import { SortOptions } from "@modules/store/components/refinement-list/sort-prod
 export const dynamic = "force-dynamic"
 export const revalidate = 300 // 5 minutes
 type Props = {
-  params: Promise<{ category: string[]; countryCode: string }>
+  params: Promise<{ category: string[]; countryCode: string; locale: string }>
   searchParams: Promise<{
     sortBy?: SortOptions
     page?: string
@@ -23,12 +23,22 @@ export async function generateStaticParams() {
 
 export async function generateMetadata(props: Props): Promise<Metadata> {
   const params = await props.params
+  const locale = params.locale || "en"
+
   try {
     const productCategory = await getCategoryByHandle(params.category)
 
-    const title = `${productCategory.name} | NordHjem`
+    const categoryName =
+      locale === "zh" && productCategory.metadata?.zh_name
+        ? String(productCategory.metadata.zh_name)
+        : productCategory.name
 
-    const description = productCategory.description ?? `${title} category.`
+    const title = `${categoryName} | NordHjem`
+
+    const description =
+      locale === "zh" && productCategory.metadata?.zh_description
+        ? String(productCategory.metadata.zh_description)
+        : productCategory.description ?? `${title} category.`
 
     return {
       title,

--- a/src/app/[locale]/[countryCode]/(main)/products/[handle]/page.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/products/[handle]/page.tsx
@@ -15,7 +15,7 @@ export const dynamic = "force-dynamic"
 export const revalidate = 300 // 5 minutes
 
 type Props = {
-  params: Promise<{ countryCode: string; handle: string }>
+  params: Promise<{ countryCode: string; handle: string; locale: string }>
   searchParams: Promise<{ v_id?: string }>
 }
 
@@ -43,6 +43,7 @@ function getImagesForVariant(
 export async function generateMetadata(props: Props): Promise<Metadata> {
   const params = await props.params
   const { handle } = params
+  const locale = params.locale || "en"
   const region = await getRegion(params.countryCode)
 
   if (!region) {
@@ -58,12 +59,21 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
     notFound()
   }
 
+  const title =
+    locale === "zh" && product.metadata?.zh_title
+      ? String(product.metadata.zh_title)
+      : product.title
+  const description =
+    locale === "zh" && product.metadata?.zh_description
+      ? String(product.metadata.zh_description)
+      : product.description || product.title
+
   return {
-    title: `${product.title} | NordHjem`,
-    description: `${product.title}`,
+    title: `${title} | NordHjem`,
+    description,
     openGraph: {
-      title: `${product.title} | NordHjem`,
-      description: `${product.title}`,
+      title: `${title} | NordHjem`,
+      description,
       images: product.thumbnail ? [product.thumbnail] : [],
     },
   }
@@ -71,6 +81,7 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
 
 export default async function ProductPage(props: Props) {
   const params = await props.params
+  const locale = params.locale || "en"
   const region = await getRegion(params.countryCode)
   const searchParams = await props.searchParams
 
@@ -92,17 +103,21 @@ export default async function ProductPage(props: Props) {
   }
 
   const productJsonLd = generateProductJsonLd(pricedProduct)
+  const title =
+    locale === "zh" && pricedProduct.metadata?.zh_title
+      ? String(pricedProduct.metadata.zh_title)
+      : pricedProduct.title
   const breadcrumbJsonLd = generateBreadcrumbJsonLd([
     {
-      name: "Home",
+      name: locale === "zh" ? "首页" : "Home",
       item: "https://nordhjem.store",
     },
     {
-      name: "Products",
+      name: locale === "zh" ? "所有商品" : "Products",
       item: "https://nordhjem.store/products",
     },
     {
-      name: pricedProduct.title,
+      name: title,
       item: `https://nordhjem.store/products/${pricedProduct.handle}`,
     },
   ])

--- a/src/app/[locale]/[countryCode]/(main)/store/page.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/store/page.tsx
@@ -1,12 +1,8 @@
 import { Metadata } from "next"
+import { getTranslations } from "next-intl/server"
 
 import { SortOptions } from "@modules/store/components/refinement-list/sort-products"
 import StoreTemplate from "@modules/store/templates"
-
-export const metadata: Metadata = {
-  title: "Store",
-  description: "Explore all of our products.",
-}
 
 type Params = {
   searchParams: Promise<{
@@ -15,12 +11,23 @@ type Params = {
   }>
   params: Promise<{
     countryCode: string
+    locale: string
   }>
 }
 
+export async function generateMetadata(props: Params): Promise<Metadata> {
+  const params = await props.params
+  const t = await getTranslations({ locale: params.locale, namespace: "store" })
+
+  return {
+    title: `${t("allProducts")} | NordHjem`,
+    description: t("allProducts"),
+  }
+}
+
 export default async function StorePage(props: Params) {
-  const params = await props.params;
-  const searchParams = await props.searchParams;
+  const params = await props.params
+  const searchParams = await props.searchParams
   const { sortBy, page } = searchParams
 
   return (


### PR DESCRIPTION
### Motivation
- Make page-level SEO (title/description and breadcrumb labels) locale-aware so Chinese visitors see zh metadata when available and English is used as a fallback.
- Product and category pages previously used only default names; the store page used a static metadata export that could not be localized.

### Description
- Product detail page `generateMetadata` now reads the URL `locale` param and prefers `product.metadata?.zh_title` / `zh_description` when `locale === "zh"`, otherwise falls back to `product.title` and `product.description`, and uses those values for `openGraph` as well (file: `src/app/[locale]/[countryCode]/(main)/products/[handle]/page.tsx`).
- Product breadcrumb JSON-LD labels (`Home`/`Products`) and the breadcrumb product name are localized using the same `locale`/`zh_*` metadata logic (file: same product page).
- Category page `generateMetadata` now reads `locale` and prefers `productCategory.metadata?.zh_name` / `zh_description` for title/description with English fallback (file: `src/app/[locale]/[countryCode]/(main)/categories/[...category]/page.tsx`).
- Store page switched from static `export const metadata` to a dynamic `generateMetadata` that loads translations via `next-intl` (`getTranslations({ locale, namespace: 'store' })`) to produce localized title/description (file: `src/app/[locale]/[countryCode]/(main)/store/page.tsx`).
- Route param typings for product, category and store pages were extended to include `locale` and optional chaining/fallbacks were added to handle missing `metadata` fields.

### Testing
- Attempted `npx next build` in the environment, but the build failed due to missing required environment variable `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY`, so a full production build could not be validated.
- No runtime or compilation errors were observed from the code edits themselves when inspected locally, and the updated pages were committed for review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69acf0ec9df483338cf86ad0f41d3ca2)