### PR TITLE
feat: localize Chinese product/variant/collection metadata with fallbacks

### DIFF
--- a/src/app/[locale]/[countryCode]/(main)/collections/[handle]/page.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/collections/[handle]/page.tsx
@@ -2,15 +2,17 @@ import { Metadata } from "next"
 import { notFound } from "next/navigation"
 
 import { getCollectionByHandle } from "@lib/data/collections"
+import { getLocalizedCollectionTitle } from "@lib/util/get-localized-product"
 import { StoreCollection } from "@medusajs/types"
 import CollectionTemplate from "@modules/collections/templates"
 import { SortOptions } from "@modules/store/components/refinement-list/sort-products"
+import { getLocale } from "next-intl/server"
 
 
 export const dynamic = "force-dynamic"
 export const revalidate = 300 // 5 minutes
 type Props = {
-  params: Promise<{ handle: string; countryCode: string }>
+  params: Promise<{ handle: string; countryCode: string; locale: string }>
   searchParams: Promise<{
     page?: string
     sortBy?: SortOptions
@@ -25,18 +27,22 @@ export async function generateStaticParams() {
 
 export async function generateMetadata(props: Props): Promise<Metadata> {
   const params = await props.params
+  const locale = await getLocale()
   const collection = await getCollectionByHandle(params.handle)
 
   if (!collection) {
     notFound()
   }
 
-  const metadata = {
-    title: `${collection.title} | NordHjem`,
-    description: `${collection.title} collection`,
-  } as Metadata
+  const collectionName = getLocalizedCollectionTitle(collection, locale)
 
-  return metadata
+  return {
+    title: `${collectionName} | NordHjem`,
+    description:
+      locale === "zh"
+        ? `${collectionName}系列`
+        : `${collectionName} collection`,
+  }
 }
 
 export default async function CollectionPage(props: Props) {

--- a/src/app/[locale]/[countryCode]/(main)/products/[handle]/page.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/products/[handle]/page.tsx
@@ -60,12 +60,12 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
   }
 
   const title =
-    locale === "zh" && product.metadata?.zh_title
-      ? String(product.metadata.zh_title)
+    locale === "zh" && product.metadata?.name_zh
+      ? String(product.metadata.name_zh)
       : product.title
   const description =
-    locale === "zh" && product.metadata?.zh_description
-      ? String(product.metadata.zh_description)
+    locale === "zh" && product.metadata?.description_zh
+      ? String(product.metadata.description_zh)
       : product.description || product.title
 
   return {
@@ -104,8 +104,8 @@ export default async function ProductPage(props: Props) {
 
   const productJsonLd = generateProductJsonLd(pricedProduct)
   const title =
-    locale === "zh" && pricedProduct.metadata?.zh_title
-      ? String(pricedProduct.metadata.zh_title)
+    locale === "zh" && pricedProduct.metadata?.name_zh
+      ? String(pricedProduct.metadata.name_zh)
       : pricedProduct.title
   const breadcrumbJsonLd = generateBreadcrumbJsonLd([
     {

--- a/src/lib/util/get-localized-product.ts
+++ b/src/lib/util/get-localized-product.ts
@@ -1,0 +1,69 @@
+/**
+ * Get localized product name.
+ * In Chinese locale, reads product.metadata.name_zh with fallback to product.title.
+ */
+export function getLocalizedProductName(
+  product: { title: string; metadata?: Record<string, any> | null },
+  locale: string
+): string {
+  if (locale === "zh" && product.metadata?.name_zh) {
+    return String(product.metadata.name_zh)
+  }
+
+  return product.title
+}
+
+/**
+ * Get localized product description.
+ * In Chinese locale, reads product.metadata.description_zh with fallback to product.description.
+ */
+export function getLocalizedProductDescription(
+  product: {
+    description?: string | null
+    metadata?: Record<string, any> | null
+  },
+  locale: string
+): string | null {
+  if (locale === "zh" && product.metadata?.description_zh) {
+    return String(product.metadata.description_zh)
+  }
+
+  return product.description ?? null
+}
+
+/**
+ * Get localized variant color.
+ * In Chinese locale, reads variant.metadata.color_zh with fallback to variant.title.
+ */
+export function getLocalizedVariantTitle(
+  variant:
+    | { title?: string | null; metadata?: Record<string, any> | null }
+    | undefined
+    | null,
+  locale: string
+): string {
+  if (!variant) {
+    return ""
+  }
+
+  if (locale === "zh" && variant.metadata?.color_zh) {
+    return String(variant.metadata.color_zh)
+  }
+
+  return variant.title ?? ""
+}
+
+/**
+ * Get localized collection name from metadata.
+ * In Chinese locale, reads collection.metadata.zh_name with fallback to collection.title.
+ */
+export function getLocalizedCollectionTitle(
+  collection: { title: string; metadata?: Record<string, any> | null },
+  locale: string
+): string {
+  if (locale === "zh" && collection.metadata?.zh_name) {
+    return String(collection.metadata.zh_name)
+  }
+
+  return collection.title
+}

--- a/src/modules/cart/components/item/index.tsx
+++ b/src/modules/cart/components/item/index.tsx
@@ -12,6 +12,7 @@ import LineItemUnitPrice from "@modules/common/components/line-item-unit-price"
 import LocalizedClientLink from "@modules/common/components/localized-client-link"
 import Spinner from "@modules/common/icons/spinner"
 import Thumbnail from "@modules/products/components/thumbnail"
+import { useLocale } from "next-intl"
 import { useState } from "react"
 
 type ItemProps = {
@@ -21,6 +22,7 @@ type ItemProps = {
 }
 
 const Item = ({ item, type = "full", currencyCode }: ItemProps) => {
+  const locale = useLocale()
   const [updating, setUpdating] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -67,7 +69,9 @@ const Item = ({ item, type = "full", currencyCode }: ItemProps) => {
           className="txt-medium-plus text-ui-fg-base"
           data-testid="product-title"
         >
-          {item.product_title}
+          {locale === "zh" && item.variant?.product?.metadata?.name_zh
+            ? String(item.variant.product.metadata.name_zh)
+            : item.product_title}
         </Text>
         <LineItemOptions variant={item.variant} data-testid="product-variant" />
       </Table.Cell>

--- a/src/modules/common/components/line-item-options/index.tsx
+++ b/src/modules/common/components/line-item-options/index.tsx
@@ -2,7 +2,8 @@
 
 import { HttpTypes } from "@medusajs/types"
 import { Text } from "@medusajs/ui"
-import { useTranslations } from "next-intl"
+import { getLocalizedVariantTitle } from "@lib/util/get-localized-product"
+import { useLocale, useTranslations } from "next-intl"
 
 type LineItemOptionsProps = {
   variant: HttpTypes.StoreProductVariant | undefined
@@ -16,6 +17,7 @@ const LineItemOptions = ({
   "data-value": dataValue,
 }: LineItemOptionsProps) => {
   const t = useTranslations("product")
+  const locale = useLocale()
 
   return (
     <Text
@@ -23,7 +25,7 @@ const LineItemOptions = ({
       data-value={dataValue}
       className="inline-block txt-medium text-ui-fg-subtle w-full overflow-hidden text-ellipsis"
     >
-      {t("variantLabel")}: {variant?.title}
+      {t("variantLabel")}: {getLocalizedVariantTitle(variant, locale)}
     </Text>
   )
 }

--- a/src/modules/layout/components/cart-dropdown/index.tsx
+++ b/src/modules/layout/components/cart-dropdown/index.tsx
@@ -14,7 +14,7 @@ import LineItemOptions from "@modules/common/components/line-item-options"
 import LineItemPrice from "@modules/common/components/line-item-price"
 import LocalizedClientLink from "@modules/common/components/localized-client-link"
 import Thumbnail from "@modules/products/components/thumbnail"
-import { useTranslations } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 import { usePathname } from "next/navigation"
 import { Fragment, useEffect, useRef, useState } from "react"
 
@@ -25,6 +25,7 @@ const CartDropdown = ({
 }) => {
   const t = useTranslations("nav")
   const tCart = useTranslations("cart")
+  const locale = useLocale()
   const [activeTimer, setActiveTimer] = useState<NodeJS.Timer | undefined>(
     undefined
   )
@@ -142,7 +143,9 @@ const CartDropdown = ({
                                     href={`/products/${item.product_handle}`}
                                     data-testid="product-link"
                                   >
-                                    {item.title}
+                                    {locale === "zh" && item.variant?.product?.metadata?.name_zh
+                                      ? String(item.variant.product.metadata.name_zh)
+                                      : item.product_title}
                                   </LocalizedClientLink>
                                 </h3>
                                 <LineItemOptions

--- a/src/modules/order/components/item/index.tsx
+++ b/src/modules/order/components/item/index.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import { HttpTypes } from "@medusajs/types"
 import { Table, Text } from "@medusajs/ui"
 
@@ -5,6 +7,7 @@ import LineItemOptions from "@modules/common/components/line-item-options"
 import LineItemPrice from "@modules/common/components/line-item-price"
 import LineItemUnitPrice from "@modules/common/components/line-item-unit-price"
 import Thumbnail from "@modules/products/components/thumbnail"
+import { useLocale } from "next-intl"
 
 type ItemProps = {
   item: HttpTypes.StoreCartLineItem | HttpTypes.StoreOrderLineItem
@@ -12,6 +15,8 @@ type ItemProps = {
 }
 
 const Item = ({ item, currencyCode }: ItemProps) => {
+  const locale = useLocale()
+
   return (
     <Table.Row className="w-full" data-testid="product-row">
       <Table.Cell className="!pl-0 p-4 w-24">
@@ -25,7 +30,9 @@ const Item = ({ item, currencyCode }: ItemProps) => {
           className="txt-medium-plus text-ui-fg-base"
           data-testid="product-name"
         >
-          {item.product_title}
+          {locale === "zh" && item.variant?.product?.metadata?.name_zh
+            ? String(item.variant.product.metadata.name_zh)
+            : item.product_title}
         </Text>
         <LineItemOptions variant={item.variant} data-testid="product-variant" />
       </Table.Cell>

--- a/src/modules/order/templates/return-request-template.tsx
+++ b/src/modules/order/templates/return-request-template.tsx
@@ -11,7 +11,7 @@ import { ArrowLeftMini } from "@medusajs/icons"
 import { HttpTypes } from "@medusajs/types"
 import { Button, Text } from "@medusajs/ui"
 import LocalizedClientLink from "@modules/common/components/localized-client-link"
-import { useTranslations } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 import { useState } from "react"
 
 type Props = {
@@ -43,6 +43,7 @@ const ReturnRequestTemplate = ({
   returnShippingOptions,
 }: Props) => {
   const t = useTranslations("returns")
+  const locale = useLocale()
   const [step, setStep] = useState<Step>("select-items")
   const [selectedItems, setSelectedItems] = useState<SelectedItem[]>([])
   const [selectedShippingOptionId, setSelectedShippingOptionId] = useState("")
@@ -51,6 +52,16 @@ const ReturnRequestTemplate = ({
 
   const itemsWithInfo = getItemsWithReturnInfo(order.items || [])
   const returnableItems = itemsWithInfo.filter((i) => i.is_returnable)
+
+  const getItemName = (item: HttpTypes.StoreOrderLineItem) =>
+    locale === "zh" && item.variant?.product?.metadata?.name_zh
+      ? String(item.variant.product.metadata.name_zh)
+      : item.product_title
+
+  const getItemVariantTitle = (item: HttpTypes.StoreOrderLineItem) =>
+    locale === "zh" && item.variant?.metadata?.color_zh
+      ? String(item.variant.metadata.color_zh)
+      : item.variant_title
 
   const toggleItem = (itemId: string) => {
     setSelectedItems((prev) => {
@@ -212,9 +223,9 @@ const ReturnRequestTemplate = ({
                       />
                     )}
                     <div>
-                      <Text className="txt-compact-medium">{item.product_title}</Text>
+                      <Text className="txt-compact-medium">{getItemName(item)}</Text>
                       <Text className="text-sm text-ui-fg-subtle">
-                        {item.variant_title}
+                        {getItemVariantTitle(item)}
                       </Text>
                     </div>
                   </div>
@@ -271,7 +282,7 @@ const ReturnRequestTemplate = ({
             return (
               <div key={sel.id} className="rounded-lg border border-ui-border-base p-4">
                 <Text className="mb-2 txt-compact-medium">
-                  {item.product_title} — {item.variant_title} × {sel.quantity}
+                  {getItemName(item)} — {getItemVariantTitle(item)} × {sel.quantity}
                 </Text>
 
                 {returnReasons.length > 0 ? (
@@ -382,9 +393,9 @@ const ReturnRequestTemplate = ({
                   className="flex justify-between border-b border-ui-border-base py-2 last:border-0"
                 >
                   <div>
-                    <Text className="text-sm">{item.product_title}</Text>
+                    <Text className="text-sm">{getItemName(item)}</Text>
                     <Text className="text-xs text-ui-fg-subtle">
-                      {item.variant_title} × {sel.quantity}
+                      {getItemVariantTitle(item)} × {sel.quantity}
                     </Text>
                     {reason && (
                       <Text className="text-xs text-ui-fg-subtle">

--- a/src/modules/products/components/product-actions/index.tsx
+++ b/src/modules/products/components/product-actions/index.tsx
@@ -8,7 +8,7 @@ import Divider from "@modules/common/components/divider"
 import OptionSelect from "@modules/products/components/product-actions/option-select"
 import { isEqual } from "lodash"
 import { useParams, usePathname, useSearchParams } from "next/navigation"
-import { useTranslations } from "next-intl"
+import { useLocale, useTranslations } from "next-intl"
 import { useEffect, useMemo, useRef, useState } from "react"
 import ProductPrice from "../product-price"
 import MobileActions from "./mobile-actions"
@@ -41,6 +41,7 @@ export default function ProductActions({
   const [isAdding, setIsAdding] = useState(false)
   const countryCode = useParams().countryCode as string
   const t = useTranslations("product")
+  const locale = useLocale()
 
   // If there is only 1 variant, preselect the options
   useEffect(() => {
@@ -76,6 +77,30 @@ export default function ProductActions({
       return isEqual(variantOptions, options)
     })
   }, [product.variants, options])
+
+  const colorMap = useMemo(() => {
+    if (locale !== "zh" || !product.variants) {
+      return undefined
+    }
+
+    const map: Record<string, string> = {}
+
+    for (const variant of product.variants) {
+      if (!variant.metadata?.color_zh) {
+        continue
+      }
+
+      const colorOption = variant.options?.find(
+        (optionValue) => optionValue.option?.title === "Color"
+      )
+
+      if (colorOption?.value) {
+        map[colorOption.value] = String(variant.metadata.color_zh)
+      }
+    }
+
+    return Object.keys(map).length > 0 ? map : undefined
+  }, [locale, product.variants])
 
   useEffect(() => {
     const params = new URLSearchParams(searchParams.toString())
@@ -153,6 +178,7 @@ export default function ProductActions({
                       title={option.title ?? ""}
                       data-testid="product-options"
                       disabled={!!disabled || isAdding}
+                      colorMap={option.title === "Color" ? colorMap : undefined}
                     />
                   </div>
                 )

--- a/src/modules/products/components/product-actions/option-select.tsx
+++ b/src/modules/products/components/product-actions/option-select.tsx
@@ -8,6 +8,7 @@ type OptionSelectProps = {
   updateOption: (title: string, value: string) => void
   title: string
   disabled: boolean
+  colorMap?: Record<string, string>
   "data-testid"?: string
 }
 
@@ -18,6 +19,7 @@ const OptionSelect: React.FC<OptionSelectProps> = ({
   title,
   "data-testid": dataTestId,
   disabled,
+  colorMap,
 }) => {
   const filteredOptions = (option.values ?? []).map((v) => v.value)
 
@@ -29,6 +31,8 @@ const OptionSelect: React.FC<OptionSelectProps> = ({
         data-testid={dataTestId}
       >
         {filteredOptions.map((v) => {
+          const displayLabel = colorMap?.[v] ?? v
+
           return (
             <button
               onClick={() => updateOption(option.id, v)}
@@ -44,7 +48,7 @@ const OptionSelect: React.FC<OptionSelectProps> = ({
               disabled={disabled}
               data-testid="option-button"
             >
-              {v}
+              {displayLabel}
             </button>
           )
         })}

--- a/src/modules/products/components/product-preview/index.tsx
+++ b/src/modules/products/components/product-preview/index.tsx
@@ -1,8 +1,10 @@
 import { Text } from "@medusajs/ui"
 import { listProducts } from "@lib/data/products"
 import { getProductPrice } from "@lib/util/get-product-price"
+import { getLocalizedProductName } from "@lib/util/get-localized-product"
 import { HttpTypes } from "@medusajs/types"
 import LocalizedClientLink from "@modules/common/components/localized-client-link"
+import { getLocale } from "next-intl/server"
 import Thumbnail from "../thumbnail"
 import PreviewPrice from "./price"
 
@@ -27,6 +29,7 @@ export default async function ProductPreview({
   const { cheapestPrice } = getProductPrice({
     product,
   })
+  const locale = await getLocale()
 
   return (
     <LocalizedClientLink href={`/products/${product.handle}`} className="group">
@@ -39,7 +42,7 @@ export default async function ProductPreview({
         />
         <div className="flex txt-compact-medium mt-4 justify-between">
           <Text className="text-ui-fg-subtle" data-testid="product-title">
-            {product.title}
+            {getLocalizedProductName(product, locale)}
           </Text>
           <div className="flex items-center gap-x-2">
             {cheapestPrice && <PreviewPrice price={cheapestPrice} />}

--- a/src/modules/products/templates/product-info/index.tsx
+++ b/src/modules/products/templates/product-info/index.tsx
@@ -1,15 +1,22 @@
 import { getLocalizedCollectionName } from "@lib/util/collection-name"
+import {
+  getLocalizedProductDescription,
+  getLocalizedProductName,
+} from "@lib/util/get-localized-product"
 import { HttpTypes } from "@medusajs/types"
 import { Heading, Text } from "@medusajs/ui"
 import LocalizedClientLink from "@modules/common/components/localized-client-link"
-import { getTranslations } from "next-intl/server"
+import { getLocale, getTranslations } from "next-intl/server"
 
 type ProductInfoProps = {
   product: HttpTypes.StoreProduct
 }
 
 const ProductInfo = async ({ product }: ProductInfoProps) => {
-  const tCollection = await getTranslations("collection")
+  const [tCollection, locale] = await Promise.all([
+    getTranslations("collection"),
+    getLocale(),
+  ])
 
   return (
     <div id="product-info">
@@ -31,14 +38,14 @@ const ProductInfo = async ({ product }: ProductInfoProps) => {
           className="text-3xl leading-10 text-[#2C3E2D]"
           data-testid="product-title"
         >
-          {product.title}
+          {getLocalizedProductName(product, locale)}
         </Heading>
 
         <Text
           className="text-medium text-[#2C3E2D]/70 whitespace-pre-line"
           data-testid="product-description"
         >
-          {product.description}
+          {getLocalizedProductDescription(product, locale)}
         </Text>
       </div>
     </div>


### PR DESCRIPTION
### Motivation

- Enable Chinese storefront to display Chinese metadata fields stored in product/variant/collection metadata (`name_zh`, `description_zh`, `color_zh`, `zh_name`) while preserving English behavior and providing safe fallbacks when metadata is missing. 
- Unify localization logic into a small reusable utility to avoid duplicating locale checks across components. 
- Fix product/collection SEO generation which previously referenced incorrect metadata keys so SSR metadata is correct for Chinese pages.

### Description

- Add `src/lib/util/get-localized-product.ts` providing `getLocalizedProductName`, `getLocalizedProductDescription`, `getLocalizedVariantTitle`, and `getLocalizedCollectionTitle` that read Chinese metadata when `locale === "zh"` and fall back to the original title/description when absent. 
- Wire product name/description localization into product preview and product info: `src/modules/products/components/product-preview/index.tsx` and `src/modules/products/templates/product-info/index.tsx` now use the shared helpers and `getLocale()` for server components. 
- Localize variant labels and color option UI: `src/modules/common/components/line-item-options/index.tsx` uses `getLocalizedVariantTitle`, `OptionSelect` (props) accepts a new `colorMap`, and `src/modules/products/components/product-actions/index.tsx` builds a `colorMap` from `variant.metadata.color_zh` (applied only for the "Color" option). 
- Show localized product names in cart/minidropdown, cart item, order item and return-request templates via safe fallbacks (use `variant.product.metadata.name_zh` when available, otherwise `product_title` / `variant_title`), and fix product SEO keys from `zh_title/zh_description` to `name_zh/description_zh` and collection SEO to use `collection.metadata.zh_name`. Modified files include the util and the components/pages listed above.

### Testing

- Ran repository search/diff checks to verify all intended occurrences were updated and no unexpected references to the old keys remain, which succeeded. 
- Attempted to run `yarn lint`, but it failed due to missing node_modules state in this environment. 
- Attempted to install dependencies with `yarn install --immutable`, but package resolution failed with a remote 403 error so full local lint/build could not be executed. 
- Executed a Playwright script to visit the Chinese store route (`/zh/cn/store`) and captured a screenshot artifact to validate runtime rendering in a headless browser, which produced an artifact successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69adae343a5083339282663e51bd9d7e)