### PR TITLE
Add SEO metadata, JSON-LD structured data, and cookie consent UI

### DIFF
--- a/src/app/[locale]/[countryCode]/(checkout)/checkout/page.tsx
+++ b/src/app/[locale]/[countryCode]/(checkout)/checkout/page.tsx
@@ -7,7 +7,9 @@ import { Metadata } from "next"
 import { notFound } from "next/navigation"
 
 export const metadata: Metadata = {
-  title: "Checkout",
+  title: "Checkout | NordHjem",
+  description: "Complete your purchase at NordHjem.",
+  robots: { index: false, follow: false },
 }
 
 export default async function Checkout() {

--- a/src/app/[locale]/[countryCode]/(main)/account/layout.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/account/layout.tsx
@@ -1,6 +1,13 @@
 import { retrieveCustomer } from "@lib/data/customer"
 import { Toaster } from "@medusajs/ui"
 import AccountLayout from "@modules/account/templates/account-layout"
+import { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "My Account | NordHjem",
+  description: "Manage your NordHjem account, orders, and addresses.",
+  robots: { index: false, follow: false },
+}
 
 export default async function AccountPageLayout({
   dashboard,

--- a/src/app/[locale]/[countryCode]/(main)/cart/page.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/cart/page.tsx
@@ -5,8 +5,9 @@ import { Metadata } from "next"
 import { notFound } from "next/navigation"
 
 export const metadata: Metadata = {
-  title: "Cart",
-  description: "View your cart",
+  title: "Shopping Cart | NordHjem",
+  description: "Review the items in your shopping cart before checkout.",
+  robots: { index: false, follow: true },
 }
 
 export default async function Cart() {

--- a/src/app/[locale]/[countryCode]/(main)/categories/[...category]/page.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/categories/[...category]/page.tsx
@@ -3,9 +3,11 @@ import { getLocale } from "next-intl/server"
 import { notFound } from "next/navigation"
 
 import { getCategoryByHandle } from "@lib/data/categories"
+import {
+  generateBreadcrumbJsonLd,
+} from "@lib/util/structured-data"
 import CategoryTemplate from "@modules/categories/templates"
 import { SortOptions } from "@modules/store/components/refinement-list/sort-products"
-
 
 export const dynamic = "force-dynamic"
 export const revalidate = 300 // 5 minutes
@@ -43,8 +45,12 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
     return {
       title,
       description,
+      openGraph: {
+        title,
+        description,
+      },
       alternates: {
-        canonical: `${params.category.join("/")}`,
+        canonical: `https://nordhjem.store/categories/${params.category.join("/")}`,
       },
     }
   } catch (error) {
@@ -64,14 +70,32 @@ export default async function CategoryPage(props: Props) {
   }
 
   const locale = await getLocale()
+  const categoryName =
+    locale === "zh" && productCategory.metadata?.zh_name
+      ? String(productCategory.metadata.zh_name)
+      : productCategory.name
+
+  const breadcrumbJsonLd = generateBreadcrumbJsonLd([
+    { name: locale === "zh" ? "首页" : "Home", item: "https://nordhjem.store" },
+    {
+      name: categoryName,
+      item: `https://nordhjem.store/categories/${params.category.join("/")}`,
+    },
+  ])
 
   return (
-    <CategoryTemplate
-      category={productCategory}
-      sortBy={sortBy}
-      page={page}
-      countryCode={params.countryCode}
-      locale={locale}
-    />
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
+      />
+      <CategoryTemplate
+        category={productCategory}
+        sortBy={sortBy}
+        page={page}
+        countryCode={params.countryCode}
+        locale={locale}
+      />
+    </>
   )
 }

--- a/src/app/[locale]/[countryCode]/(main)/collections/[handle]/page.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/collections/[handle]/page.tsx
@@ -3,11 +3,11 @@ import { notFound } from "next/navigation"
 
 import { getCollectionByHandle } from "@lib/data/collections"
 import { getLocalizedCollectionTitle } from "@lib/util/get-localized-product"
+import { generateBreadcrumbJsonLd } from "@lib/util/structured-data"
 import { StoreCollection } from "@medusajs/types"
 import CollectionTemplate from "@modules/collections/templates"
 import { SortOptions } from "@modules/store/components/refinement-list/sort-products"
 import { getLocale } from "next-intl/server"
-
 
 export const dynamic = "force-dynamic"
 export const revalidate = 300 // 5 minutes
@@ -35,13 +35,19 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
   }
 
   const collectionName = getLocalizedCollectionTitle(collection, locale)
+  const description =
+    locale === "zh" ? `${collectionName}系列` : `${collectionName} collection`
 
   return {
     title: `${collectionName} | NordHjem`,
-    description:
-      locale === "zh"
-        ? `${collectionName}系列`
-        : `${collectionName} collection`,
+    description,
+    openGraph: {
+      title: `${collectionName} | NordHjem`,
+      description,
+    },
+    alternates: {
+      canonical: `https://nordhjem.store/collections/${params.handle}`,
+    },
   }
 }
 
@@ -49,6 +55,7 @@ export default async function CollectionPage(props: Props) {
   const searchParams = await props.searchParams
   const params = await props.params
   const { sortBy, page } = searchParams
+  const locale = await getLocale()
 
   const collection = await getCollectionByHandle(params.handle).then(
     (collection: StoreCollection) => collection
@@ -58,12 +65,27 @@ export default async function CollectionPage(props: Props) {
     notFound()
   }
 
+  const collectionName = getLocalizedCollectionTitle(collection, locale)
+  const breadcrumbJsonLd = generateBreadcrumbJsonLd([
+    { name: locale === "zh" ? "首页" : "Home", item: "https://nordhjem.store" },
+    {
+      name: collectionName,
+      item: `https://nordhjem.store/collections/${params.handle}`,
+    },
+  ])
+
   return (
-    <CollectionTemplate
-      collection={collection}
-      page={page}
-      sortBy={sortBy}
-      countryCode={params.countryCode}
-    />
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
+      />
+      <CollectionTemplate
+        collection={collection}
+        page={page}
+        sortBy={sortBy}
+        countryCode={params.countryCode}
+      />
+    </>
   )
 }

--- a/src/app/[locale]/[countryCode]/(main)/layout.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/layout.tsx
@@ -4,6 +4,7 @@ import { listCartOptions, retrieveCart } from "@lib/data/cart"
 import { retrieveCustomer } from "@lib/data/customer"
 import { StoreCartShippingOption } from "@medusajs/types"
 import CartMismatchBanner from "@modules/layout/components/cart-mismatch-banner"
+import CookieConsent from "@modules/common/components/cookie-consent"
 import Footer from "@modules/layout/templates/footer"
 import Nav from "@modules/layout/templates/nav"
 import FreeShippingPriceNudge from "@modules/shipping/components/free-shipping-price-nudge"
@@ -51,6 +52,7 @@ export default async function PageLayout(props: { children: React.ReactNode }) {
       )}
       {props.children}
       <Footer />
+      <CookieConsent />
     </>
   )
 }

--- a/src/app/[locale]/[countryCode]/(main)/legal/privacy-policy/page.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/legal/privacy-policy/page.tsx
@@ -1,4 +1,10 @@
+import { Metadata } from "next"
 import { getTranslations } from "next-intl/server"
+
+export const metadata: Metadata = {
+  title: "Privacy Policy | NordHjem",
+  description: "Learn how NordHjem collects, uses, and protects your personal information.",
+}
 
 export default async function PrivacyPolicyPage() {
   const t = await getTranslations("legal.privacy")

--- a/src/app/[locale]/[countryCode]/(main)/legal/refund-policy/page.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/legal/refund-policy/page.tsx
@@ -1,4 +1,10 @@
+import { Metadata } from "next"
 import { getTranslations } from "next-intl/server"
+
+export const metadata: Metadata = {
+  title: "Refund Policy | NordHjem",
+  description: "NordHjem refund and return policy — eligibility, process, and timelines.",
+}
 
 export default async function RefundPolicyPage() {
   const t = await getTranslations("legal.refund")

--- a/src/app/[locale]/[countryCode]/(main)/legal/shipping-policy/page.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/legal/shipping-policy/page.tsx
@@ -1,4 +1,10 @@
+import { Metadata } from "next"
 import { getTranslations } from "next-intl/server"
+
+export const metadata: Metadata = {
+  title: "Shipping Policy | NordHjem",
+  description: "Shipping methods, delivery times, and international shipping at NordHjem.",
+}
 
 export default async function ShippingPolicyPage() {
   const t = await getTranslations("legal.shipping")

--- a/src/app/[locale]/[countryCode]/(main)/legal/terms-of-service/page.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/legal/terms-of-service/page.tsx
@@ -1,4 +1,10 @@
+import { Metadata } from "next"
 import { getTranslations } from "next-intl/server"
+
+export const metadata: Metadata = {
+  title: "Terms of Service | NordHjem",
+  description: "Terms and conditions for using the NordHjem online store.",
+}
 
 export default async function TermsOfServicePage() {
   const t = await getTranslations("legal.terms")

--- a/src/app/[locale]/[countryCode]/(main)/order/[id]/confirmed/page.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/order/[id]/confirmed/page.tsx
@@ -7,8 +7,9 @@ type Props = {
   params: Promise<{ id: string }>
 }
 export const metadata: Metadata = {
-  title: "Order Confirmed",
-  description: "You purchase was successful",
+  title: "Order Confirmed | NordHjem",
+  description: "Your purchase was successful. Thank you for shopping at NordHjem.",
+  robots: { index: false, follow: false },
 }
 
 export default async function OrderConfirmedPage(props: Props) {

--- a/src/app/[locale]/[countryCode]/(main)/page.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/page.tsx
@@ -1,3 +1,4 @@
+import { Metadata } from "next"
 import { getTranslations } from "next-intl/server"
 
 import FeaturedProducts from "@modules/home/components/featured-products"
@@ -6,13 +7,29 @@ import Categories from "@modules/home/components/categories"
 import LocalizedClientLink from "@modules/common/components/localized-client-link"
 import { listCollections } from "@lib/data/collections"
 import { getRegion } from "@lib/data/regions"
+import { generateWebSiteJsonLd } from "@lib/util/structured-data"
 
-export async function generateMetadata() {
-  const t = await getTranslations("site")
+export async function generateMetadata(props: {
+  params: Promise<{ countryCode: string; locale: string }>
+}): Promise<Metadata> {
+  const params = await props.params
+  const locale = params.locale || "en"
+  const t = await getTranslations({ locale, namespace: "site" })
+
+  const title = t("name") + " | " + t("tagline")
+  const description = t("description")
 
   return {
-    title: t("name") + " — " + t("tagline"),
-    description: t("description"),
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      images: [{ url: "https://nordhjem.store/opengraph-image.jpg" }],
+    },
+    alternates: {
+      canonical: `https://nordhjem.store/${locale}/${params.countryCode}`,
+    },
   }
 }
 
@@ -36,6 +53,10 @@ export default async function Home(props: {
 
   return (
     <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(generateWebSiteJsonLd()) }}
+      />
       <Hero />
       <Categories />
       <div className="py-12">

--- a/src/app/[locale]/[countryCode]/(main)/products/[handle]/page.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/products/[handle]/page.tsx
@@ -68,13 +68,18 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
       ? String(product.metadata.description_zh)
       : product.description || product.title
 
+  const ogDescription = description.slice(0, 160)
+
   return {
     title: `${title} | NordHjem`,
     description,
     openGraph: {
       title: `${title} | NordHjem`,
-      description,
+      description: ogDescription,
       images: product.thumbnail ? [product.thumbnail] : [],
+    },
+    alternates: {
+      canonical: `https://nordhjem.store/products/${handle}`,
     },
   }
 }

--- a/src/app/[locale]/[countryCode]/(main)/store/page.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/store/page.tsx
@@ -22,6 +22,13 @@ export async function generateMetadata(props: Params): Promise<Metadata> {
   return {
     title: `${t("allProducts")} | NordHjem`,
     description: t("allProducts"),
+    openGraph: {
+      title: `${t("allProducts")} | NordHjem`,
+      description: t("allProducts"),
+    },
+    alternates: {
+      canonical: "https://nordhjem.store/store",
+    },
   }
 }
 

--- a/src/lib/util/cookie-consent.ts
+++ b/src/lib/util/cookie-consent.ts
@@ -1,0 +1,31 @@
+const CONSENT_KEY = "nordhjem_cookie_consent"
+
+type ConsentState = {
+  necessary: boolean
+  analytics: boolean
+  marketing: boolean
+}
+
+export function getConsentState(): ConsentState | null {
+  if (typeof window === "undefined") return null
+
+  const stored = localStorage.getItem(CONSENT_KEY)
+
+  if (!stored) return null
+
+  try {
+    return JSON.parse(stored) as ConsentState
+  } catch {
+    return null
+  }
+}
+
+export function hasAnalyticsConsent(): boolean {
+  const consent = getConsentState()
+  return consent?.analytics ?? false
+}
+
+export function hasMarketingConsent(): boolean {
+  const consent = getConsentState()
+  return consent?.marketing ?? false
+}

--- a/src/lib/util/structured-data.ts
+++ b/src/lib/util/structured-data.ts
@@ -71,5 +71,16 @@ export function generateOrganizationJsonLd() {
     "@type": "Organization",
     name: BRAND_NAME,
     url: "https://nordhjem.store",
+    logo: "https://nordhjem.store/logo.png",
+    sameAs: [],
+  }
+}
+
+export function generateWebSiteJsonLd() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name: BRAND_NAME,
+    url: "https://nordhjem.store",
   }
 }

--- a/src/modules/common/components/cookie-consent/index.tsx
+++ b/src/modules/common/components/cookie-consent/index.tsx
@@ -1,0 +1,167 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import LocalizedClientLink from "@modules/common/components/localized-client-link"
+
+const CONSENT_KEY = "nordhjem_cookie_consent"
+
+type ConsentState = {
+  necessary: boolean
+  analytics: boolean
+  marketing: boolean
+}
+
+export default function CookieConsent() {
+  const [visible, setVisible] = useState(false)
+  const [showPreferences, setShowPreferences] = useState(false)
+  const [consent, setConsent] = useState<ConsentState>({
+    necessary: true,
+    analytics: false,
+    marketing: false,
+  })
+
+  useEffect(() => {
+    const stored = localStorage.getItem(CONSENT_KEY)
+
+    if (!stored) {
+      setVisible(true)
+      return
+    }
+
+    try {
+      JSON.parse(stored)
+    } catch {
+      localStorage.removeItem(CONSENT_KEY)
+      setVisible(true)
+    }
+  }, [])
+
+  const acceptAll = () => {
+    const fullConsent: ConsentState = {
+      necessary: true,
+      analytics: true,
+      marketing: true,
+    }
+
+    localStorage.setItem(CONSENT_KEY, JSON.stringify(fullConsent))
+    setVisible(false)
+  }
+
+  const savePreferences = () => {
+    localStorage.setItem(CONSENT_KEY, JSON.stringify(consent))
+    setVisible(false)
+  }
+
+  if (!visible) return null
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 z-50 p-4 md:p-6">
+      <div className="mx-auto max-w-4xl rounded-lg bg-[#2C3E2D]/95 p-6 text-[#FAFAF8] shadow-xl backdrop-blur-sm">
+        {!showPreferences ? (
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <p className="flex-1 text-sm leading-relaxed">
+              We use cookies to enhance your experience. By continuing, you agree to our{" "}
+              <LocalizedClientLink
+                href="/legal/cookie-policy"
+                className="underline transition-colors hover:text-[#C4A35A]"
+              >
+                Cookie Policy
+              </LocalizedClientLink>
+              .
+            </p>
+            <div className="shrink-0 flex gap-3">
+              <button
+                onClick={() => setShowPreferences(true)}
+                className="rounded border border-[#FAFAF8]/30 px-4 py-2 text-sm transition-colors hover:bg-[#FAFAF8]/10"
+              >
+                Manage Preferences
+              </button>
+              <button
+                onClick={acceptAll}
+                className="rounded bg-[#FAFAF8] px-4 py-2 text-sm font-medium text-[#2C3E2D] transition-colors hover:bg-[#FAFAF8]/90"
+              >
+                Accept All
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <h3 className="text-base font-medium">Cookie Preferences</h3>
+
+            <div className="space-y-3">
+              <label className="flex items-center justify-between">
+                <div>
+                  <span className="text-sm font-medium">Necessary Cookies</span>
+                  <p className="text-xs text-[#FAFAF8]/60">
+                    Required for the website to function. Always enabled.
+                  </p>
+                </div>
+                <input
+                  type="checkbox"
+                  checked={true}
+                  disabled
+                  className="h-4 w-4 accent-[#C4A35A]"
+                />
+              </label>
+
+              <label className="flex cursor-pointer items-center justify-between">
+                <div>
+                  <span className="text-sm font-medium">Analytics Cookies</span>
+                  <p className="text-xs text-[#FAFAF8]/60">
+                    Help us understand how visitors interact with our website.
+                  </p>
+                </div>
+                <input
+                  type="checkbox"
+                  checked={consent.analytics}
+                  onChange={(e) =>
+                    setConsent((prev) => ({
+                      ...prev,
+                      analytics: e.target.checked,
+                    }))
+                  }
+                  className="h-4 w-4 accent-[#C4A35A]"
+                />
+              </label>
+
+              <label className="flex cursor-pointer items-center justify-between">
+                <div>
+                  <span className="text-sm font-medium">Marketing Cookies</span>
+                  <p className="text-xs text-[#FAFAF8]/60">
+                    Used to deliver personalized advertisements.
+                  </p>
+                </div>
+                <input
+                  type="checkbox"
+                  checked={consent.marketing}
+                  onChange={(e) =>
+                    setConsent((prev) => ({
+                      ...prev,
+                      marketing: e.target.checked,
+                    }))
+                  }
+                  className="h-4 w-4 accent-[#C4A35A]"
+                />
+              </label>
+            </div>
+
+            <div className="flex justify-end gap-3 pt-2">
+              <button
+                onClick={() => setShowPreferences(false)}
+                className="rounded border border-[#FAFAF8]/30 px-4 py-2 text-sm transition-colors hover:bg-[#FAFAF8]/10"
+              >
+                Back
+              </button>
+              <button
+                onClick={savePreferences}
+                className="rounded bg-[#FAFAF8] px-4 py-2 text-sm font-medium text-[#2C3E2D] transition-colors hover:bg-[#FAFAF8]/90"
+              >
+                Save Preferences
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
### Motivation
- Improve SEO, social sharing, and privacy compliance by adding page metadata, Open Graph data, canonical alternates, structured data, and a cookie consent experience across the site.

### Description
- Added `Metadata` to multiple pages (home, cart, checkout, account, order-confirmed, product, collection, category, store, and legal pages) including titles, descriptions, `openGraph` entries, and `alternates.canonical` where applicable and set robots directives for non-indexable pages.
- Introduced JSON-LD structured data utilities and usage by adding `generateBreadcrumbJsonLd`, `generateWebSiteJsonLd`, and organization/website fields in `src/lib/util/structured-data.ts` and injecting breadcrumb JSON-LD on category and collection pages and website JSON-LD on the home page.
- Improved product Open Graph description truncation and added canonical alternates for product, category, collection, and store pages.
- Implemented a client-side cookie consent component at `src/modules/common/components/cookie-consent` and a small cookie consent util at `src/lib/util/cookie-consent.ts`, and mounted the consent UI in the main layout (`(main)/layout.tsx`).

### Testing
- Built the application with `next build` and the build completed successfully.
- Ran linting with `eslint` and there were no lint errors reported.
- Executed the test suite with `pnpm test` and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69adf143a3a88333a287bc7ab9eb9085)