### PR TITLE
fix: guard variant.images in product page variant image resolver

### DIFF
--- a/src/app/[locale]/[countryCode]/(main)/products/[handle]/page.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/products/[handle]/page.tsx
@@ -32,7 +32,7 @@ function getImagesForVariant(
   }
 
   const variant = product.variants!.find((v) => v.id === selectedVariantId)
-  if (!variant || !variant.images.length) {
+  if (!variant || !variant.images || !variant.images.length) {
     return product.images
   }
 


### PR DESCRIPTION
### Motivation
- Fix a runtime crash on product detail pages where `getImagesForVariant` accessed `.length` on a possibly `undefined` `variant.images`, causing `TypeError` and 404/500 responses.

### Description
- In `src/app/[locale]/[countryCode]/(main)/products/[handle]/page.tsx` the `getImagesForVariant` check was changed from `!variant || !variant.images.length` to `!variant || !variant.images || !variant.images.length` to safely handle `variant.images` being `undefined`.

### Testing
- Ran `npm run build`, which could not complete in this environment due to a missing required environment variable `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY`, so build validation did not finish.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69adf8771fac83339f844dc2fd35a2bb)