### PR TITLE
fix(account): render login for unauthenticated /account/* routes via @login catch-all

### DIFF
--- a/src/app/[locale]/[countryCode]/(main)/account/@login/[...catchAll]/page.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/account/@login/[...catchAll]/page.tsx
@@ -1,0 +1,5 @@
+import LoginTemplate from "@modules/account/templates/login-template"
+
+export default function AccountLoginCatchAll() {
+  return <LoginTemplate />
+}

--- a/src/modules/account/components/login/index.tsx
+++ b/src/modules/account/components/login/index.tsx
@@ -5,7 +5,7 @@ import { SubmitButton } from "@modules/checkout/components/submit-button"
 import Input from "@modules/common/components/input"
 import { useActionState } from "react"
 import { useTranslations } from "next-intl"
-import { useSearchParams } from "next/navigation"
+import { usePathname, useSearchParams } from "next/navigation"
 
 type Props = {
   setCurrentView: (view: LOGIN_VIEW) => void
@@ -15,7 +15,14 @@ const Login = ({ setCurrentView }: Props) => {
   const [message, formAction] = useActionState(login, null)
   const t = useTranslations("account")
   const searchParams = useSearchParams()
-  const redirectTo = searchParams.get("redirect")
+  const pathname = usePathname()
+
+  const redirectFromParams = searchParams.get("redirect")
+  const redirectFromPath = (() => {
+    const accountMatch = pathname?.match(/\/account\/(.+)/)
+    return accountMatch ? accountMatch[1] : null
+  })()
+  const redirectTo = redirectFromParams || redirectFromPath
 
   return (
     <div


### PR DESCRIPTION
### Motivation
- Next.js parallel routes caused unauthenticated visits to `/account/*` (e.g. `/account/orders`) to 404 because the `@login` slot only had a single `page.tsx` and could not match subpaths, so the orders page redirect logic never ran.

### Description
- Added a catch-all login page at `src/app/[locale]/[countryCode]/(main)/account/@login/[...catchAll]/page.tsx` that returns the existing `LoginTemplate` so any `/account/*` subpath renders the login UI instead of 404.
- Updated `src/modules/account/components/login/index.tsx` to compute the post-login redirect by preferring an existing `?redirect=...` search param and falling back to deriving the target from the current `pathname` after `/account/` (using a regex), and to include it as the hidden `redirect` field in the login form.
- Preserves existing page-level redirect checks (e.g. orders page `retrieveCustomer()` logic) as a secondary safeguard for authenticated redirects.

### Testing
- Attempted to run `npm run build`, but the Next.js build aborted due to a missing required environment variable `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY`, so a full build/test could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69adc624cac08333adc8e30bff81f90c)