### PR TITLE
fix: show "Select an option" instead of "Out of Stock" when no variant selected

### DIFF
--- a/src/modules/products/components/product-actions/index.tsx
+++ b/src/modules/products/components/product-actions/index.tsx
@@ -178,7 +178,7 @@ export default function ProductActions({
           isLoading={isAdding}
           data-testid="add-product-button"
         >
-          {!selectedVariant && !options
+          {!selectedVariant
             ? t("selectVariant")
             : !inStock || !isValidVariant
             ? t("outOfStock")


### PR DESCRIPTION
### Motivation
- Fix incorrect "Out of Stock" label on the add-to-cart button when no variant is selected because `options` is initialized as `{}` (truthy), which prevented the `selectVariant` branch from matching.

### Description
- Removed the redundant `&& !options` guard in `src/modules/products/components/product-actions/index.tsx` so the button now shows `t("selectVariant")` whenever `selectedVariant` is falsy.

### Testing
- Ran `yarn lint` (blocked by missing env var `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY`), started the app with `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY=dummy yarn dev`, captured a Playwright screenshot of `http://127.0.0.1:8000/en/us/products/coastal-sofa-white` which confirms the button shows the corrected `Select an option` label, and verified the source diff contains only the intended single-line change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69acfb4e848883339b6da9a9a062ff02)