### PR TITLE
feat: enhance search sorting, add price range filters, and restock notification CTA

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -110,7 +110,14 @@
     "relatedProductsDescription": "You might also want to check out these products.",
     "adding": "Adding...",
     "from": "From",
-    "originalPrice": "Original"
+    "originalPrice": "Original",
+    "notifyWhenAvailable": "Notify When Available",
+    "enterEmail": "Enter your email",
+    "subscribe": "Subscribe",
+    "restockSubscribed": "Subscribed! We'll notify you when this item is back in stock.",
+    "restockError": "Something went wrong. Please try again.",
+    "invalidEmail": "Please enter a valid email address.",
+    "cancel": "Cancel"
   },
   "collection": {
     "title": "Collections",
@@ -494,7 +501,19 @@
     "sortBy": "Sort by",
     "latestArrivals": "Latest Arrivals",
     "priceLowToHigh": "Price: Low -> High",
-    "priceHighToLow": "Price: High -> Low"
+    "priceHighToLow": "Price: High -> Low",
+    "recommended": "Recommended",
+    "nameAZ": "Name A-Z",
+    "priceRange": "Price Range",
+    "priceRange0to500": "$0 – $500",
+    "priceRange500to1000": "$500 – $1,000",
+    "priceRange1000to2000": "$1,000 – $2,000",
+    "priceRange2000to5000": "$2,000 – $5,000",
+    "priceRange5000plus": "$5,000+",
+    "min": "Min",
+    "max": "Max",
+    "apply": "Go",
+    "clearFilter": "Clear filter"
   },
   "legal": {
     "privacy": {

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -110,7 +110,14 @@
     "relatedProductsDescription": "您可能还喜欢这些产品。",
     "adding": "添加中...",
     "from": "起",
-    "originalPrice": "原价"
+    "originalPrice": "原价",
+    "notifyWhenAvailable": "到货通知",
+    "enterEmail": "输入您的邮箱",
+    "subscribe": "订阅",
+    "restockSubscribed": "已订阅！到货后我们会通知您。",
+    "restockError": "出了点问题，请重试。",
+    "invalidEmail": "请输入有效的邮箱地址。",
+    "cancel": "取消"
   },
   "collection": {
     "title": "商品系列",
@@ -494,7 +501,19 @@
     "sortBy": "排序方式",
     "latestArrivals": "最新上架",
     "priceLowToHigh": "价格：从低到高",
-    "priceHighToLow": "价格：从高到低"
+    "priceHighToLow": "价格：从高到低",
+    "recommended": "推荐",
+    "nameAZ": "名称 A-Z",
+    "priceRange": "价格区间",
+    "priceRange0to500": "$0 – $500",
+    "priceRange500to1000": "$500 – $1,000",
+    "priceRange1000to2000": "$1,000 – $2,000",
+    "priceRange2000to5000": "$2,000 – $5,000",
+    "priceRange5000plus": "$5,000+",
+    "min": "最低",
+    "max": "最高",
+    "apply": "筛选",
+    "clearFilter": "清除筛选"
   },
   "legal": {
     "privacy": {

--- a/src/app/[locale]/[countryCode]/(main)/categories/[...category]/page.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/categories/[...category]/page.tsx
@@ -16,6 +16,8 @@ type Props = {
   searchParams: Promise<{
     sortBy?: SortOptions
     page?: string
+    min_price?: string
+    max_price?: string
   }>
 }
 
@@ -61,7 +63,7 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
 export default async function CategoryPage(props: Props) {
   const searchParams = await props.searchParams
   const params = await props.params
-  const { sortBy, page } = searchParams
+  const { sortBy, page, min_price, max_price } = searchParams
 
   const productCategory = await getCategoryByHandle(params.category)
 
@@ -95,6 +97,8 @@ export default async function CategoryPage(props: Props) {
         page={page}
         countryCode={params.countryCode}
         locale={locale}
+        minPrice={min_price}
+        maxPrice={max_price}
       />
     </>
   )

--- a/src/app/[locale]/[countryCode]/(main)/collections/[handle]/page.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/collections/[handle]/page.tsx
@@ -16,6 +16,8 @@ type Props = {
   searchParams: Promise<{
     page?: string
     sortBy?: SortOptions
+    min_price?: string
+    max_price?: string
   }>
 }
 
@@ -54,7 +56,7 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
 export default async function CollectionPage(props: Props) {
   const searchParams = await props.searchParams
   const params = await props.params
-  const { sortBy, page } = searchParams
+  const { sortBy, page, min_price, max_price } = searchParams
   const locale = await getLocale()
 
   const collection = await getCollectionByHandle(params.handle).then(
@@ -85,6 +87,8 @@ export default async function CollectionPage(props: Props) {
         page={page}
         sortBy={sortBy}
         countryCode={params.countryCode}
+        minPrice={min_price}
+        maxPrice={max_price}
       />
     </>
   )

--- a/src/app/[locale]/[countryCode]/(main)/store/page.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/store/page.tsx
@@ -8,6 +8,8 @@ type Params = {
   searchParams: Promise<{
     sortBy?: SortOptions
     page?: string
+    min_price?: string
+    max_price?: string
   }>
   params: Promise<{
     countryCode: string
@@ -35,13 +37,15 @@ export async function generateMetadata(props: Params): Promise<Metadata> {
 export default async function StorePage(props: Params) {
   const params = await props.params
   const searchParams = await props.searchParams
-  const { sortBy, page } = searchParams
+  const { sortBy, page, min_price, max_price } = searchParams
 
   return (
     <StoreTemplate
       sortBy={sortBy}
       page={page}
       countryCode={params.countryCode}
+      minPrice={min_price}
+      maxPrice={max_price}
     />
   )
 }

--- a/src/lib/util/sort-products.ts
+++ b/src/lib/util/sort-products.ts
@@ -46,5 +46,15 @@ export function sortProducts(
     })
   }
 
+  if (sortBy === "name_asc") {
+    sortedProducts.sort((a, b) => {
+      const nameA = (a.title || "").toLowerCase()
+      const nameB = (b.title || "").toLowerCase()
+      return nameA.localeCompare(nameB)
+    })
+  }
+
+  // "recommended" keeps the default API order (no sorting)
+
   return sortedProducts
 }

--- a/src/modules/categories/templates/index.tsx
+++ b/src/modules/categories/templates/index.tsx
@@ -25,15 +25,19 @@ export default function CategoryTemplate({
   page,
   countryCode,
   locale,
+  minPrice,
+  maxPrice,
 }: {
   category: HttpTypes.StoreProductCategory
   sortBy?: SortOptions
   page?: string
   countryCode: string
   locale?: string | null
+  minPrice?: string
+  maxPrice?: string
 }) {
   const pageNumber = page ? parseInt(page) : 1
-  const sort = sortBy || "created_at"
+  const sort = sortBy || "recommended"
 
   if (!category || !countryCode) notFound()
 
@@ -103,6 +107,8 @@ export default function CategoryTemplate({
             page={pageNumber}
             categoryId={category.id}
             countryCode={countryCode}
+            minPrice={minPrice}
+            maxPrice={maxPrice}
           />
         </Suspense>
       </div>

--- a/src/modules/collections/templates/index.tsx
+++ b/src/modules/collections/templates/index.tsx
@@ -13,15 +13,19 @@ export default async function CollectionTemplate({
   collection,
   page,
   countryCode,
+  minPrice,
+  maxPrice,
 }: {
   sortBy?: SortOptions
   collection: HttpTypes.StoreCollection
   page?: string
   countryCode: string
+  minPrice?: string
+  maxPrice?: string
 }) {
   const t = await getTranslations("collection")
   const pageNumber = page ? parseInt(page) : 1
-  const sort = sortBy || "created_at"
+  const sort = sortBy || "recommended"
 
   return (
     <div className="flex flex-col small:flex-row small:items-start py-6 content-container">
@@ -44,6 +48,8 @@ export default async function CollectionTemplate({
             page={pageNumber}
             collectionId={collection.id}
             countryCode={countryCode}
+            minPrice={minPrice}
+            maxPrice={maxPrice}
           />
         </Suspense>
       </div>

--- a/src/modules/products/components/product-actions/index.tsx
+++ b/src/modules/products/components/product-actions/index.tsx
@@ -17,6 +17,7 @@ import {
 import { useLocale, useTranslations } from "next-intl"
 import { useEffect, useMemo, useRef, useState } from "react"
 import ProductPrice from "../product-price"
+import RestockNotification from "../restock-notification"
 import MobileActions from "./mobile-actions"
 
 type ProductActionsProps = {
@@ -205,26 +206,30 @@ export default function ProductActions({
 
         <ProductPrice product={product} variant={selectedVariant} />
 
-        <Button
-          onClick={handleAddToCart}
-          disabled={
-            !inStock ||
-            !selectedVariant ||
-            !!disabled ||
-            isAdding ||
-            !isValidVariant
-          }
-          variant="primary"
-          className="w-full h-10"
-          isLoading={isAdding}
-          data-testid="add-product-button"
-        >
-          {!selectedVariant
-            ? t("selectVariant")
-            : !inStock || !isValidVariant
-            ? t("outOfStock")
-            : t("addToCart")}
-        </Button>
+        {selectedVariant && !inStock ? (
+          <RestockNotification
+            variantId={selectedVariant.id}
+            userEmail={undefined}
+          />
+        ) : (
+          <Button
+            onClick={handleAddToCart}
+            disabled={
+              !selectedVariant ||
+              !!disabled ||
+              isAdding ||
+              !isValidVariant
+            }
+            variant="primary"
+            className="w-full h-10"
+            isLoading={isAdding}
+            data-testid="add-product-button"
+          >
+            {!selectedVariant
+              ? t("selectVariant")
+              : t("addToCart")}
+          </Button>
+        )}
         <MobileActions
           product={product}
           variant={selectedVariant}

--- a/src/modules/products/components/restock-notification/index.tsx
+++ b/src/modules/products/components/restock-notification/index.tsx
@@ -1,0 +1,124 @@
+"use client"
+
+import { useState } from "react"
+import { Button } from "@medusajs/ui"
+import { useTranslations } from "next-intl"
+
+type RestockNotificationProps = {
+  variantId: string
+  userEmail?: string
+}
+
+const RestockNotification = ({ variantId, userEmail }: RestockNotificationProps) => {
+  const t = useTranslations("product")
+  const [showForm, setShowForm] = useState(false)
+  const [email, setEmail] = useState(userEmail || "")
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [isSubscribed, setIsSubscribed] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const isValidEmail = (email: string) => {
+    return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)
+  }
+
+  const handleSubmit = async () => {
+    if (!isValidEmail(email)) {
+      setError(t("invalidEmail"))
+      return
+    }
+
+    setIsSubmitting(true)
+    setError(null)
+
+    try {
+      const res = await fetch("/store/restock-subscriptions", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-publishable-api-key": process.env.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY || "",
+        },
+        body: JSON.stringify({
+          variant_id: variantId,
+          email,
+        }),
+      })
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        if (res.status === 409 || data?.message?.includes("already")) {
+          setIsSubscribed(true)
+          setShowForm(false)
+          return
+        }
+        throw new Error(data?.message || t("restockError"))
+      }
+
+      setIsSubscribed(true)
+      setShowForm(false)
+    } catch (err: any) {
+      setError(err.message || t("restockError"))
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  if (isSubscribed) {
+    return (
+      <div className="w-full text-center py-3 px-4 bg-green-50 border border-green-200 rounded text-green-800 text-sm">
+        ✓ {t("restockSubscribed")}
+      </div>
+    )
+  }
+
+  if (!showForm) {
+    return (
+      <Button
+        onClick={() => setShowForm(true)}
+        variant="secondary"
+        className="w-full h-10"
+      >
+        {t("notifyWhenAvailable")}
+      </Button>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-y-2 w-full">
+      <div className="flex gap-2">
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => {
+            setEmail(e.target.value)
+            setError(null)
+          }}
+          placeholder={t("enterEmail")}
+          className="flex-1 text-sm border border-gray-200 rounded px-3 py-2 focus:outline-none focus:border-[#2C3E2D]"
+        />
+        <Button
+          onClick={handleSubmit}
+          variant="primary"
+          className="h-10 px-4"
+          isLoading={isSubmitting}
+          disabled={!email || isSubmitting}
+        >
+          {t("subscribe")}
+        </Button>
+      </div>
+      {error && (
+        <p className="text-sm text-red-500">{error}</p>
+      )}
+      <button
+        onClick={() => {
+          setShowForm(false)
+          setError(null)
+        }}
+        className="text-sm text-gray-500 underline text-left"
+      >
+        {t("cancel")}
+      </button>
+    </div>
+  )
+}
+
+export default RestockNotification

--- a/src/modules/store/components/refinement-list/index.tsx
+++ b/src/modules/store/components/refinement-list/index.tsx
@@ -1,39 +1,42 @@
 "use client"
 
 import { usePathname, useRouter, useSearchParams } from "next/navigation"
-import { useCallback } from "react"
 
 import SortProducts, { SortOptions } from "./sort-products"
+import PriceFilter from "./price-filter"
 
 type RefinementListProps = {
   sortBy: SortOptions
   search?: boolean
-  'data-testid'?: string
+  "data-testid"?: string
 }
 
-const RefinementList = ({ sortBy, 'data-testid': dataTestId }: RefinementListProps) => {
+const RefinementList = ({ sortBy, "data-testid": dataTestId }: RefinementListProps) => {
   const router = useRouter()
   const pathname = usePathname()
   const searchParams = useSearchParams()
 
-  const createQueryString = useCallback(
-    (name: string, value: string) => {
-      const params = new URLSearchParams(searchParams)
-      params.set(name, value)
-
-      return params.toString()
-    },
-    [searchParams]
-  )
-
   const setQueryParams = (name: string, value: string) => {
-    const query = createQueryString(name, value)
-    router.push(`${pathname}?${query}`)
+    const params = new URLSearchParams(searchParams?.toString())
+    params.set(name, value)
+    router.push(`${pathname}?${params.toString()}`)
+  }
+
+  const clearQueryParam = (name: string) => {
+    const params = new URLSearchParams(searchParams?.toString())
+    params.delete(name)
+    router.push(`${pathname}?${params.toString()}`)
   }
 
   return (
     <div className="flex small:flex-col gap-12 py-4 mb-8 small:px-0 pl-6 small:min-w-[250px] small:ml-[1.675rem]">
       <SortProducts sortBy={sortBy} setQueryParams={setQueryParams} data-testid={dataTestId} />
+      <PriceFilter
+        minPrice={searchParams?.get("min_price") || undefined}
+        maxPrice={searchParams?.get("max_price") || undefined}
+        setQueryParams={setQueryParams}
+        clearQueryParam={clearQueryParam}
+      />
     </div>
   )
 }

--- a/src/modules/store/components/refinement-list/price-filter/index.tsx
+++ b/src/modules/store/components/refinement-list/price-filter/index.tsx
@@ -1,0 +1,143 @@
+"use client"
+
+import { FormEvent } from "react"
+import { useTranslations } from "next-intl"
+
+export type PriceRange = {
+  min?: number
+  max?: number
+}
+
+type PriceFilterProps = {
+  minPrice?: string
+  maxPrice?: string
+  setQueryParams: (name: string, value: string) => void
+  clearQueryParam: (name: string) => void
+}
+
+const PRESET_RANGES = [
+  { min: 0, max: 500, labelKey: "priceRange0to500" },
+  { min: 500, max: 1000, labelKey: "priceRange500to1000" },
+  { min: 1000, max: 2000, labelKey: "priceRange1000to2000" },
+  { min: 2000, max: 5000, labelKey: "priceRange2000to5000" },
+  { min: 5000, max: undefined, labelKey: "priceRange5000plus" },
+] as const
+
+const PriceFilter = ({
+  minPrice,
+  maxPrice,
+  setQueryParams,
+  clearQueryParam,
+}: PriceFilterProps) => {
+  const t = useTranslations("store")
+
+  const isActive = (min: number, max: number | undefined) => {
+    const currentMin = minPrice ? parseInt(minPrice) : undefined
+    const currentMax = maxPrice ? parseInt(maxPrice) : undefined
+    return currentMin === min && currentMax === max
+  }
+
+  const handlePresetClick = (min: number, max: number | undefined) => {
+    if (isActive(min, max)) {
+      clearQueryParam("min_price")
+      clearQueryParam("max_price")
+      return
+    }
+    setQueryParams("min_price", String(min))
+    if (max !== undefined) {
+      setQueryParams("max_price", String(max))
+    } else {
+      clearQueryParam("max_price")
+    }
+  }
+
+  const handleCustomSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    const formData = new FormData(e.currentTarget)
+    let min = formData.get("custom_min") as string
+    let max = formData.get("custom_max") as string
+
+    if (min && max && parseInt(min) > parseInt(max)) {
+      const temp = min
+      min = max
+      max = temp
+    }
+
+    if (min) {
+      setQueryParams("min_price", min)
+    } else {
+      clearQueryParam("min_price")
+    }
+    if (max) {
+      setQueryParams("max_price", max)
+    } else {
+      clearQueryParam("max_price")
+    }
+  }
+
+  const handleClear = () => {
+    clearQueryParam("min_price")
+    clearQueryParam("max_price")
+  }
+
+  const hasActiveFilter = minPrice || maxPrice
+
+  return (
+    <div className="flex flex-col gap-y-3">
+      <span className="text-base-semi text-[#2C3E2D]">{t("priceRange")}</span>
+
+      <div className="flex flex-col gap-y-2">
+        {PRESET_RANGES.map((range) => (
+          <button
+            key={range.labelKey}
+            onClick={() => handlePresetClick(range.min, range.max)}
+            className={`text-left text-sm px-3 py-1.5 rounded border transition-colors ${
+              isActive(range.min, range.max)
+                ? "border-[#2C3E2D] bg-[#2C3E2D] text-white"
+                : "border-gray-200 hover:border-[#2C3E2D] text-gray-700"
+            }`}
+          >
+            {t(range.labelKey)}
+          </button>
+        ))}
+      </div>
+
+      <form onSubmit={handleCustomSubmit} className="flex items-center gap-2 mt-2">
+        <input
+          type="number"
+          name="custom_min"
+          placeholder={t("min")}
+          defaultValue={minPrice || ""}
+          min={0}
+          className="w-20 text-sm border border-gray-200 rounded px-2 py-1 focus:outline-none focus:border-[#2C3E2D]"
+        />
+        <span className="text-gray-400">—</span>
+        <input
+          type="number"
+          name="custom_max"
+          placeholder={t("max")}
+          defaultValue={maxPrice || ""}
+          min={0}
+          className="w-20 text-sm border border-gray-200 rounded px-2 py-1 focus:outline-none focus:border-[#2C3E2D]"
+        />
+        <button
+          type="submit"
+          className="text-sm px-2 py-1 bg-[#2C3E2D] text-white rounded hover:bg-[#1a2a1b] transition-colors"
+        >
+          {t("apply")}
+        </button>
+      </form>
+
+      {hasActiveFilter && (
+        <button
+          onClick={handleClear}
+          className="text-sm text-[#2C3E2D] underline text-left"
+        >
+          {t("clearFilter")}
+        </button>
+      )}
+    </div>
+  )
+}
+
+export default PriceFilter

--- a/src/modules/store/components/refinement-list/sort-products/index.tsx
+++ b/src/modules/store/components/refinement-list/sort-products/index.tsx
@@ -3,7 +3,7 @@
 import FilterRadioGroup from "@modules/common/components/filter-radio-group"
 import { useTranslations } from "next-intl"
 
-export type SortOptions = "price_asc" | "price_desc" | "created_at"
+export type SortOptions = "recommended" | "price_asc" | "price_desc" | "created_at" | "name_asc"
 
 type SortProductsProps = {
   sortBy: SortOptions
@@ -20,6 +20,10 @@ const SortProducts = ({
 
   const sortOptions = [
     {
+      value: "recommended" as const,
+      label: t("recommended"),
+    },
+    {
       value: "created_at" as const,
       label: t("latestArrivals"),
     },
@@ -30,6 +34,10 @@ const SortProducts = ({
     {
       value: "price_desc" as const,
       label: t("priceHighToLow"),
+    },
+    {
+      value: "name_asc" as const,
+      label: t("nameAZ"),
     },
   ]
 

--- a/src/modules/store/templates/index.tsx
+++ b/src/modules/store/templates/index.tsx
@@ -11,14 +11,18 @@ const StoreTemplate = async ({
   sortBy,
   page,
   countryCode,
+  minPrice,
+  maxPrice,
 }: {
   sortBy?: SortOptions
   page?: string
   countryCode: string
+  minPrice?: string
+  maxPrice?: string
 }) => {
   const t = await getTranslations("store")
   const pageNumber = page ? parseInt(page) : 1
-  const sort = sortBy || "created_at"
+  const sort = sortBy || "recommended"
 
   return (
     <div
@@ -35,6 +39,8 @@ const StoreTemplate = async ({
             sortBy={sort}
             page={pageNumber}
             countryCode={countryCode}
+            minPrice={minPrice}
+            maxPrice={maxPrice}
           />
         </Suspense>
       </div>

--- a/src/modules/store/templates/paginated-products.tsx
+++ b/src/modules/store/templates/paginated-products.tsx
@@ -4,7 +4,6 @@ import ProductPreview from "@modules/products/components/product-preview"
 import { Pagination } from "@modules/store/components/pagination"
 import { SortOptions } from "@modules/store/components/refinement-list/sort-products"
 
-const PRODUCT_LIMIT = 12
 
 type PaginatedProductsParams = {
   limit: number
@@ -21,6 +20,8 @@ export default async function PaginatedProducts({
   categoryId,
   productsIds,
   countryCode,
+  minPrice,
+  maxPrice,
 }: {
   sortBy?: SortOptions
   page: number
@@ -28,6 +29,8 @@ export default async function PaginatedProducts({
   categoryId?: string
   productsIds?: string[]
   countryCode: string
+  minPrice?: string
+  maxPrice?: string
 }) {
   const queryParams: PaginatedProductsParams = {
     limit: 12,
@@ -58,13 +61,30 @@ export default async function PaginatedProducts({
   let {
     response: { products, count },
   } = await listProductsWithSort({
-    page,
-    queryParams,
+    page: 1,
+    queryParams: { ...queryParams, limit: 100 },
     sortBy,
     countryCode,
   })
 
-  const totalPages = Math.ceil(count / PRODUCT_LIMIT)
+  const minPriceNum = minPrice ? parseInt(minPrice) : undefined
+  const maxPriceNum = maxPrice ? parseInt(maxPrice) : undefined
+
+  if (minPriceNum !== undefined || maxPriceNum !== undefined) {
+    products = products.filter((product) => {
+      const price = product.variants?.[0]?.calculated_price?.calculated_amount
+      if (price == null) return false
+      if (minPriceNum !== undefined && price < minPriceNum) return false
+      if (maxPriceNum !== undefined && price > maxPriceNum) return false
+      return true
+    })
+    count = products.length
+  }
+
+  const limit = 12
+  const offset = (page - 1) * limit
+  products = products.slice(offset, offset + limit)
+  const totalPages = Math.ceil(count / limit)
 
   return (
     <>


### PR DESCRIPTION
### Motivation
- Implement CTO-requested sorting enhancements by adding `recommended` (default) and `name_asc` options and make sorting more flexible across store/collection/category pages.  
- Provide client-side price-range filtering in the store sidebar so users can quickly filter the currently fetched product set without server changes.  
- Replace the static out-of-stock button with a subscribe flow so customers can sign up for restock notifications that POST to the `restock-subscriptions` API.  
- Skills used: no external skill files were required; changes were implemented directly in the codebase.

### Description
- Extended sort options by updating `SortOptions` and the sort menu in `src/modules/store/components/refinement-list/sort-products/index.tsx` to include `recommended` and `name_asc`, and set default sort to `recommended` in store/collection/category templates (`src/modules/store/templates/index.tsx`, `src/modules/collections/templates/index.tsx`, `src/modules/categories/templates/index.tsx`).
- Added title sorting (`name_asc`) and preserved `recommended` as a no-op in `src/lib/util/sort-products.ts` so API order is kept when requested.
- Added a new `PriceFilter` component at `src/modules/store/components/refinement-list/price-filter/index.tsx` and integrated it into `RefinementList` (`src/modules/store/components/refinement-list/index.tsx`); query params `min_price`/`max_price` are set/cleared via URL.
- Implemented client-side price filtering and post-filter pagination in `src/modules/store/templates/paginated-products.tsx`, and threaded `min_price`/`max_price` through page routes and templates (`src/app/.../store/page.tsx`, `.../collections/[handle]/page.tsx`, `.../categories/[...category]/page.tsx`).
- Added `RestockNotification` component at `src/modules/products/components/restock-notification/index.tsx` and switched PDP behavior in `src/modules/products/components/product-actions/index.tsx` to show the subscribe UI when a selected variant is out of stock; the component validates email, POSTs to `/store/restock-subscriptions`, treats `409` (duplicate) as success, and shows success/error states.
- Added i18n keys for English and Chinese in `messages/en.json` and `messages/zh.json` for sorting, price ranges, and restock messages.

### Testing
- Attempted production build with `npm run build` failed due to missing required env var `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY` (expected); command: `npm run build` (failed).
- Attempted build with a dummy key (`NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY=dummy npm run build`) failed in this environment due to inability to fetch Google Fonts during Next.js font processing (external network/font fetch in CI); command: `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY=dummy npm run build` (failed).
- Lint check (`NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY=dummy npm run lint`) surfaced an existing baseline Next lint rule loading issue unrelated to these changes; command: `npm run lint` (failed - baseline issue).
- Type-check (`npx tsc --noEmit`) reports pre-existing project TypeScript issues beyond the scope of these changes; one nullable `searchParams` path was handled in the refinement list to reduce a TS complaint; command: `npx tsc --noEmit` (failed - baseline issues).
- Dev server started successfully (`NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY=dummy npm run dev`) and a Playwright-driven screenshot of the updated store page was captured to validate the UI changes locally (dev run succeeded and screenshot produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ae126c4d3c83339907b3e443d7f3ae)