### PR TITLE
fix: remove V1 /100 scaling in money formatter

### DIFF
--- a/src/lib/util/money.ts
+++ b/src/lib/util/money.ts
@@ -25,6 +25,6 @@ export const convertToLocale = ({
         currency: currency_code,
         minimumFractionDigits,
         maximumFractionDigits,
-      }).format(amount / 100)
-    : (amount / 100).toFixed(2)
+      }).format(amount)
+    : amount.toFixed(2)
 }


### PR DESCRIPTION
### Motivation
- Medusa V2 stores prices in major units (e.g. 689 for $689.00) so the previous V1-era `/ 100` scaling in the frontend causes prices to be displayed 100× too small and must be removed.

### Description
- Updated `convertToLocale` in `src/lib/util/money.ts` to stop dividing `amount` by 100 so formatted currency uses `.format(amount)` and fallback uses `amount.toFixed(2)` while preserving the existing null/invalid guard returning `"—"`.

### Testing
- Ran `yarn tsc --noEmit`, which reported pre-existing TypeScript errors unrelated to this change and did not indicate new errors introduced by this change. 
- Searched the repository with `rg` for `/ 100` and related patterns and found no other `amount / 100` usages needing update. 
- Confirmed only `src/lib/util/money.ts` was modified by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69acf4c07b608333988ca728d4dd9e07)