### PR TITLE
feat: implement storefront return request flow (EN/ZH)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -328,7 +328,10 @@
       "refunded": "Refunded",
       "pending": "Pending payment",
       "pendingConfirmation": "Pending confirmation"
-    }
+    },
+    "requestReturn": "Request Return",
+    "requestReturnDescription": "Return items from this order",
+    "startReturn": "Start Return"
   },
   "account": {
     "title": "My Account",
@@ -546,5 +549,35 @@
         }
       }
     }
+  },
+  "returns": {
+    "title": "Request Return",
+    "backToOrder": "Back to order",
+    "backToOrders": "Back to orders",
+    "orderLabel": "Order",
+    "selectItemsTitle": "Select items to return",
+    "selectItemsDescription": "Choose the items you would like to return and the quantity for each.",
+    "maxQuantity": "Max",
+    "continue": "Continue",
+    "back": "Back",
+    "selectReasonTitle": "Return reason",
+    "selectReason": "Select a reason...",
+    "noReasonsConfigured": "No return reasons configured",
+    "notePlaceholder": "Additional notes (optional)",
+    "selectShippingTitle": "Return shipping method",
+    "noShippingOptions": "No return shipping options available. Please contact support.",
+    "freeShipping": "Free",
+    "confirmTitle": "Review and submit",
+    "returnItems": "Items to return",
+    "reason": "Reason",
+    "note": "Note",
+    "returnShipping": "Return shipping",
+    "submitReturn": "Submit return request",
+    "submitError": "Failed to submit return request",
+    "successTitle": "Return request submitted",
+    "successDescription": "Your return request has been received. We will review it and get back to you shortly.",
+    "errorTitle": "Something went wrong",
+    "tryAgain": "Try again",
+    "noReturnableItems": "There are no items eligible for return in this order."
   }
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -328,7 +328,10 @@
       "refunded": "已退款",
       "pending": "待支付",
       "pendingConfirmation": "待确认"
-    }
+    },
+    "requestReturn": "申请退货",
+    "requestReturnDescription": "退回此订单中的商品",
+    "startReturn": "开始退货"
   },
   "account": {
     "title": "我的账户",
@@ -546,5 +549,35 @@
         }
       }
     }
+  },
+  "returns": {
+    "title": "申请退货",
+    "backToOrder": "返回订单",
+    "backToOrders": "返回订单列表",
+    "orderLabel": "订单",
+    "selectItemsTitle": "选择退货商品",
+    "selectItemsDescription": "选择您要退回的商品及数量。",
+    "maxQuantity": "最多",
+    "continue": "下一步",
+    "back": "上一步",
+    "selectReasonTitle": "退货原因",
+    "selectReason": "请选择原因...",
+    "noReasonsConfigured": "暂未配置退货原因",
+    "notePlaceholder": "补充说明（可选）",
+    "selectShippingTitle": "退货运费方式",
+    "noShippingOptions": "暂无退货运费选项，请联系客服。",
+    "freeShipping": "免费",
+    "confirmTitle": "确认并提交",
+    "returnItems": "退货商品",
+    "reason": "原因",
+    "note": "备注",
+    "returnShipping": "退货运费",
+    "submitReturn": "提交退货申请",
+    "submitError": "提交退货申请失败",
+    "successTitle": "退货申请已提交",
+    "successDescription": "我们已收到您的退货申请，将尽快审核并与您联系。",
+    "errorTitle": "出错了",
+    "tryAgain": "重试",
+    "noReturnableItems": "此订单中没有可退货的商品。"
   }
 }

--- a/src/app/[locale]/[countryCode]/(main)/account/@dashboard/orders/return/[id]/page.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/account/@dashboard/orders/return/[id]/page.tsx
@@ -1,0 +1,58 @@
+import { retrieveOrder } from "@lib/data/orders"
+import { listReturnReasons, listReturnShippingOptions } from "@lib/data/returns"
+import ReturnRequestTemplate from "@modules/order/templates/return-request-template"
+import { HttpTypes } from "@medusajs/types"
+import { Metadata } from "next"
+import { notFound } from "next/navigation"
+
+type Props = {
+  params: Promise<{ id: string }>
+}
+
+type StoreOrderWithCart = HttpTypes.StoreOrder & {
+  cart?: { id?: string }
+  cart_id?: string
+}
+
+export async function generateMetadata(props: Props): Promise<Metadata> {
+  const params = await props.params
+  const order = await retrieveOrder(params.id).catch(() => null)
+
+  if (!order) {
+    notFound()
+  }
+
+  return {
+    title: `Request Return — Order #${order.display_id}`,
+    description: "Request a return for your order items",
+  }
+}
+
+export default async function ReturnRequestPage(props: Props) {
+  const params = await props.params
+  const order = await retrieveOrder(params.id).catch(() => null)
+
+  if (!order) {
+    notFound()
+  }
+
+  const returnReasons = await listReturnReasons()
+
+  const orderWithCart = order as StoreOrderWithCart
+  const cartId = orderWithCart.cart?.id || orderWithCart.cart_id
+  let returnShippingOptions: Awaited<
+    ReturnType<typeof listReturnShippingOptions>
+  > = []
+
+  if (cartId) {
+    returnShippingOptions = await listReturnShippingOptions(cartId)
+  }
+
+  return (
+    <ReturnRequestTemplate
+      order={order}
+      returnReasons={returnReasons}
+      returnShippingOptions={returnShippingOptions}
+    />
+  )
+}

--- a/src/lib/data/orders.ts
+++ b/src/lib/data/orders.ts
@@ -19,7 +19,7 @@ export const retrieveOrder = async (id: string) => {
       method: "GET",
       query: {
         fields:
-          "*payment_collections.payments,*items,*items.metadata,*items.variant,*items.product",
+          "*payment_collections.payments,*items,*items.metadata,*items.variant,*items.product,+items.detail,+cart.id",
       },
       headers,
       next,

--- a/src/lib/data/returns.ts
+++ b/src/lib/data/returns.ts
@@ -1,0 +1,117 @@
+"use server"
+
+import { sdk } from "@lib/config"
+import { getAuthHeaders, getCacheOptions } from "./cookies"
+
+export interface ReturnReason {
+  id: string
+  value: string
+  label: string
+  description?: string
+  created_at: string
+  updated_at: string
+}
+
+export interface ReturnShippingOption {
+  id: string
+  name: string
+  amount: number
+  price_type: string
+  provider_id: string
+}
+
+export interface CreateReturnItem {
+  id: string
+  quantity: number
+  reason_id?: string
+  note?: string
+}
+
+export interface CreateReturnPayload {
+  order_id: string
+  items: CreateReturnItem[]
+  return_shipping: {
+    option_id: string
+  }
+  location_id?: string
+  note?: string
+}
+
+export async function listReturnReasons(): Promise<ReturnReason[]> {
+  const headers = {
+    ...(await getAuthHeaders()),
+  }
+
+  const next = {
+    ...(await getCacheOptions("returns")),
+  }
+
+  try {
+    const response = await sdk.client.fetch<{
+      return_reasons: ReturnReason[]
+    }>("/store/return-reasons", {
+      method: "GET",
+      headers,
+      next,
+      cache: "force-cache",
+    })
+
+    return response.return_reasons
+  } catch {
+    return []
+  }
+}
+
+export async function listReturnShippingOptions(
+  cartId: string
+): Promise<ReturnShippingOption[]> {
+  const headers = {
+    ...(await getAuthHeaders()),
+  }
+
+  const next = {
+    ...(await getCacheOptions("fulfillment")),
+  }
+
+  try {
+    const response = await sdk.client.fetch<{
+      shipping_options: ReturnShippingOption[]
+    }>("/store/shipping-options", {
+      method: "GET",
+      query: {
+        cart_id: cartId,
+        is_return: true,
+      },
+      headers,
+      next,
+      cache: "force-cache",
+    })
+
+    return response.shipping_options
+  } catch {
+    return []
+  }
+}
+
+export async function createReturnRequest(
+  payload: CreateReturnPayload
+): Promise<{ success: boolean; error: string | null }> {
+  const headers = {
+    ...(await getAuthHeaders()),
+  }
+
+  try {
+    await sdk.client.fetch("/store/returns", {
+      method: "POST",
+      body: payload,
+      headers,
+    })
+
+    return { success: true, error: null }
+  } catch (err: any) {
+    return {
+      success: false,
+      error: err?.message || "Failed to create return request",
+    }
+  }
+}

--- a/src/lib/util/returns.ts
+++ b/src/lib/util/returns.ts
@@ -1,0 +1,57 @@
+import { HttpTypes } from "@medusajs/types"
+
+type ReturnDetail = {
+  fulfilled_quantity?: number
+  delivered_quantity?: number
+  shipped_quantity?: number
+  return_requested_quantity?: number
+  return_received_quantity?: number
+  return_dismissed_quantity?: number
+  written_off_quantity?: number
+}
+
+export function getReturnableQuantity(item: HttpTypes.StoreOrderLineItem): number {
+  const detail = item.detail as ReturnDetail | undefined
+
+  if (!detail) {
+    return 0
+  }
+
+  const delivered =
+    detail.delivered_quantity ??
+    detail.shipped_quantity ??
+    detail.fulfilled_quantity ??
+    0
+  const alreadyRequested = detail.return_requested_quantity ?? 0
+  const alreadyReceived = detail.return_received_quantity ?? 0
+  const writtenOff = detail.written_off_quantity ?? 0
+
+  return Math.max(0, delivered - alreadyRequested - alreadyReceived - writtenOff)
+}
+
+export function hasReturnableItems(order: HttpTypes.StoreOrder): boolean {
+  if (!order.items || order.items.length === 0) {
+    return false
+  }
+
+  return order.items.some((item) => getReturnableQuantity(item) > 0)
+}
+
+export function getItemsWithReturnInfo(
+  items: HttpTypes.StoreOrderLineItem[]
+): Array<
+  HttpTypes.StoreOrderLineItem & {
+    returnable_quantity: number
+    is_returnable: boolean
+  }
+> {
+  return items.map((item) => {
+    const returnableQty = getReturnableQuantity(item)
+
+    return {
+      ...item,
+      returnable_quantity: returnableQty,
+      is_returnable: returnableQty > 0,
+    }
+  })
+}

--- a/src/modules/order/templates/order-details-template.tsx
+++ b/src/modules/order/templates/order-details-template.tsx
@@ -2,9 +2,10 @@
 
 import { XMark } from "@medusajs/icons"
 import { HttpTypes } from "@medusajs/types"
-import { Badge, Text } from "@medusajs/ui"
+import { Badge, Button, Text } from "@medusajs/ui"
 import LocalizedClientLink from "@modules/common/components/localized-client-link"
 import Help from "@modules/order/components/help"
+import { hasReturnableItems } from "@lib/util/returns"
 import Items from "@modules/order/components/items"
 import OrderDetails from "@modules/order/components/order-details"
 import OrderSummary from "@modules/order/components/order-summary"
@@ -144,6 +145,27 @@ const OrderDetailsTemplate: React.FC<OrderDetailsTemplateProps> = ({
         <Items order={order} />
         <ShippingDetails order={order} />
         <OrderSummary order={order} />
+        {hasReturnableItems(order) && (
+          <div className="rounded-lg border border-ui-border-base p-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <Text className="txt-medium-plus">
+                  {t.has("requestReturn") ? t("requestReturn") : "Request Return"}
+                </Text>
+                <Text className="text-sm text-ui-fg-subtle">
+                  {t.has("requestReturnDescription")
+                    ? t("requestReturnDescription")
+                    : "Return items from this order"}
+                </Text>
+              </div>
+              <LocalizedClientLink href={`/account/orders/return/${order.id}`}>
+                <Button variant="secondary" size="base">
+                  {t.has("startReturn") ? t("startReturn") : "Start Return"}
+                </Button>
+              </LocalizedClientLink>
+            </div>
+          </div>
+        )}
         <Help />
       </div>
     </div>

--- a/src/modules/order/templates/return-request-template.tsx
+++ b/src/modules/order/templates/return-request-template.tsx
@@ -1,0 +1,431 @@
+"use client"
+
+import {
+  createReturnRequest,
+  type ReturnReason,
+  type ReturnShippingOption,
+} from "@lib/data/returns"
+import { getItemsWithReturnInfo } from "@lib/util/returns"
+import { convertToLocale } from "@lib/util/money"
+import { ArrowLeftMini } from "@medusajs/icons"
+import { HttpTypes } from "@medusajs/types"
+import { Button, Text } from "@medusajs/ui"
+import LocalizedClientLink from "@modules/common/components/localized-client-link"
+import { useTranslations } from "next-intl"
+import { useState } from "react"
+
+type Props = {
+  order: HttpTypes.StoreOrder
+  returnReasons: ReturnReason[]
+  returnShippingOptions: ReturnShippingOption[]
+}
+
+interface SelectedItem {
+  id: string
+  quantity: number
+  reason_id: string
+  note: string
+}
+
+type Step =
+  | "select-items"
+  | "select-reason"
+  | "select-shipping"
+  | "confirm"
+  | "success"
+  | "error"
+
+const steps: Step[] = ["select-items", "select-reason", "select-shipping", "confirm"]
+
+const ReturnRequestTemplate = ({
+  order,
+  returnReasons,
+  returnShippingOptions,
+}: Props) => {
+  const t = useTranslations("returns")
+  const [step, setStep] = useState<Step>("select-items")
+  const [selectedItems, setSelectedItems] = useState<SelectedItem[]>([])
+  const [selectedShippingOptionId, setSelectedShippingOptionId] = useState("")
+  const [submitting, setSubmitting] = useState(false)
+  const [errorMessage, setErrorMessage] = useState("")
+
+  const itemsWithInfo = getItemsWithReturnInfo(order.items || [])
+  const returnableItems = itemsWithInfo.filter((i) => i.is_returnable)
+
+  const toggleItem = (itemId: string) => {
+    setSelectedItems((prev) => {
+      const exists = prev.find((s) => s.id === itemId)
+
+      if (exists) {
+        return prev.filter((s) => s.id !== itemId)
+      }
+
+      return [...prev, { id: itemId, quantity: 1, reason_id: "", note: "" }]
+    })
+  }
+
+  const updateItemQuantity = (itemId: string, quantity: number) => {
+    setSelectedItems((prev) =>
+      prev.map((s) => (s.id === itemId ? { ...s, quantity } : s))
+    )
+  }
+
+  const updateItemReason = (itemId: string, reason_id: string) => {
+    setSelectedItems((prev) =>
+      prev.map((s) => (s.id === itemId ? { ...s, reason_id } : s))
+    )
+  }
+
+  const updateItemNote = (itemId: string, note: string) => {
+    setSelectedItems((prev) =>
+      prev.map((s) => (s.id === itemId ? { ...s, note } : s))
+    )
+  }
+
+  const handleSubmit = async () => {
+    setSubmitting(true)
+    setErrorMessage("")
+
+    const result = await createReturnRequest({
+      order_id: order.id,
+      items: selectedItems.map((s) => ({
+        id: s.id,
+        quantity: s.quantity,
+        ...(s.reason_id ? { reason_id: s.reason_id } : {}),
+        ...(s.note ? { note: s.note } : {}),
+      })),
+      return_shipping: {
+        option_id: selectedShippingOptionId,
+      },
+    })
+
+    setSubmitting(false)
+
+    if (result.success) {
+      setStep("success")
+      return
+    }
+
+    setErrorMessage(result.error || t("submitError"))
+    setStep("error")
+  }
+
+  if (returnableItems.length === 0) {
+    return (
+      <div className="flex flex-col gap-y-4">
+        <LocalizedClientLink
+          href={`/account/orders/details/${order.id}`}
+          className="flex items-center gap-x-1 text-sm text-ui-fg-subtle hover:text-ui-fg-base"
+        >
+          <ArrowLeftMini /> {t("backToOrder")}
+        </LocalizedClientLink>
+        <div className="rounded-lg border border-ui-border-base p-6 text-center">
+          <Text className="text-ui-fg-muted">{t("noReturnableItems")}</Text>
+        </div>
+      </div>
+    )
+  }
+
+  if (step === "success") {
+    return (
+      <div className="flex flex-col gap-y-4">
+        <div className="rounded-lg border border-ui-border-base p-6 text-center">
+          <Text className="mb-2 txt-xlarge">✓</Text>
+          <Text className="mb-2 txt-medium-plus">{t("successTitle")}</Text>
+          <Text className="mb-4 text-ui-fg-subtle">{t("successDescription")}</Text>
+          <LocalizedClientLink href="/account/orders">
+            <Button variant="secondary">{t("backToOrders")}</Button>
+          </LocalizedClientLink>
+        </div>
+      </div>
+    )
+  }
+
+  if (step === "error") {
+    return (
+      <div className="flex flex-col gap-y-4">
+        <div className="rounded-lg border border-ui-border-base p-6 text-center">
+          <Text className="mb-2 txt-medium-plus text-ui-fg-error">
+            {t("errorTitle")}
+          </Text>
+          <Text className="mb-4 text-ui-fg-subtle">{errorMessage}</Text>
+          <Button variant="secondary" onClick={() => setStep("select-items")}>
+            {t("tryAgain")}
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl-semi">{t("title")}</h1>
+        <LocalizedClientLink
+          href={`/account/orders/details/${order.id}`}
+          className="flex items-center gap-x-1 text-sm text-ui-fg-subtle hover:text-ui-fg-base"
+        >
+          <ArrowLeftMini /> {t("backToOrder")}
+        </LocalizedClientLink>
+      </div>
+
+      <Text className="text-ui-fg-subtle">
+        {t("orderLabel")} #{order.display_id}
+      </Text>
+
+      <div className="mb-2 flex gap-2">
+        {steps.map((s, idx) => (
+          <div
+            key={s}
+            className={`h-1 flex-1 rounded-full ${
+              idx <= steps.indexOf(step) ? "bg-ui-fg-interactive" : "bg-ui-border-base"
+            }`}
+          />
+        ))}
+      </div>
+
+      {step === "select-items" && (
+        <div className="flex flex-col gap-y-3">
+          <Text className="txt-medium-plus">{t("selectItemsTitle")}</Text>
+          <Text className="text-sm text-ui-fg-subtle">{t("selectItemsDescription")}</Text>
+
+          {returnableItems.map((item) => {
+            const selected = selectedItems.find((s) => s.id === item.id)
+
+            return (
+              <div
+                key={item.id}
+                className={`cursor-pointer rounded-lg border p-4 transition-colors ${
+                  selected
+                    ? "border-ui-fg-interactive bg-ui-bg-interactive"
+                    : "border-ui-border-base hover:border-ui-border-strong"
+                }`}
+                onClick={() => toggleItem(item.id)}
+              >
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-x-3">
+                    {item.thumbnail && (
+                      <img
+                        src={item.thumbnail}
+                        alt={item.title}
+                        className="h-12 w-12 rounded object-cover"
+                      />
+                    )}
+                    <div>
+                      <Text className="txt-compact-medium">{item.product_title}</Text>
+                      <Text className="text-sm text-ui-fg-subtle">
+                        {item.variant_title}
+                      </Text>
+                    </div>
+                  </div>
+                  <div className="text-right">
+                    <Text className="text-sm text-ui-fg-subtle">
+                      {t("maxQuantity")}: {item.returnable_quantity}
+                    </Text>
+                    {selected && (
+                      <select
+                        value={selected.quantity}
+                        onClick={(e) => e.stopPropagation()}
+                        onChange={(e) =>
+                          updateItemQuantity(item.id, Number.parseInt(e.target.value, 10))
+                        }
+                        className="mt-1 rounded border border-ui-border-base px-2 py-1 text-sm"
+                      >
+                        {Array.from(
+                          { length: item.returnable_quantity },
+                          (_, i) => i + 1
+                        ).map((n) => (
+                          <option key={n} value={n}>
+                            {n}
+                          </option>
+                        ))}
+                      </select>
+                    )}
+                  </div>
+                </div>
+              </div>
+            )
+          })}
+
+          <Button
+            onClick={() => setStep("select-reason")}
+            disabled={selectedItems.length === 0}
+            className="mt-2"
+          >
+            {t("continue")}
+          </Button>
+        </div>
+      )}
+
+      {step === "select-reason" && (
+        <div className="flex flex-col gap-y-3">
+          <Text className="txt-medium-plus">{t("selectReasonTitle")}</Text>
+
+          {selectedItems.map((sel) => {
+            const item = itemsWithInfo.find((i) => i.id === sel.id)
+
+            if (!item) {
+              return null
+            }
+
+            return (
+              <div key={sel.id} className="rounded-lg border border-ui-border-base p-4">
+                <Text className="mb-2 txt-compact-medium">
+                  {item.product_title} — {item.variant_title} × {sel.quantity}
+                </Text>
+
+                {returnReasons.length > 0 ? (
+                  <select
+                    value={sel.reason_id}
+                    onChange={(e) => updateItemReason(sel.id, e.target.value)}
+                    className="mb-2 w-full rounded border border-ui-border-base px-3 py-2 text-sm"
+                  >
+                    <option value="">{t("selectReason")}</option>
+                    {returnReasons.map((reason) => (
+                      <option key={reason.id} value={reason.id}>
+                        {reason.label || reason.value}
+                      </option>
+                    ))}
+                  </select>
+                ) : (
+                  <Text className="mb-2 text-sm text-ui-fg-muted">
+                    {t("noReasonsConfigured")}
+                  </Text>
+                )}
+
+                <textarea
+                  placeholder={t("notePlaceholder")}
+                  value={sel.note}
+                  onChange={(e) => updateItemNote(sel.id, e.target.value)}
+                  className="w-full rounded border border-ui-border-base px-3 py-2 text-sm"
+                  rows={2}
+                />
+              </div>
+            )
+          })}
+
+          <div className="mt-2 flex gap-2">
+            <Button variant="secondary" onClick={() => setStep("select-items")}>
+              {t("back")}
+            </Button>
+            <Button onClick={() => setStep("select-shipping")}>{t("continue")}</Button>
+          </div>
+        </div>
+      )}
+
+      {step === "select-shipping" && (
+        <div className="flex flex-col gap-y-3">
+          <Text className="txt-medium-plus">{t("selectShippingTitle")}</Text>
+
+          {returnShippingOptions.length > 0 ? (
+            returnShippingOptions.map((option) => (
+              <div
+                key={option.id}
+                className={`cursor-pointer rounded-lg border p-4 transition-colors ${
+                  selectedShippingOptionId === option.id
+                    ? "border-ui-fg-interactive bg-ui-bg-interactive"
+                    : "border-ui-border-base hover:border-ui-border-strong"
+                }`}
+                onClick={() => setSelectedShippingOptionId(option.id)}
+              >
+                <div className="flex items-center justify-between">
+                  <Text className="txt-compact-medium">{option.name}</Text>
+                  <Text>
+                    {option.amount === 0
+                      ? t("freeShipping")
+                      : convertToLocale({
+                          amount: option.amount,
+                          currency_code: order.currency_code,
+                        })}
+                  </Text>
+                </div>
+              </div>
+            ))
+          ) : (
+            <div className="rounded-lg border border-ui-border-base p-4">
+              <Text className="text-sm text-ui-fg-muted">{t("noShippingOptions")}</Text>
+            </div>
+          )}
+
+          <div className="mt-2 flex gap-2">
+            <Button variant="secondary" onClick={() => setStep("select-reason")}>
+              {t("back")}
+            </Button>
+            <Button
+              onClick={() => setStep("confirm")}
+              disabled={returnShippingOptions.length > 0 && !selectedShippingOptionId}
+            >
+              {t("continue")}
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {step === "confirm" && (
+        <div className="flex flex-col gap-y-3">
+          <Text className="txt-medium-plus">{t("confirmTitle")}</Text>
+
+          <div className="rounded-lg border border-ui-border-base p-4">
+            <Text className="mb-2 txt-compact-medium">{t("returnItems")}</Text>
+            {selectedItems.map((sel) => {
+              const item = itemsWithInfo.find((i) => i.id === sel.id)
+
+              if (!item) {
+                return null
+              }
+
+              const reason = returnReasons.find((r) => r.id === sel.reason_id)
+
+              return (
+                <div
+                  key={sel.id}
+                  className="flex justify-between border-b border-ui-border-base py-2 last:border-0"
+                >
+                  <div>
+                    <Text className="text-sm">{item.product_title}</Text>
+                    <Text className="text-xs text-ui-fg-subtle">
+                      {item.variant_title} × {sel.quantity}
+                    </Text>
+                    {reason && (
+                      <Text className="text-xs text-ui-fg-subtle">
+                        {t("reason")}: {reason.label || reason.value}
+                      </Text>
+                    )}
+                    {sel.note && (
+                      <Text className="text-xs text-ui-fg-subtle">
+                        {t("note")}: {sel.note}
+                      </Text>
+                    )}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+
+          {selectedShippingOptionId && (
+            <div className="rounded-lg border border-ui-border-base p-4">
+              <Text className="txt-compact-medium">{t("returnShipping")}</Text>
+              <Text className="text-sm text-ui-fg-subtle">
+                {
+                  returnShippingOptions.find((o) => o.id === selectedShippingOptionId)
+                    ?.name
+                }
+              </Text>
+            </div>
+          )}
+
+          <div className="mt-2 flex gap-2">
+            <Button variant="secondary" onClick={() => setStep("select-shipping")}>
+              {t("back")}
+            </Button>
+            <Button onClick={handleSubmit} isLoading={submitting}>
+              {t("submitReturn")}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default ReturnRequestTemplate


### PR DESCRIPTION
### Motivation
- Provide a complete customer-facing return request flow so users can request returns from an order detail page through confirmation and submission. 
- Integrate with Medusa Store API endpoints for return reasons, return shipping options, and creating return requests. 
- Make the UI bilingual (English/Chinese) using `next-intl` and surface return eligibility based on order line item detail fields.

### Description
- Add server data functions in `src/lib/data/returns.ts` implementing `listReturnReasons`, `listReturnShippingOptions`, and `createReturnRequest`. 
- Add return helpers in `src/lib/util/returns.ts` providing `getReturnableQuantity`, `hasReturnableItems`, and `getItemsWithReturnInfo`. 
- Extend `retrieveOrder` in `src/lib/data/orders.ts` to include `+items.detail,+cart.id` so returnability checks and return-shipping lookup work. 
- Add a new return request route and server page at `src/app/[locale]/[countryCode]/(main)/account/@dashboard/orders/return/[id]/page.tsx` and a multi-step client template `src/modules/order/templates/return-request-template.tsx`, and add a conditional CTA in `src/modules/order/templates/order-details-template.tsx`. 
- Add translations for the return flow to `messages/en.json` and `messages/zh.json` under the `returns` namespace and add order-level CTA keys.

### Testing
- Ran TypeScript compile check with `npx tsc --noEmit`, which failed due to pre-existing repository TypeScript errors unrelated to the added files. 
- Ran lint via `next lint` (with `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY=dummy`) which reported an existing ESLint/Next plugin configuration issue (`@next/next/no-html-link-for-pages`), not introduced by these changes. 
- Verified i18n key parity with a script that confirmed `messages/en.json` and `messages/zh.json` `returns` keys match. 
- Started the dev server (`NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY=dummy npm run dev`) and captured a Playwright screenshot of the storefront orders route to validate the UI scaffolding for the flow (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ad03b186c08333a9780116384340d0)