### PR TITLE
feat: Crisp chat — sync medusa_customer_id, reset on logout, and Telegram webhook relay

### DIFF
--- a/src/app/api/crisp-webhook/route.ts
+++ b/src/app/api/crisp-webhook/route.ts
@@ -1,0 +1,121 @@
+import { NextRequest, NextResponse } from "next/server"
+
+const TELEGRAM_BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN
+const TELEGRAM_CHAT_ID = process.env.TELEGRAM_CHAT_ID
+const CRISP_WEBHOOK_SECRET = process.env.CRISP_WEBHOOK_SECRET
+
+export async function POST(req: NextRequest) {
+  // 1. Verify webhook secret (URL param ?key=xxx)
+  if (CRISP_WEBHOOK_SECRET) {
+    const key = req.nextUrl.searchParams.get("key")
+    if (key !== CRISP_WEBHOOK_SECRET) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+  }
+
+  // 2. Parse payload
+  let payload: CrispWebhookPayload
+  try {
+    payload = await req.json()
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 })
+  }
+
+  // 3. Only forward user-sent messages (not operator replies)
+  if (payload.event !== "message:send" || payload.data?.from !== "user") {
+    return NextResponse.json({ status: "ignored" })
+  }
+
+  // 4. Guard: Telegram config must exist
+  if (!TELEGRAM_BOT_TOKEN || !TELEGRAM_CHAT_ID) {
+    console.error("[crisp-webhook] Missing TELEGRAM_BOT_TOKEN or TELEGRAM_CHAT_ID")
+    return NextResponse.json({ status: "ok" })
+  }
+
+  // 5. Build Telegram message
+  const { content, type, user, session_id } = payload.data
+  const nickname = user?.nickname || "Anonymous"
+  const messageText = type === "text" ? content : `[${type}]`
+  const crispInboxUrl = `https://app.crisp.chat/website/${payload.website_id}/inbox/${session_id}/`
+
+  const telegramText = [
+    `🔔 <b>New Crisp Message</b>`,
+    `👤 ${escapeHtml(nickname)}`,
+    `💬 ${escapeHtml(messageText)}`,
+    `🔗 <a href="${crispInboxUrl}">Open in Crisp</a>`,
+  ].join("\n")
+
+  // 6. Send to Telegram with retry (1 retry on failure)
+  let success = false
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const res = await fetch(
+        `https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            chat_id: TELEGRAM_CHAT_ID,
+            text: telegramText,
+            parse_mode: "HTML",
+            disable_web_page_preview: true,
+          }),
+        }
+      )
+      if (res.ok) {
+        success = true
+        break
+      }
+      console.error(
+        `[crisp-webhook] Telegram API error (attempt ${attempt + 1}):`,
+        res.status,
+        await res.text()
+      )
+    } catch (err) {
+      console.error(
+        `[crisp-webhook] Telegram fetch error (attempt ${attempt + 1}):`,
+        err
+      )
+    }
+    // Wait 1s before retry
+    if (attempt === 0) {
+      await new Promise((r) => setTimeout(r, 1000))
+    }
+  }
+
+  if (!success) {
+    console.error("[crisp-webhook] Failed to send Telegram message after 2 attempts")
+  }
+
+  // Always return 200 to Crisp (avoid retry storm)
+  return NextResponse.json({ status: "ok" })
+}
+
+// --- Types ---
+
+interface CrispWebhookPayload {
+  website_id: string
+  event: string
+  data: {
+    session_id: string
+    type: string
+    content: string
+    from: string
+    origin: string
+    timestamp: number
+    user?: {
+      nickname?: string
+      user_id?: string
+    }
+  }
+  timestamp: number
+}
+
+// --- Helpers ---
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+}

--- a/src/modules/account/components/account-nav/index.tsx
+++ b/src/modules/account/components/account-nav/index.tsx
@@ -12,6 +12,7 @@ import Package from "@modules/common/icons/package"
 import LocalizedClientLink from "@modules/common/components/localized-client-link"
 import { HttpTypes } from "@medusajs/types"
 import { signout } from "@lib/data/customer"
+import { resetCrispSession } from "@modules/common/components/crisp-chat"
 
 const AccountNav = ({
   customer,
@@ -23,6 +24,7 @@ const AccountNav = ({
   const t = useTranslations("account")
 
   const handleLogout = async () => {
+    resetCrispSession()
     await signout(countryCode)
   }
 

--- a/src/modules/common/components/crisp-chat/index.tsx
+++ b/src/modules/common/components/crisp-chat/index.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect } from "react"
+import { useEffect, useRef } from "react"
 import { usePathname } from "next/navigation"
 
 declare global {
@@ -13,99 +13,124 @@ declare global {
   }
 }
 
-const ZH_WELCOME_MESSAGE = "你好！有任何关于北欧家具的问题，随时问我。"
-const EN_WELCOME_MESSAGE =
-  "Hi! Feel free to ask any questions about Nordic furniture."
-
-const isChineseLocale = (locale: string) => locale.toLowerCase().startsWith("zh")
-
-const detectLocale = (pathname: string) => {
-  const localeFromPath = pathname.split("/").filter(Boolean)[0]
-
-  if (localeFromPath) {
-    return localeFromPath
+/**
+ * Extract countryCode from URL pathname.
+ * Route structure: /[locale]/[countryCode]/...
+ * Examples:
+ *   /en/us/products → "en"  (locale segment, used for Crisp locale)
+ *   /zh/cn/products → "zh"
+ *   /en/us          → "en"
+ * We use the FIRST segment (locale) for Crisp language.
+ */
+const detectLocale = (pathname: string): string => {
+  const segments = pathname.split("/").filter(Boolean)
+  // segments[0] = locale (en | zh), segments[1] = countryCode (us | cn)
+  if (segments[0]) {
+    return segments[0]
   }
-
   if (typeof navigator !== "undefined" && navigator.language) {
-    return navigator.language
+    return navigator.language.startsWith("zh") ? "zh" : "en"
   }
-
   return "en"
 }
 
 const CrispChat = () => {
   const pathname = usePathname()
+  const scriptLoadedRef = useRef(false)
 
   useEffect(() => {
     const websiteId = process.env.NEXT_PUBLIC_CRISP_WEBSITE_ID
     if (!websiteId) return
 
     const locale = detectLocale(pathname)
-    const welcomeMessage = isChineseLocale(locale)
-      ? ZH_WELCOME_MESSAGE
-      : EN_WELCOME_MESSAGE
 
+    // Initialize Crisp globals
     window.$crisp = window.$crisp || []
     window.CRISP_WEBSITE_ID = websiteId
     window.CRISP_RUNTIME_CONFIG = {
-      locale,
+      locale: locale.startsWith("zh") ? "zh" : "en",
     }
 
+    // Set session data: locale
     window.$crisp.push(["set", "session:data", [[["locale", locale]]]])
-    window.$crisp.push([
-      "set",
-      "session:data",
-      [[["welcome_message", welcomeMessage]]],
-    ])
 
-    const script = document.createElement("script")
-    script.src = "https://client.crisp.chat/l.js"
-    script.async = true
-
-    const syncCustomerData = async () => {
-      try {
-        const response = await fetch("/store/customers/me", {
-          credentials: "include",
-        })
-
-        if (!response.ok) return
-
-        const data = (await response.json()) as {
-          customer?: {
-            email?: string
-            first_name?: string
-            last_name?: string
-          }
-        }
-
-        const customer = data.customer
-        if (!customer) return
-
-        const nickname = [customer.first_name, customer.last_name]
-          .filter(Boolean)
-          .join(" ")
-
-        if (customer.email) {
-          window.$crisp.push(["set", "user:email", [customer.email]])
-        }
-
-        if (nickname) {
-          window.$crisp.push(["set", "user:nickname", [nickname]])
-        }
-      } catch {
-        // Ignore customer sync errors and allow Crisp to load normally.
-      }
+    // Load script only once
+    if (!scriptLoadedRef.current) {
+      const script = document.createElement("script")
+      script.src = "https://client.crisp.chat/l.js"
+      script.async = true
+      document.head.appendChild(script)
+      scriptLoadedRef.current = true
     }
 
-    document.head.appendChild(script)
-    syncCustomerData()
-
-    return () => {
-      script.remove()
-    }
+    // Sync customer identity
+    syncCustomerIdentity()
   }, [pathname])
 
   return null
+}
+
+/**
+ * Fetch current logged-in customer and sync identity to Crisp.
+ * If not logged in (401), do nothing — anonymous session remains.
+ */
+async function syncCustomerIdentity() {
+  try {
+    const response = await fetch("/store/customers/me", {
+      credentials: "include",
+    })
+
+    if (!response.ok) return
+
+    const data = (await response.json()) as {
+      customer?: {
+        id?: string
+        email?: string
+        first_name?: string
+        last_name?: string
+      }
+    }
+
+    const customer = data.customer
+    if (!customer) return
+
+    const nickname = [customer.first_name, customer.last_name]
+      .filter(Boolean)
+      .join(" ")
+
+    if (customer.email) {
+      window.$crisp.push(["set", "user:email", [customer.email]])
+    }
+
+    if (nickname) {
+      window.$crisp.push(["set", "user:nickname", [nickname]])
+    }
+
+    // Sync medusa_customer_id to session data
+    if (customer.id) {
+      window.$crisp.push([
+        "set",
+        "session:data",
+        [[["medusa_customer_id", customer.id]]],
+      ])
+    }
+  } catch {
+    // Ignore errors — Crisp works fine for anonymous users
+  }
+}
+
+/**
+ * Reset Crisp session. Call this BEFORE server-side signout.
+ * Exported so account-nav can call it on logout.
+ */
+export function resetCrispSession() {
+  try {
+    if (typeof window !== "undefined" && window.$crisp) {
+      window.$crisp.push(["do", "session:reset"])
+    }
+  } catch {
+    // Ignore — best effort
+  }
 }
 
 export default CrispChat


### PR DESCRIPTION
### Motivation
- Ensure Crisp sessions include the Medusa customer id and keep UI language in sync with the storefront URL locale segment so support agents see accurate user context. 
- Make sure Crisp client session is reset on user logout before the server-side `signout` runs to avoid leaking identity into the next session. 
- Relay incoming Crisp `message:send` events to a Telegram chat to notify staff of new user messages.

### Description
- Rewrote the Crisp client component at `src/modules/common/components/crisp-chat/index.tsx` to detect locale from the first URL segment (`/[locale]/[countryCode]`), set `CRISP_RUNTIME_CONFIG` accordingly, push `locale` to session data, load the Crisp script only once across pathname changes, sync `email`, `user:nickname`, and `medusa_customer_id` into Crisp session data, and export `resetCrispSession()` for client-side logout cleanup. 
- Updated logout flow in `src/modules/account/components/account-nav/index.tsx` to import `resetCrispSession` and call it before calling `signout(countryCode)`. 
- Added a new API route `src/app/api/crisp-webhook/route.ts` implementing `POST /api/crisp-webhook` which optionally verifies a `?key=` secret, ignores non-`message:send` or non-user-origin events, builds an HTML-escaped Telegram message (includes nickname, message/content, and Crisp inbox link), retries once on Telegram API failure, logs failures, and returns 200 to Crisp to avoid retry storms. 

### Testing
- Ran type check `npx tsc --noEmit` which failed due to pre-existing unrelated TypeScript errors elsewhere in the repository (typecheck did not pass globally). 
- Ran ESLint for the changed files with `npx eslint src/modules/common/components/crisp-chat/index.tsx src/app/api/crisp-webhook/route.ts src/modules/account/components/account-nav/index.tsx` which failed due to a runtime configuration issue in the `@next/next/no-html-link-for-pages` rule (environmental/plugin issue, unrelated to the logical changes). 
- Attempted to start the dev server with `yarn dev` but it cannot run in this environment because required environment variables (e.g. `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY`) are not set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ad00752d1c8333a57a8a3bdff3d1be)