### PR TITLE
fix: load zh metadata for cart item names and collection SEO

### DIFF
--- a/src/lib/data/cart.ts
+++ b/src/lib/data/cart.ts
@@ -24,7 +24,7 @@ import { getLocale } from "@lib/data/locale-actions"
 export async function retrieveCart(cartId?: string, fields?: string) {
   const id = cartId || (await getCartId())
   fields ??=
-    "*items, *region, *items.product, *items.variant, *items.thumbnail, *items.metadata, +items.total, *promotions, +shipping_methods.name"
+    "*items, *region, *items.product, *items.variant, *items.variant.product, *items.thumbnail, *items.metadata, +items.total, *promotions, +shipping_methods.name"
 
   if (!id) {
     return null

--- a/src/lib/data/collections.ts
+++ b/src/lib/data/collections.ts
@@ -51,7 +51,7 @@ export const getCollectionByHandle = async (
 
   return sdk.client
     .fetch<HttpTypes.StoreCollectionListResponse>(`/store/collections`, {
-      query: { handle, fields: "*products" },
+      query: { handle, fields: "*products,+metadata" },
       next,
       cache: "force-cache",
     })

--- a/src/modules/cart/components/item/index.tsx
+++ b/src/modules/cart/components/item/index.tsx
@@ -69,8 +69,13 @@ const Item = ({ item, type = "full", currencyCode }: ItemProps) => {
           className="txt-medium-plus text-ui-fg-base"
           data-testid="product-title"
         >
-          {locale === "zh" && item.variant?.product?.metadata?.name_zh
-            ? String(item.variant.product.metadata.name_zh)
+          {locale === "zh" &&
+          ((item as any).product?.metadata?.name_zh ||
+            item.variant?.product?.metadata?.name_zh)
+            ? String(
+                (item as any).product?.metadata?.name_zh ||
+                  item.variant?.product?.metadata?.name_zh
+              )
             : item.product_title}
         </Text>
         <LineItemOptions variant={item.variant} data-testid="product-variant" />

--- a/src/modules/layout/components/cart-dropdown/index.tsx
+++ b/src/modules/layout/components/cart-dropdown/index.tsx
@@ -143,8 +143,13 @@ const CartDropdown = ({
                                     href={`/products/${item.product_handle}`}
                                     data-testid="product-link"
                                   >
-                                    {locale === "zh" && item.variant?.product?.metadata?.name_zh
-                                      ? String(item.variant.product.metadata.name_zh)
+                                    {locale === "zh" &&
+                                    ((item as any).product?.metadata?.name_zh ||
+                                      item.variant?.product?.metadata?.name_zh)
+                                      ? String(
+                                          (item as any).product?.metadata?.name_zh ||
+                                            item.variant?.product?.metadata?.name_zh
+                                        )
                                       : item.product_title}
                                   </LocalizedClientLink>
                                 </h3>

--- a/src/modules/order/components/item/index.tsx
+++ b/src/modules/order/components/item/index.tsx
@@ -30,8 +30,13 @@ const Item = ({ item, currencyCode }: ItemProps) => {
           className="txt-medium-plus text-ui-fg-base"
           data-testid="product-name"
         >
-          {locale === "zh" && item.variant?.product?.metadata?.name_zh
-            ? String(item.variant.product.metadata.name_zh)
+          {locale === "zh" &&
+          ((item as any).product?.metadata?.name_zh ||
+            item.variant?.product?.metadata?.name_zh)
+            ? String(
+                (item as any).product?.metadata?.name_zh ||
+                  item.variant?.product?.metadata?.name_zh
+              )
             : item.product_title}
         </Text>
         <LineItemOptions variant={item.variant} data-testid="product-variant" />

--- a/src/modules/order/templates/return-request-template.tsx
+++ b/src/modules/order/templates/return-request-template.tsx
@@ -54,8 +54,13 @@ const ReturnRequestTemplate = ({
   const returnableItems = itemsWithInfo.filter((i) => i.is_returnable)
 
   const getItemName = (item: HttpTypes.StoreOrderLineItem) =>
-    locale === "zh" && item.variant?.product?.metadata?.name_zh
-      ? String(item.variant.product.metadata.name_zh)
+    locale === "zh" &&
+    ((item as any).product?.metadata?.name_zh ||
+      item.variant?.product?.metadata?.name_zh)
+      ? String(
+          (item as any).product?.metadata?.name_zh ||
+            item.variant?.product?.metadata?.name_zh
+        )
       : item.product_title
 
   const getItemVariantTitle = (item: HttpTypes.StoreOrderLineItem) =>


### PR DESCRIPTION
### Motivation
- Collection fetches and cart line-item expansions did not include localized `metadata`, causing Chinese product names and collection SEO titles to fall back to English.
- Cart line items sometimes hydrate product metadata at `item.product` instead of `item.variant.product`, so UI code must defensively resolve both paths.

### Description
- Updated `getCollectionByHandle` to request collection metadata by changing query fields to `"*products,+metadata"` in `src/lib/data/collections.ts` so collection-level localized SEO values are available.
- Included `*items.variant.product` in the cart fetch `fields` string in `src/lib/data/cart.ts` to improve hydration of `variant.product.metadata` for cart line items.
- Added defensive fallback logic in UI components to resolve Chinese product names from either `(item as any).product?.metadata?.name_zh` or `item.variant?.product?.metadata?.name_zh` before falling back to `item.product_title` in the following files: `src/modules/layout/components/cart-dropdown/index.tsx`, `src/modules/cart/components/item/index.tsx`, `src/modules/order/components/item/index.tsx`, and `src/modules/order/templates/return-request-template.tsx`.

### Testing
- Ran `yarn lint` which failed due to missing environment variable `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY`, so a full lint/typecheck could not be completed in this environment (failed).
- Ran an automated Playwright script to capture a verification screenshot of the running site which executed and produced an artifact at `artifacts/cart-hotfix.png` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69adb3e1ac008333a8c64e87d1355ece)