### PR TITLE
feat(order): show return status in order details

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -578,6 +578,18 @@
     "successDescription": "Your return request has been received. We will review it and get back to you shortly.",
     "errorTitle": "Something went wrong",
     "tryAgain": "Try again",
-    "noReturnableItems": "There are no items eligible for return in this order."
+    "noReturnableItems": "There are no items eligible for return in this order.",
+    "statusTitle": "Return Requests",
+    "returnLabel": "Return",
+    "submittedOn": "Submitted on",
+    "itemQuantity": "Qty",
+    "received": "Received",
+    "refundAmount": "Refund amount",
+    "status": {
+      "requested": "Requested",
+      "received": "Received",
+      "canceled": "Canceled",
+      "partially_received": "Partially Received"
+    }
   }
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -578,6 +578,18 @@
     "successDescription": "我们已收到您的退货申请，将尽快审核并与您联系。",
     "errorTitle": "出错了",
     "tryAgain": "重试",
-    "noReturnableItems": "此订单中没有可退货的商品。"
+    "noReturnableItems": "此订单中没有可退货的商品。",
+    "statusTitle": "退货记录",
+    "returnLabel": "退货",
+    "submittedOn": "提交于",
+    "itemQuantity": "数量",
+    "received": "已签收",
+    "refundAmount": "退款金额",
+    "status": {
+      "requested": "已申请",
+      "received": "已签收",
+      "canceled": "已取消",
+      "partially_received": "部分签收"
+    }
   }
 }

--- a/src/lib/data/orders.ts
+++ b/src/lib/data/orders.ts
@@ -19,7 +19,7 @@ export const retrieveOrder = async (id: string) => {
       method: "GET",
       query: {
         fields:
-          "*payment_collections.payments,*items,*items.metadata,*items.variant,*items.product,+items.detail,+cart.id",
+          "*payment_collections.payments,*items,*items.metadata,*items.variant,*items.product,+items.detail,+cart.id,+returns,+returns.items",
       },
       headers,
       next,

--- a/src/modules/order/components/return-status/index.tsx
+++ b/src/modules/order/components/return-status/index.tsx
@@ -1,0 +1,117 @@
+"use client"
+
+import { Badge, Text } from "@medusajs/ui"
+import { useTranslations } from "next-intl"
+
+interface ReturnItem {
+  id: string
+  item_id: string
+  quantity: number
+  received_quantity?: number
+  damaged_quantity?: number
+  reason?: {
+    id: string
+    value: string
+    label?: string
+  }
+  note?: string
+}
+
+interface Return {
+  id: string
+  status: string
+  refund_amount?: number
+  items?: ReturnItem[]
+  created_at: string
+}
+
+type Props = {
+  returns: Return[]
+  currencyCode: string
+}
+
+const statusColorMap: Record<
+  string,
+  "green" | "orange" | "red" | "grey" | "blue" | "purple"
+> = {
+  requested: "orange",
+  received: "green",
+  canceled: "red",
+  partially_received: "blue",
+}
+
+const ReturnStatus = ({ returns, currencyCode }: Props) => {
+  const t = useTranslations("returns")
+
+  if (!returns || returns.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="flex flex-col gap-y-3">
+      <Text className="txt-medium-plus">
+        {t.has("statusTitle") ? t("statusTitle") : "Return Requests"}
+      </Text>
+
+      {returns.map((ret, idx) => (
+        <div key={ret.id} className="rounded-lg border border-ui-border-base p-4">
+          <div className="mb-3 flex items-center justify-between">
+            <Text className="txt-compact-medium">
+              {t.has("returnLabel") ? t("returnLabel") : "Return"} #{idx + 1}
+            </Text>
+            <Badge color={statusColorMap[ret.status] || "grey"}>
+              {t.has(`status.${ret.status}`)
+                ? t(`status.${ret.status}`)
+                : ret.status}
+            </Badge>
+          </div>
+
+          <Text className="mb-2 text-sm text-ui-fg-subtle">
+            {t.has("submittedOn") ? t("submittedOn") : "Submitted on"}{" "}
+            {new Date(ret.created_at).toLocaleDateString()}
+          </Text>
+
+          {ret.items && ret.items.length > 0 && (
+            <div className="mt-2 space-y-1">
+              {ret.items.map((item) => (
+                <div
+                  key={item.id}
+                  className="flex justify-between text-sm text-ui-fg-subtle"
+                >
+                  <Text className="text-sm">
+                    {t.has("itemQuantity") ? t("itemQuantity") : "Qty"}: {item.quantity}
+                    {item.received_quantity != null && item.received_quantity > 0 && (
+                      <span className="ml-2 text-ui-fg-muted">
+                        ({t.has("received") ? t("received") : "Received"}: {" "}
+                        {item.received_quantity})
+                      </span>
+                    )}
+                  </Text>
+                  {item.reason && (
+                    <Text className="text-sm text-ui-fg-muted">
+                      {item.reason.label || item.reason.value}
+                    </Text>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+
+          {ret.refund_amount != null && ret.refund_amount > 0 && (
+            <div className="mt-2 border-t border-ui-border-base pt-2">
+              <Text className="text-sm">
+                {t.has("refundAmount") ? t("refundAmount") : "Refund amount"}:{" "}
+                {new Intl.NumberFormat(undefined, {
+                  style: "currency",
+                  currency: currencyCode,
+                }).format(ret.refund_amount / 100)}
+              </Text>
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default ReturnStatus

--- a/src/modules/order/templates/order-details-template.tsx
+++ b/src/modules/order/templates/order-details-template.tsx
@@ -6,6 +6,7 @@ import { Badge, Button, Text } from "@medusajs/ui"
 import LocalizedClientLink from "@modules/common/components/localized-client-link"
 import Help from "@modules/order/components/help"
 import { hasReturnableItems } from "@lib/util/returns"
+import ReturnStatus from "@modules/order/components/return-status"
 import Items from "@modules/order/components/items"
 import OrderDetails from "@modules/order/components/order-details"
 import OrderSummary from "@modules/order/components/order-summary"
@@ -145,6 +146,14 @@ const OrderDetailsTemplate: React.FC<OrderDetailsTemplateProps> = ({
         <Items order={order} />
         <ShippingDetails order={order} />
         <OrderSummary order={order} />
+        {(order as any).returns && (order as any).returns.length > 0 && (
+          <div className="rounded-lg border border-ui-border-base p-4">
+            <ReturnStatus
+              returns={(order as any).returns}
+              currencyCode={order.currency_code}
+            />
+          </div>
+        )}
         {hasReturnableItems(order) && (
           <div className="rounded-lg border border-ui-border-base p-4">
             <div className="flex items-center justify-between">


### PR DESCRIPTION
### Motivation
- Orders that have submitted return requests were not showing return progress on the order details page, so users cannot view the status or refund info for prior return requests.

### Description
- Extend `retrieveOrder` to request `returns` and `returns.items` from the Store API so order responses include return records (`src/lib/data/orders.ts`).
- Add a new `ReturnStatus` client component to render return requests, status Badge (with color mapping and grey fallback), submitted date, per-item quantity/reason/received count, and optional refund amount (`src/modules/order/components/return-status/index.tsx`).
- Render the `ReturnStatus` section in the order details template when `(order as any).returns` exists and contains entries while preserving the existing return request action (`src/modules/order/templates/order-details-template.tsx`).
- Add new i18n keys for `returns` in `messages/en.json` and `messages/zh.json` for labels and status mappings.

### Testing
- Ran `npx tsc --noEmit`, which failed due to pre-existing TypeScript errors in unrelated files (type issues elsewhere in the repo). (failed)
- Ran `npx eslint` against the changed files, which failed in this environment due to an ESLint/Next rule loading error (`@next/next/no-html-link-for-pages` path argument undefined). (failed)
- Verified i18n parity between `messages/en.json` and `messages/zh.json` for the `returns` namespace using a key-diff script; keys matched. (passed)
- Attempted `npm run dev` but the app did not start because required env var `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY` is missing in this environment. (cannot start)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ad17987d9c83339657dd442937f205)