### PR TITLE
feat/exchange-claim-status-display

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -591,5 +591,33 @@
       "canceled": "Canceled",
       "partially_received": "Partially Received"
     }
+  },
+  "exchanges": {
+    "statusTitle": "Exchanges",
+    "exchangeLabel": "Exchange",
+    "submittedOn": "Submitted on",
+    "newItems": "New items",
+    "status": {
+      "active": "Active",
+      "completed": "Completed",
+      "canceled": "Canceled"
+    }
+  },
+  "claims": {
+    "statusTitle": "Claims",
+    "claimLabel": "Claim",
+    "submittedOn": "Submitted on",
+    "claimedItems": "Claimed items",
+    "replacementItems": "Replacement items",
+    "refundAmount": "Refund amount",
+    "type": {
+      "refund": "Refund",
+      "replace": "Replace"
+    },
+    "status": {
+      "active": "Active",
+      "completed": "Completed",
+      "canceled": "Canceled"
+    }
   }
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -591,5 +591,33 @@
       "canceled": "已取消",
       "partially_received": "部分签收"
     }
+  },
+  "exchanges": {
+    "statusTitle": "换货记录",
+    "exchangeLabel": "换货",
+    "submittedOn": "提交于",
+    "newItems": "新商品",
+    "status": {
+      "active": "处理中",
+      "completed": "已完成",
+      "canceled": "已取消"
+    }
+  },
+  "claims": {
+    "statusTitle": "索赔记录",
+    "claimLabel": "索赔",
+    "submittedOn": "提交于",
+    "claimedItems": "索赔商品",
+    "replacementItems": "替换商品",
+    "refundAmount": "退款金额",
+    "type": {
+      "refund": "退款",
+      "replace": "换货"
+    },
+    "status": {
+      "active": "处理中",
+      "completed": "已完成",
+      "canceled": "已取消"
+    }
   }
 }

--- a/src/lib/data/orders.ts
+++ b/src/lib/data/orders.ts
@@ -19,7 +19,7 @@ export const retrieveOrder = async (id: string) => {
       method: "GET",
       query: {
         fields:
-          "*payment_collections.payments,*items,*items.metadata,*items.variant,*items.product,+items.detail,+cart.id,+returns,+returns.items",
+          "*payment_collections.payments,*items,*items.metadata,*items.variant,*items.product,+items.detail,+cart.id,+returns,+returns.items,+exchanges,+exchanges.additional_items,+claims,+claims.claim_items,+claims.additional_items",
       },
       headers,
       next,

--- a/src/modules/order/components/claim-status/index.tsx
+++ b/src/modules/order/components/claim-status/index.tsx
@@ -1,0 +1,156 @@
+"use client"
+
+import { convertToLocale } from "@lib/util/money"
+import { Badge, Text } from "@medusajs/ui"
+import { useTranslations } from "next-intl"
+
+interface ClaimItem {
+  id: string
+  item_id: string
+  quantity: number
+  reason?: string
+  note?: string
+}
+
+interface AdditionalItem {
+  id: string
+  item_id: string
+  quantity: number
+  unit_price: number
+  title?: string
+  variant_title?: string
+  thumbnail?: string
+}
+
+interface Claim {
+  id: string
+  display_id: number
+  type: "refund" | "replace"
+  order_version: number
+  refund_amount: number | null
+  canceled_at: string | null
+  created_at: string
+  claim_items?: ClaimItem[]
+  additional_items?: AdditionalItem[]
+}
+
+type Props = {
+  claims: Claim[]
+  currencyCode: string
+}
+
+const statusColorMap: Record<
+  string,
+  "green" | "orange" | "red" | "grey" | "blue" | "purple"
+> = {
+  active: "orange",
+  completed: "green",
+  canceled: "red",
+}
+
+const typeColorMap: Record<string, "blue" | "purple"> = {
+  refund: "blue",
+  replace: "purple",
+}
+
+function getClaimStatus(claim: Claim): string {
+  if (claim.canceled_at) return "canceled"
+
+  return "active"
+}
+
+const ClaimStatus = ({ claims, currencyCode }: Props) => {
+  const t = useTranslations("claims")
+
+  if (!claims || claims.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="flex flex-col gap-y-3">
+      <Text className="txt-medium-plus">
+        {t.has("statusTitle") ? t("statusTitle") : "Claims"}
+      </Text>
+
+      {claims.map((claim) => {
+        const status = getClaimStatus(claim)
+
+        return (
+          <div key={claim.id} className="rounded-lg border border-ui-border-base p-4">
+            <div className="mb-3 flex items-center justify-between">
+              <div className="flex items-center gap-x-2">
+                <Text className="txt-compact-medium">
+                  {t.has("claimLabel") ? t("claimLabel") : "Claim"} #{claim.display_id}
+                </Text>
+                <Badge color={typeColorMap[claim.type] || "grey"}>
+                  {t.has(`type.${claim.type}`) ? t(`type.${claim.type}`) : claim.type}
+                </Badge>
+              </div>
+              <Badge color={statusColorMap[status] || "grey"}>
+                {t.has(`status.${status}`) ? t(`status.${status}`) : status}
+              </Badge>
+            </div>
+
+            <Text className="mb-2 text-sm text-ui-fg-subtle">
+              {t.has("submittedOn") ? t("submittedOn") : "Submitted on"}{" "}
+              {new Date(claim.created_at).toLocaleDateString()}
+            </Text>
+
+            {claim.claim_items && claim.claim_items.length > 0 && (
+              <div className="mt-2 space-y-1">
+                <Text className="text-xs font-medium text-ui-fg-muted">
+                  {t.has("claimedItems") ? t("claimedItems") : "Claimed items"}
+                </Text>
+                {claim.claim_items.map((item) => (
+                  <div key={item.id} className="flex justify-between text-sm text-ui-fg-subtle">
+                    <Text className="text-sm">Qty: {item.quantity}</Text>
+                    {item.reason && (
+                      <Text className="text-sm text-ui-fg-muted">{item.reason}</Text>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {claim.additional_items && claim.additional_items.length > 0 && (
+              <div className="mt-2 space-y-1">
+                <Text className="text-xs font-medium text-ui-fg-muted">
+                  {t.has("replacementItems")
+                    ? t("replacementItems")
+                    : "Replacement items"}
+                </Text>
+                {claim.additional_items.map((item) => (
+                  <div key={item.id} className="flex justify-between text-sm text-ui-fg-subtle">
+                    <Text className="text-sm">
+                      {item.title || item.variant_title || "Item"} × {item.quantity}
+                    </Text>
+                    <Text className="text-sm">
+                      {convertToLocale({
+                        amount: item.unit_price,
+                        currency_code: currencyCode,
+                      })}
+                    </Text>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {claim.refund_amount != null && claim.refund_amount > 0 && (
+              <div className="mt-2 border-t border-ui-border-base pt-2">
+                <Text className="text-sm">
+                  {t.has("refundAmount") ? t("refundAmount") : "Refund amount"}: {" "}
+                  {convertToLocale({
+                    amount: claim.refund_amount,
+                    currency_code: currencyCode,
+                  })}
+                </Text>
+              </div>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+export default ClaimStatus

--- a/src/modules/order/components/exchange-status/index.tsx
+++ b/src/modules/order/components/exchange-status/index.tsx
@@ -1,0 +1,110 @@
+"use client"
+
+import { convertToLocale } from "@lib/util/money"
+import { Badge, Text } from "@medusajs/ui"
+import { useTranslations } from "next-intl"
+
+interface ExchangeItem {
+  id: string
+  item_id: string
+  quantity: number
+  note?: string
+}
+
+interface AdditionalItem {
+  id: string
+  item_id: string
+  quantity: number
+  unit_price: number
+  title?: string
+  variant_title?: string
+  thumbnail?: string
+}
+
+interface Exchange {
+  id: string
+  display_id: number
+  order_version: number
+  canceled_at: string | null
+  created_at: string
+  additional_items?: AdditionalItem[]
+}
+
+type Props = {
+  exchanges: Exchange[]
+  currencyCode: string
+}
+
+const statusColorMap: Record<string, "green" | "orange" | "red" | "grey" | "blue"> = {
+  active: "orange",
+  completed: "green",
+  canceled: "red",
+}
+
+function getExchangeStatus(exchange: Exchange): string {
+  if (exchange.canceled_at) return "canceled"
+
+  return "active"
+}
+
+const ExchangeStatus = ({ exchanges, currencyCode }: Props) => {
+  const t = useTranslations("exchanges")
+
+  if (!exchanges || exchanges.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="flex flex-col gap-y-3">
+      <Text className="txt-medium-plus">
+        {t.has("statusTitle") ? t("statusTitle") : "Exchanges"}
+      </Text>
+
+      {exchanges.map((exchange) => {
+        const status = getExchangeStatus(exchange)
+
+        return (
+          <div key={exchange.id} className="rounded-lg border border-ui-border-base p-4">
+            <div className="mb-3 flex items-center justify-between">
+              <Text className="txt-compact-medium">
+                {t.has("exchangeLabel") ? t("exchangeLabel") : "Exchange"} #
+                {exchange.display_id}
+              </Text>
+              <Badge color={statusColorMap[status] || "grey"}>
+                {t.has(`status.${status}`) ? t(`status.${status}`) : status}
+              </Badge>
+            </div>
+
+            <Text className="mb-2 text-sm text-ui-fg-subtle">
+              {t.has("submittedOn") ? t("submittedOn") : "Submitted on"}{" "}
+              {new Date(exchange.created_at).toLocaleDateString()}
+            </Text>
+
+            {exchange.additional_items && exchange.additional_items.length > 0 && (
+              <div className="mt-2 space-y-1">
+                <Text className="text-xs font-medium text-ui-fg-muted">
+                  {t.has("newItems") ? t("newItems") : "New items"}
+                </Text>
+                {exchange.additional_items.map((item) => (
+                  <div key={item.id} className="flex justify-between text-sm text-ui-fg-subtle">
+                    <Text className="text-sm">
+                      {item.title || item.variant_title || "Item"} × {item.quantity}
+                    </Text>
+                    <Text className="text-sm">
+                      {convertToLocale({
+                        amount: item.unit_price,
+                        currency_code: currencyCode,
+                      })}
+                    </Text>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+export default ExchangeStatus

--- a/src/modules/order/templates/order-details-template.tsx
+++ b/src/modules/order/templates/order-details-template.tsx
@@ -7,6 +7,8 @@ import LocalizedClientLink from "@modules/common/components/localized-client-lin
 import Help from "@modules/order/components/help"
 import { hasReturnableItems } from "@lib/util/returns"
 import ReturnStatus from "@modules/order/components/return-status"
+import ExchangeStatus from "@modules/order/components/exchange-status"
+import ClaimStatus from "@modules/order/components/claim-status"
 import Items from "@modules/order/components/items"
 import OrderDetails from "@modules/order/components/order-details"
 import OrderSummary from "@modules/order/components/order-summary"
@@ -154,6 +156,25 @@ const OrderDetailsTemplate: React.FC<OrderDetailsTemplateProps> = ({
             />
           </div>
         )}
+
+        {(order as any).exchanges && (order as any).exchanges.length > 0 && (
+          <div className="rounded-lg border border-ui-border-base p-4">
+            <ExchangeStatus
+              exchanges={(order as any).exchanges}
+              currencyCode={order.currency_code}
+            />
+          </div>
+        )}
+
+        {(order as any).claims && (order as any).claims.length > 0 && (
+          <div className="rounded-lg border border-ui-border-base p-4">
+            <ClaimStatus
+              claims={(order as any).claims}
+              currencyCode={order.currency_code}
+            />
+          </div>
+        )}
+
         {hasReturnableItems(order) && (
           <div className="rounded-lg border border-ui-border-base p-4">
             <div className="flex items-center justify-between">


### PR DESCRIPTION
### Motivation
- Provide read-only display for Medusa v2 Exchange and Claim records on the order details page because the Store API does not expose Exchange/Claim creation endpoints. 
- Match the existing `ReturnStatus` UX pattern (status badges + cards + i18n) so admin-created exchanges/claims are visible to customers. 
- Ensure required relational data is requested from `GET /store/orders/:id` so the frontend can render exchanges and claims.

### Description
- Added `ExchangeStatus` component at `src/modules/order/components/exchange-status/index.tsx` to render exchange cards with status badges, submission date, and additional item pricing using `convertToLocale`. 
- Added `ClaimStatus` component at `src/modules/order/components/claim-status/index.tsx` to render claim cards with type/status badges, claimed/replacement items, and optional refund amount using `convertToLocale`. 
- Integrated both components into the order details template `src/modules/order/templates/order-details-template.tsx` immediately after the existing return status block and guarded access with `(order as any)` for compatibility with Medusa v2 types. 
- Extended order retrieval fields in `src/lib/data/orders.ts` to include `+exchanges,+exchanges.additional_items,+claims,+claims.claim_items,+claims.additional_items` so the Store order response contains the new relations. 
- Added new i18n namespaces for `exchanges` and `claims` in `messages/en.json` and `messages/zh.json`. 
- Lockfile and package metadata were updated during changes (dependency resolution updates present in `yarn.lock` and `package.json`).

### Testing
- Attempted `npm run build` without env set and it failed with missing env var `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY`. 
- Attempted `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY=dummy npm run build` and the build failed due to network/Google Fonts fetch errors in the environment, preventing a full production build. 
- Ran `npm run lint` and `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY=dummy npm run lint`, which failed due to an existing lint rule issue (`@next/next/no-html-link-for-pages`) unrelated to these changes. 
- Ran `npx tsc --noEmit` which reported pre-existing TypeScript issues in the repository not introduced by this change. 
- Started the dev server successfully with `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY=dummy` and captured a UI screenshot of the account orders route for visual verification at `artifacts/exchange-claim-status.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ad1fe42aa88333a07cf4adb24cf709)