### PR TITLE
fix: reduce sitemap bloat and improve Crisp webhook notifications

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -39,3 +39,24 @@ NEXT_PUBLIC_BASE_URL=
 # Leave empty to disable GA4. Requires user cookie consent.
 # Example: G-XXXXXXXXXX
 NEXT_PUBLIC_GA4_ID=
+
+# ==========================================
+# Crisp Webhook Configuration (Optional)
+# ==========================================
+# Secret key for verifying Crisp webhook requests.
+# Append as ?key=xxx to the webhook URL in Crisp Dashboard.
+# Example: my-secret-key-123
+CRISP_WEBHOOK_SECRET=
+
+# ==========================================
+# Telegram Bot Configuration (Optional)
+# ==========================================
+# Telegram Bot Token for forwarding Crisp messages.
+# Get from @BotFather on Telegram.
+# Example: 123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11
+TELEGRAM_BOT_TOKEN=
+
+# Telegram Chat ID for receiving notifications.
+# Use the bot's /getUpdates endpoint to find your chat ID.
+# Example: -1001234567890
+TELEGRAM_CHAT_ID=

--- a/src/app/api/crisp-webhook/route.ts
+++ b/src/app/api/crisp-webhook/route.ts
@@ -34,15 +34,25 @@ export async function POST(req: NextRequest) {
 
   // 5. Build Telegram message
   const { content, type, user, session_id } = payload.data
-  const nickname = user?.nickname || "Anonymous"
-  const messageText = type === "text" ? content : `[${type}]`
+  const nickname = user?.nickname || "匿名用户"
+  const email = user?.email || "未知"
+  const messageText =
+    type === "text"
+      ? content
+      : type === "file"
+        ? "[文件]"
+        : type === "animation"
+          ? "[动图]"
+          : `[${type === "image" ? "图片" : type}]`
   const crispInboxUrl = `https://app.crisp.chat/website/${payload.website_id}/inbox/${session_id}/`
 
   const telegramText = [
-    `🔔 <b>New Crisp Message</b>`,
-    `👤 ${escapeHtml(nickname)}`,
-    `💬 ${escapeHtml(messageText)}`,
-    `🔗 <a href="${crispInboxUrl}">Open in Crisp</a>`,
+    `🗨️ <b>客服消息</b>`,
+    `👤 用户: ${escapeHtml(nickname)}`,
+    `📧 邮箱: ${escapeHtml(email)}`,
+    `💬 内容: ${escapeHtml(messageText)}`,
+    `---`,
+    `🔗 <a href="${crispInboxUrl}">回复请打开 Crisp Dashboard</a>`,
   ].join("\n")
 
   // 6. Send to Telegram with retry (1 retry on failure)
@@ -106,6 +116,7 @@ interface CrispWebhookPayload {
     user?: {
       nickname?: string
       user_id?: string
+      email?: string
     }
   }
   timestamp: number

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -6,6 +6,26 @@ import { getBaseURL } from "@lib/util/env"
 import { routing } from "@/i18n/routing"
 import { MetadataRoute } from "next"
 
+/**
+ * Active market country codes for sitemap generation.
+ * Only these countries get product/category/collection/static URLs in sitemap.
+ * This prevents sitemap bloat from Medusa's ~250 registered countries.
+ */
+const ACTIVE_COUNTRIES = [
+  "us",
+  "ca",
+  "gb",
+  "de",
+  "fr",
+  "it",
+  "nl",
+  "no",
+  "dk",
+  "fi",
+  "es",
+  "au",
+] as const
+
 const CATEGORY_CHANGE_FREQUENCY: MetadataRoute.Sitemap[number]["changeFrequency"] =
   "weekly"
 const COLLECTION_CHANGE_FREQUENCY: MetadataRoute.Sitemap[number]["changeFrequency"] =
@@ -54,13 +74,18 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     listCollections(),
   ])
 
-  const countryCodes = Array.from(
+  const allCountryCodes = Array.from(
     new Set(
       (regions ?? [])
         .flatMap((region) => region.countries ?? [])
-        .map((country) => country.iso_2)
+        .map((country) => country.iso_2?.toLowerCase())
         .filter((iso2): iso2 is string => Boolean(iso2))
     )
+  )
+
+  // Filter to active markets only to keep sitemap under Google's 50,000 URL limit
+  const countryCodes = allCountryCodes.filter((code) =>
+    ACTIVE_COUNTRIES.includes(code as (typeof ACTIVE_COUNTRIES)[number])
   )
 
   const localeCountryPairs = routing.locales.flatMap((locale) =>


### PR DESCRIPTION
### Motivation
- Prevent sitemap.xml growing beyond Google limits by restricting sitemap generation to a small set of active markets instead of all Medusa-registered countries. 
- Improve Crisp → Telegram notification clarity by switching to Chinese formatting, surfacing the user email, and handling non-text message types. 
- Confirm that Crisp customer identity binding and session reset behavior are already implemented and do not require code changes.

### Description
- Added an `ACTIVE_COUNTRIES` whitelist and normalized `iso_2` to lowercase in `src/app/sitemap.ts`, then filtered region-derived country codes against the whitelist while preserving the existing sitemap generation flow and `primaryCountryCode` fallback of `countryCodes[0] || "us"`.
- Updated `src/app/api/crisp-webhook/route.ts` to include `user.email` in the payload type, provide Chinese-formatted Telegram messages, add nickname/email fallbacks (`匿名用户` / `未知`), and map non-text message types to localized labels (`[图片]`, `[文件]`, `[动图]`, fallback to `[type]`).
- Appended optional webhook environment variables to `.env.template`: `CRISP_WEBHOOK_SECRET`, `TELEGRAM_BOT_TOKEN`, and `TELEGRAM_CHAT_ID`.
- Verified that `syncCustomerIdentity()` and `resetCrispSession()` in `src/modules/common/components/crisp-chat/index.tsx` already implement the required identity binding and logout reset behavior (no code changes required for Task C).

### Testing
- Ran static assertions with a small Python check that verified the `ACTIVE_COUNTRIES` list, sitemap filtering logic, sitemap product URL template, Crisp webhook ignore conditions, Chinese formatting and `email` field, and `.env.template` entries, and these checks passed.
- Attempted `npm run build` which initially failed due to missing required env vars (`NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY`), and a subsequent build with dummy env vars failed because the environment could not fetch Google Fonts during Next.js build (network/font fetch issue), so a full production build could not be validated here.
- Ran `npm run lint` which failed in this environment due to an existing Next lint configuration issue (`@next/next/no-html-link-for-pages` path undefined) unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ae08e7805c833393f9afeb96604cbf)