### PR TITLE
feat: after-sales UI (return image uploads) + after-sales history page and account i18n/password improvements

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -427,7 +427,36 @@
     },
     "gotQuestions": "Got questions?",
     "gotQuestionsDescription": "You can find frequently asked questions and answers on our customer service page.",
-    "customerService": "Customer Service"
+    "customerService": "Customer Service",
+    "afterSales": "After-Sales",
+    "afterSalesDescription": "View your return, exchange, and claim history.",
+    "afterSalesAll": "All",
+    "afterSalesReturns": "Returns",
+    "afterSalesExchanges": "Exchanges",
+    "afterSalesClaims": "Claims",
+    "noAfterSales": "No after-sales records yet.",
+    "afterSalesOrderLink": "Order",
+    "afterSalesItems": "{count} items",
+    "passwordLabel": "Password",
+    "passwordDescription": "Manage your account password",
+    "oldPassword": "Current password",
+    "newPasswordLabel": "New password",
+    "confirmPasswordLabel": "Confirm new password",
+    "passwordMismatch": "Passwords do not match",
+    "passwordTooShort": "Password must be at least 8 characters",
+    "incorrectPassword": "Current password is incorrect",
+    "passwordUpdateFailed": "Failed to update password. Please try again.",
+    "passwordUpdated": "Password updated successfully",
+    "passwordNotShown": "Password is not shown for security reasons",
+    "signedInAs": "Signed in as:",
+    "completed": "Completed",
+    "saved": "Saved",
+    "recentOrders": "Recent orders",
+    "noRecentOrders": "No recent orders",
+    "profileDescription": "View and update your profile information, including your name, email, and phone number.",
+    "previousPage": "← Previous",
+    "nextPage": "Next →",
+    "pageIndicator": "Page {page}"
   },
   "trackOrder": {
     "title": "Track Your Order",
@@ -657,7 +686,13 @@
       "received": "Received",
       "canceled": "Canceled",
       "partially_received": "Partially Received"
-    }
+    },
+    "uploadImages": "Upload images (optional)",
+    "uploadImagesDescription": "Add photos of the items you want to return (max 3 images)",
+    "maxFileSize": "Max 5MB per image",
+    "tooManyImages": "Maximum 3 images allowed",
+    "imageTooLarge": "Image exceeds 5MB limit",
+    "removeImage": "Remove"
   },
   "exchanges": {
     "statusTitle": "Exchanges",
@@ -668,7 +703,10 @@
       "active": "Active",
       "completed": "Completed",
       "canceled": "Canceled"
-    }
+    },
+    "originalItems": "Original items",
+    "contactSupport": "Contact Support",
+    "exchangeProgress": "Exchange in progress"
   },
   "claims": {
     "statusTitle": "Claims",
@@ -685,7 +723,11 @@
       "active": "Active",
       "completed": "Completed",
       "canceled": "Canceled"
-    }
+    },
+    "claimReason": "Reason",
+    "claimNote": "Note",
+    "contactSupport": "Contact Support",
+    "claimProgress": "Claim in progress"
   },
   "about": {
     "title": "About NordHjem",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -427,7 +427,36 @@
     },
     "gotQuestions": "有疑问？",
     "gotQuestionsDescription": "您可以在我们的客户服务页面找到常见问题和答案。",
-    "customerService": "客户服务"
+    "customerService": "客户服务",
+    "afterSales": "售后记录",
+    "afterSalesDescription": "查看退货、换货和索赔记录。",
+    "afterSalesAll": "全部",
+    "afterSalesReturns": "退货",
+    "afterSalesExchanges": "换货",
+    "afterSalesClaims": "索赔",
+    "noAfterSales": "暂无售后记录。",
+    "afterSalesOrderLink": "订单",
+    "afterSalesItems": "{count} 件商品",
+    "passwordLabel": "密码",
+    "passwordDescription": "管理账户密码",
+    "oldPassword": "当前密码",
+    "newPasswordLabel": "新密码",
+    "confirmPasswordLabel": "确认新密码",
+    "passwordMismatch": "两次输入的密码不一致",
+    "passwordTooShort": "密码至少需要 8 个字符",
+    "incorrectPassword": "当前密码不正确",
+    "passwordUpdateFailed": "密码更新失败，请重试。",
+    "passwordUpdated": "密码更新成功",
+    "passwordNotShown": "出于安全原因不显示密码",
+    "signedInAs": "登录账号：",
+    "completed": "已完成",
+    "saved": "已保存",
+    "recentOrders": "最近订单",
+    "noRecentOrders": "暂无最近订单",
+    "profileDescription": "查看和更新个人信息，包括姓名、邮箱和电话号码。",
+    "previousPage": "← 上一页",
+    "nextPage": "下一页 →",
+    "pageIndicator": "第 {page} 页"
   },
   "trackOrder": {
     "title": "订单查询",
@@ -657,7 +686,13 @@
       "received": "已签收",
       "canceled": "已取消",
       "partially_received": "部分签收"
-    }
+    },
+    "uploadImages": "上传图片（可选）",
+    "uploadImagesDescription": "添加退货商品照片（最多3张）",
+    "maxFileSize": "每张图片最大 5MB",
+    "tooManyImages": "最多上传 3 张图片",
+    "imageTooLarge": "图片超过 5MB 限制",
+    "removeImage": "移除"
   },
   "exchanges": {
     "statusTitle": "换货记录",
@@ -668,7 +703,10 @@
       "active": "处理中",
       "completed": "已完成",
       "canceled": "已取消"
-    }
+    },
+    "originalItems": "原商品",
+    "contactSupport": "联系客服",
+    "exchangeProgress": "换货处理中"
   },
   "claims": {
     "statusTitle": "索赔记录",
@@ -685,7 +723,11 @@
       "active": "处理中",
       "completed": "已完成",
       "canceled": "已取消"
-    }
+    },
+    "claimReason": "原因",
+    "claimNote": "备注",
+    "contactSupport": "联系客服",
+    "claimProgress": "索赔处理中"
   },
   "about": {
     "title": "关于 NordHjem",

--- a/src/app/[locale]/[countryCode]/(main)/account/@dashboard/after-sales/page.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/account/@dashboard/after-sales/page.tsx
@@ -1,0 +1,83 @@
+import { retrieveCustomer } from "@lib/data/customer"
+import { listOrders } from "@lib/data/orders"
+import AfterSalesHistory from "@modules/account/components/after-sales-history"
+import { Metadata } from "next"
+import { redirect } from "next/navigation"
+import { getTranslations } from "next-intl/server"
+
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("account")
+  return {
+    title: t("afterSales"),
+    description: t("afterSalesDescription"),
+  }
+}
+
+type Props = {
+  params: Promise<{ countryCode: string }>
+}
+
+export default async function AfterSalesPage(props: Props) {
+  const customer = await retrieveCustomer().catch(() => null)
+  const { countryCode } = await props.params
+  const t = await getTranslations("account")
+
+  if (!customer) {
+    redirect(`/${countryCode}/account`)
+  }
+
+  const orders = (await listOrders(100, 0).catch(() => [])) || []
+
+  const records = orders
+    .flatMap((order) => {
+      const returns = (order as any).returns || []
+      const exchanges = (order as any).exchanges || []
+      const claims = (order as any).claims || []
+
+      return [
+        ...returns.map((ret: any) => ({
+          id: ret.id,
+          type: "return" as const,
+          orderId: order.id,
+          orderDisplayId: order.display_id,
+          createdAt: ret.created_at,
+          status: ret.status || "active",
+          itemsCount: ret.items?.length || 0,
+          refundAmount: ret.refund_amount,
+        })),
+        ...exchanges.map((exchange: any) => ({
+          id: exchange.id,
+          type: "exchange" as const,
+          orderId: order.id,
+          orderDisplayId: order.display_id,
+          createdAt: exchange.created_at,
+          status: exchange.canceled_at ? "canceled" : "active",
+          itemsCount: (exchange.additional_items || []).length,
+        })),
+        ...claims.map((claim: any) => ({
+          id: claim.id,
+          type: "claim" as const,
+          orderId: order.id,
+          orderDisplayId: order.display_id,
+          createdAt: claim.created_at,
+          status: claim.canceled_at ? "canceled" : "active",
+          itemsCount: (claim.claim_items || []).length,
+          refundAmount: claim.refund_amount,
+        })),
+      ]
+    })
+    .sort((a, b) => +new Date(b.createdAt) - +new Date(a.createdAt))
+
+  return (
+    <div className="w-full" data-testid="after-sales-page-wrapper">
+      <div className="mb-8 flex flex-col gap-y-4">
+        <h1 className="text-2xl-semi">{t("afterSales")}</h1>
+        <p className="text-base-regular">{t("afterSalesDescription")}</p>
+      </div>
+      <AfterSalesHistory
+        records={records}
+        currencyCode={orders[0]?.currency_code || "USD"}
+      />
+    </div>
+  )
+}

--- a/src/app/[locale]/[countryCode]/(main)/account/@dashboard/orders/page.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/account/@dashboard/orders/page.tsx
@@ -74,16 +74,16 @@ export default async function Orders(props: Props) {
                 href={`?page=${currentPage - 1}`}
                 className="text-sm text-ui-fg-interactive hover:text-ui-fg-interactive-hover"
               >
-                {t("orders") === "订单历史" ? "← 上一页" : "← Previous"}
+                {t("previousPage")}
               </a>
             ) : (
               <span className="text-sm text-ui-fg-disabled">
-                {t("orders") === "订单历史" ? "← 上一页" : "← Previous"}
+                {t("previousPage")}
               </span>
             )}
 
             <span className="text-sm text-ui-fg-subtle">
-              {t("orders") === "订单历史" ? `第 ${currentPage} 页` : `Page ${currentPage}`}
+              {t("pageIndicator", { page: currentPage })}
             </span>
 
             {hasNextPage ? (
@@ -91,11 +91,11 @@ export default async function Orders(props: Props) {
                 href={`?page=${currentPage + 1}`}
                 className="text-sm text-ui-fg-interactive hover:text-ui-fg-interactive-hover"
               >
-                {t("orders") === "订单历史" ? "下一页 →" : "Next →"}
+                {t("nextPage")}
               </a>
             ) : (
               <span className="text-sm text-ui-fg-disabled">
-                {t("orders") === "订单历史" ? "下一页 →" : "Next →"}
+                {t("nextPage")}
               </span>
             )}
           </div>

--- a/src/app/[locale]/[countryCode]/(main)/account/@dashboard/profile/page.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/account/@dashboard/profile/page.tsx
@@ -9,15 +9,21 @@ import ProfilePassword from "@modules/account/components/profile-password"
 import { notFound } from "next/navigation"
 import { listRegions } from "@lib/data/regions"
 import { retrieveCustomer } from "@lib/data/customer"
+import { getTranslations } from "next-intl/server"
 
-export const metadata: Metadata = {
-  title: "Profile",
-  description: "View and edit your NordHjem profile.",
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("account")
+
+  return {
+    title: t("profile"),
+    description: t("profileDescription"),
+  }
 }
 
 export default async function Profile() {
   const customer = await retrieveCustomer()
   const regions = await listRegions()
+  const t = await getTranslations("account")
 
   if (!customer || !regions) {
     notFound()
@@ -26,12 +32,8 @@ export default async function Profile() {
   return (
     <div className="w-full" data-testid="profile-page-wrapper">
       <div className="mb-8 flex flex-col gap-y-4">
-        <h1 className="text-2xl-semi">Profile</h1>
-        <p className="text-base-regular">
-          View and update your profile information, including your name, email,
-          and phone number. You can also update your billing address, or change
-          your password.
-        </p>
+        <h1 className="text-2xl-semi">{t("profile")}</h1>
+        <p className="text-base-regular">{t("profileDescription")}</p>
       </div>
       <div className="flex flex-col gap-y-8 w-full">
         <ProfileName customer={customer} />
@@ -40,8 +42,8 @@ export default async function Profile() {
         <Divider />
         <ProfilePhone customer={customer} />
         <Divider />
-        {/* <ProfilePassword customer={customer} />
-        <Divider /> */}
+        <ProfilePassword customer={customer} />
+        <Divider />
         <ProfileBillingAddress customer={customer} regions={regions} />
       </div>
     </div>
@@ -51,4 +53,3 @@ export default async function Profile() {
 const Divider = () => {
   return <div className="w-full h-px bg-gray-200" />
 }
-;``

--- a/src/lib/data/customer.ts
+++ b/src/lib/data/customer.ts
@@ -59,6 +59,89 @@ export const updateCustomer = async (body: HttpTypes.StoreUpdateCustomer) => {
   return updateRes
 }
 
+export const updateCustomerPassword = async (
+  currentState: Record<string, unknown>,
+  formData: FormData
+): Promise<{
+  success: boolean
+  error: string | null
+  translations?: Record<string, string>
+}> => {
+  const oldPassword = formData.get("old_password") as string
+  const newPassword = formData.get("new_password") as string
+  const confirmPassword = formData.get("confirm_password") as string
+  const t = (currentState.translations as Record<string, string>) || {}
+
+  if (!oldPassword || !newPassword || !confirmPassword) {
+    return {
+      success: false,
+      error: t.passwordUpdateFailed || "Invalid input",
+      translations: t,
+    }
+  }
+
+  if (newPassword !== confirmPassword) {
+    return {
+      success: false,
+      error: t.passwordMismatch || "Passwords do not match",
+      translations: t,
+    }
+  }
+
+  if (newPassword.length < 8) {
+    return {
+      success: false,
+      error: t.passwordTooShort || "Password must be at least 8 characters",
+      translations: t,
+    }
+  }
+
+  try {
+    const customer = await retrieveCustomer()
+
+    if (!customer?.email) {
+      return {
+        success: false,
+        error: t.passwordUpdateFailed || "Unable to update",
+        translations: t,
+      }
+    }
+
+    await sdk.auth.login("customer", "emailpass", {
+      email: customer.email,
+      password: oldPassword,
+    })
+
+    const headers = {
+      ...(await getAuthHeaders()),
+    }
+
+    try {
+      await (sdk.auth as any).updateProvider("customer", "emailpass", {
+        password: newPassword,
+      })
+    } catch {
+      await sdk.client.fetch("/auth/customer/emailpass/update", {
+        method: "POST",
+        body: { password: newPassword },
+        headers,
+      })
+    }
+
+    return { success: true, error: null, translations: t }
+  } catch (error: any) {
+    const message = error?.message || ""
+
+    return {
+      success: false,
+      error: message.includes("Unauthorized")
+        ? t.incorrectPassword || "Current password is incorrect"
+        : t.passwordUpdateFailed || "Failed to update password",
+      translations: t,
+    }
+  }
+}
+
 export async function signup(_currentState: unknown, formData: FormData) {
   const password = formData.get("password") as string
   const customerForm = {

--- a/src/lib/data/orders.ts
+++ b/src/lib/data/orders.ts
@@ -48,7 +48,8 @@ export const listOrders = async (
         limit,
         offset,
         order: "-created_at",
-        fields: "*items,+items.metadata,*items.variant,*items.product",
+        fields:
+          "*items,+items.metadata,*items.variant,*items.product,+returns,+returns.items,+exchanges,+exchanges.additional_items,+claims,+claims.claim_items,+claims.additional_items",
         ...filters,
       },
       headers,

--- a/src/modules/account/components/account-nav/index.tsx
+++ b/src/modules/account/components/account-nav/index.tsx
@@ -93,6 +93,19 @@ const AccountNav = ({
                   </LocalizedClientLink>
                 </li>
                 <li>
+                  <LocalizedClientLink
+                    href="/account/after-sales"
+                    className="flex items-center justify-between py-4 border-b border-gray-200 px-8"
+                    data-testid="after-sales-link"
+                  >
+                    <div className="flex items-center gap-x-2">
+                      <Package size={20} />
+                      <span>{t("afterSales")}</span>
+                    </div>
+                    <ChevronDown className="transform -rotate-90" />
+                  </LocalizedClientLink>
+                </li>
+                <li>
                   <button
                     type="button"
                     className="flex items-center justify-between py-4 border-b border-gray-200 px-8 w-full"
@@ -152,6 +165,15 @@ const AccountNav = ({
                   data-testid="orders-link"
                 >
                   {t("ordersLabel")}
+                </AccountNavLink>
+              </li>
+              <li>
+                <AccountNavLink
+                  href="/account/after-sales"
+                  route={route!}
+                  data-testid="after-sales-link"
+                >
+                  {t("afterSales")}
                 </AccountNavLink>
               </li>
               <li className="text-grey-700">

--- a/src/modules/account/components/after-sales-history/index.tsx
+++ b/src/modules/account/components/after-sales-history/index.tsx
@@ -1,0 +1,137 @@
+"use client"
+import { Badge, Text } from "@medusajs/ui"
+import LocalizedClientLink from "@modules/common/components/localized-client-link"
+import { useMemo, useState } from "react"
+import { useTranslations } from "next-intl"
+
+type RecordType = "return" | "exchange" | "claim"
+
+type AfterSalesRecord = {
+  id: string
+  type: RecordType
+  orderId: string
+  orderDisplayId: number
+  createdAt: string
+  status: string
+  itemsCount: number
+  refundAmount?: number | null
+}
+
+const AfterSalesHistory = ({
+  records,
+  currencyCode,
+}: {
+  records: AfterSalesRecord[]
+  currencyCode: string
+}) => {
+  const t = useTranslations("account")
+  const returnT = useTranslations("returns")
+  const exchangeT = useTranslations("exchanges")
+  const claimT = useTranslations("claims")
+  const [tab, setTab] = useState<"all" | RecordType>("all")
+
+  const filtered = useMemo(
+    () =>
+      tab === "all" ? records : records.filter((record) => record.type === tab),
+    [records, tab]
+  )
+
+  return (
+    <div className="flex flex-col gap-y-4">
+      <div className="flex gap-2">
+        {[
+          ["all", t("afterSalesAll")],
+          ["return", t("afterSalesReturns")],
+          ["exchange", t("afterSalesExchanges")],
+          ["claim", t("afterSalesClaims")],
+        ].map(([value, label]) => (
+          <button
+            key={value}
+            type="button"
+            onClick={() => setTab(value as "all" | RecordType)}
+            className={`rounded-full border px-3 py-1 text-sm ${
+              tab === value
+                ? "border-ui-fg-interactive bg-ui-bg-interactive"
+                : "border-ui-border-base"
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {filtered.length === 0 ? (
+        <div className="rounded-lg border border-ui-border-base p-6 text-center">
+          <Text>{t("noAfterSales")}</Text>
+        </div>
+      ) : (
+        filtered.map((record) => (
+          <LocalizedClientLink
+            key={`${record.type}-${record.id}`}
+            href={`/account/orders/details/${record.orderId}`}
+            className="rounded-lg border border-ui-border-base p-4 hover:border-ui-border-strong"
+          >
+            <div className="mb-2 flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <Badge
+                  color={
+                    record.type === "return"
+                      ? "blue"
+                      : record.type === "exchange"
+                      ? "purple"
+                      : "orange"
+                  }
+                >
+                  {record.type === "return"
+                    ? t("afterSalesReturns")
+                    : record.type === "exchange"
+                    ? t("afterSalesExchanges")
+                    : t("afterSalesClaims")}
+                </Badge>
+                <Text className="txt-compact-medium">
+                  {t("afterSalesOrderLink")} #{record.orderDisplayId}
+                </Text>
+              </div>
+              <Badge
+                color={
+                  record.status === "canceled"
+                    ? "red"
+                    : record.status === "completed" ||
+                      record.status === "received"
+                    ? "green"
+                    : "orange"
+                }
+              >
+                {record.type === "return"
+                  ? returnT.has(`status.${record.status}`)
+                    ? returnT(`status.${record.status}`)
+                    : record.status
+                  : record.type === "exchange"
+                  ? exchangeT.has(`status.${record.status}`)
+                    ? exchangeT(`status.${record.status}`)
+                    : record.status
+                  : claimT.has(`status.${record.status}`)
+                  ? claimT(`status.${record.status}`)
+                  : record.status}
+              </Badge>
+            </div>
+            <Text className="text-sm text-ui-fg-subtle">
+              {new Date(record.createdAt).toLocaleDateString()}
+            </Text>
+            <Text className="mt-1 text-sm text-ui-fg-subtle">
+              {t("afterSalesItems", { count: record.itemsCount })}
+              {record.refundAmount && record.refundAmount > 0
+                ? ` • ${claimT("refundAmount")}: ${new Intl.NumberFormat(
+                    undefined,
+                    { style: "currency", currency: currencyCode }
+                  ).format(record.refundAmount / 100)}`
+                : ""}
+            </Text>
+          </LocalizedClientLink>
+        ))
+      )}
+    </div>
+  )
+}
+
+export default AfterSalesHistory

--- a/src/modules/account/components/overview/index.tsx
+++ b/src/modules/account/components/overview/index.tsx
@@ -4,6 +4,7 @@ import ChevronDown from "@modules/common/icons/chevron-down"
 import LocalizedClientLink from "@modules/common/components/localized-client-link"
 import { convertToLocale } from "@lib/util/money"
 import { HttpTypes } from "@medusajs/types"
+import { useTranslations } from "next-intl"
 
 type OverviewProps = {
   customer: HttpTypes.StoreCustomer | null
@@ -11,15 +12,17 @@ type OverviewProps = {
 }
 
 const Overview = ({ customer, orders }: OverviewProps) => {
+  const t = useTranslations("account")
+
   return (
     <div data-testid="overview-page-wrapper">
       <div className="hidden small:block">
         <div className="text-xl-semi flex justify-between items-center mb-4">
           <span data-testid="welcome-message" data-value={customer?.first_name}>
-            Hello {customer?.first_name}
+            {t("welcome", { name: customer?.first_name || "" })}
           </span>
           <span className="text-small-regular text-ui-fg-base">
-            Signed in as:{" "}
+            {t("signedInAs")}{" "}
             <span
               className="font-semibold"
               data-testid="customer-email"
@@ -33,7 +36,7 @@ const Overview = ({ customer, orders }: OverviewProps) => {
           <div className="flex flex-col gap-y-4 h-full col-span-1 row-span-2 flex-1">
             <div className="flex items-start gap-x-16 mb-6">
               <div className="flex flex-col gap-y-4">
-                <h3 className="text-large-semi">Profile</h3>
+                <h3 className="text-large-semi">{t("profile")}</h3>
                 <div className="flex items-end gap-x-2">
                   <span
                     className="text-3xl-semi leading-none"
@@ -43,13 +46,13 @@ const Overview = ({ customer, orders }: OverviewProps) => {
                     {getProfileCompletion(customer)}%
                   </span>
                   <span className="uppercase text-base-regular text-ui-fg-subtle">
-                    Completed
+                    {t("completed")}
                   </span>
                 </div>
               </div>
 
               <div className="flex flex-col gap-y-4">
-                <h3 className="text-large-semi">Addresses</h3>
+                <h3 className="text-large-semi">{t("addresses")}</h3>
                 <div className="flex items-end gap-x-2">
                   <span
                     className="text-3xl-semi leading-none"
@@ -59,7 +62,7 @@ const Overview = ({ customer, orders }: OverviewProps) => {
                     {customer?.addresses?.length || 0}
                   </span>
                   <span className="uppercase text-base-regular text-ui-fg-subtle">
-                    Saved
+                    {t("saved")}
                   </span>
                 </div>
               </div>
@@ -67,7 +70,7 @@ const Overview = ({ customer, orders }: OverviewProps) => {
 
             <div className="flex flex-col gap-y-4">
               <div className="flex items-center gap-x-2">
-                <h3 className="text-large-semi">Recent orders</h3>
+                <h3 className="text-large-semi">{t("recentOrders")}</h3>
               </div>
               <ul
                 className="flex flex-col gap-y-4"
@@ -86,12 +89,14 @@ const Overview = ({ customer, orders }: OverviewProps) => {
                         >
                           <Container className="bg-gray-50 flex justify-between items-center p-4">
                             <div className="grid grid-cols-3 grid-rows-2 text-small-regular gap-x-4 flex-1">
-                              <span className="font-semibold">Date placed</span>
                               <span className="font-semibold">
-                                Order number
+                                {t("orderDate")}
                               </span>
                               <span className="font-semibold">
-                                Total amount
+                                {t("orderNumber")}
+                              </span>
+                              <span className="font-semibold">
+                                {t("orderTotal")}
                               </span>
                               <span data-testid="order-created-date">
                                 {new Date(order.created_at).toDateString()}
@@ -114,7 +119,7 @@ const Overview = ({ customer, orders }: OverviewProps) => {
                               data-testid="open-order-button"
                             >
                               <span className="sr-only">
-                                Go to order #{order.display_id}
+                                {t("afterSalesOrderLink")} #{order.display_id}
                               </span>
                               <ChevronDown className="-rotate-90" />
                             </button>
@@ -124,7 +129,9 @@ const Overview = ({ customer, orders }: OverviewProps) => {
                     )
                   })
                 ) : (
-                  <span data-testid="no-orders-message">No recent orders</span>
+                  <span data-testid="no-orders-message">
+                    {t("noRecentOrders")}
+                  </span>
                 )}
               </ul>
             </div>

--- a/src/modules/account/components/profile-password/index.tsx
+++ b/src/modules/account/components/profile-password/index.tsx
@@ -1,63 +1,71 @@
 "use client"
 
-import React, { useEffect, useActionState } from "react"
+import React, { useActionState, useEffect } from "react"
 import Input from "@modules/common/components/input"
 import AccountInfo from "../account-info"
 import { HttpTypes } from "@medusajs/types"
 import { toast } from "@medusajs/ui"
 import { useTranslations } from "next-intl"
+import { updateCustomerPassword } from "@lib/data/customer"
 
 type MyInformationProps = {
   customer: HttpTypes.StoreCustomer
 }
 
-const ProfilePassword: React.FC<MyInformationProps> = ({ customer }) => {
+const ProfilePassword: React.FC<MyInformationProps> = () => {
   const [successState, setSuccessState] = React.useState(false)
   const t = useTranslations("account")
 
-  // TODO: Add support for password updates
-  const updatePassword = async () => {
-    toast.info(t("passwordNotImplemented"))
-  }
+  const [state, formAction] = useActionState(updateCustomerPassword, {
+    success: false,
+    error: null,
+    translations: {
+      passwordMismatch: t("passwordMismatch"),
+      passwordTooShort: t("passwordTooShort"),
+      incorrectPassword: t("incorrectPassword"),
+      passwordUpdateFailed: t("passwordUpdateFailed"),
+    },
+  })
 
   const clearState = () => {
     setSuccessState(false)
   }
 
+  useEffect(() => {
+    setSuccessState(!!state.success)
+    if (state.success) {
+      toast.success(t("passwordUpdated"))
+    }
+  }, [state, t])
+
   return (
-    <form
-      action={updatePassword}
-      onReset={() => clearState()}
-      className="w-full"
-    >
+    <form action={formAction} onReset={() => clearState()} className="w-full">
       <AccountInfo
-        label="Password"
-        currentInfo={
-          <span>The password is not shown for security reasons</span>
-        }
+        label={t("passwordLabel")}
+        currentInfo={<span>{t("passwordNotShown")}</span>}
         isSuccess={successState}
-        isError={false}
-        errorMessage={undefined}
+        isError={!!state.error}
+        errorMessage={state.error ?? undefined}
         clearState={clearState}
         data-testid="account-password-editor"
       >
         <div className="grid grid-cols-2 gap-4">
           <Input
-            label="Old password"
+            label={t("oldPassword")}
             name="old_password"
             required
             type="password"
             data-testid="old-password-input"
           />
           <Input
-            label="New password"
+            label={t("newPasswordLabel")}
             type="password"
             name="new_password"
             required
             data-testid="new-password-input"
           />
           <Input
-            label="Confirm password"
+            label={t("confirmPasswordLabel")}
             type="password"
             name="confirm_password"
             required

--- a/src/modules/order/components/claim-status/index.tsx
+++ b/src/modules/order/components/claim-status/index.tsx
@@ -6,7 +6,6 @@ import { useTranslations } from "next-intl"
 
 interface ClaimItem {
   id: string
-  item_id: string
   quantity: number
   reason?: string
   note?: string
@@ -14,22 +13,18 @@ interface ClaimItem {
 
 interface AdditionalItem {
   id: string
-  item_id: string
   quantity: number
   unit_price: number
   title?: string
   variant_title?: string
-  thumbnail?: string
 }
 
 interface Claim {
   id: string
   display_id: number
   type: "refund" | "replace"
-  order_version: number
   refund_amount: number | null
   canceled_at: string | null
-  created_at: string
   claim_items?: ClaimItem[]
   additional_items?: AdditionalItem[]
 }
@@ -39,31 +34,17 @@ type Props = {
   currencyCode: string
 }
 
-const statusColorMap: Record<
-  string,
-  "green" | "orange" | "red" | "grey" | "blue" | "purple"
-> = {
-  active: "orange",
-  completed: "green",
-  canceled: "red",
-}
-
-const typeColorMap: Record<string, "blue" | "purple"> = {
-  refund: "blue",
-  replace: "purple",
-}
-
-function getClaimStatus(claim: Claim): string {
-  if (claim.canceled_at) return "canceled"
-
-  return "active"
-}
-
 const ClaimStatus = ({ claims, currencyCode }: Props) => {
   const t = useTranslations("claims")
 
   if (!claims || claims.length === 0) {
     return null
+  }
+
+  const openSupport = () => {
+    if (typeof window !== "undefined" && (window as any).$crisp) {
+      ;(window as any).$crisp.push(["do", "chat:open"])
+    }
   }
 
   return (
@@ -73,78 +54,104 @@ const ClaimStatus = ({ claims, currencyCode }: Props) => {
       </Text>
 
       {claims.map((claim) => {
-        const status = getClaimStatus(claim)
-
+        const status = claim.canceled_at ? "canceled" : "active"
         return (
-          <div key={claim.id} className="rounded-lg border border-ui-border-base p-4">
+          <div
+            key={claim.id}
+            className="rounded-lg border border-ui-border-base p-4"
+          >
             <div className="mb-3 flex items-center justify-between">
               <div className="flex items-center gap-x-2">
                 <Text className="txt-compact-medium">
-                  {t.has("claimLabel") ? t("claimLabel") : "Claim"} #{claim.display_id}
+                  {t.has("claimLabel") ? t("claimLabel") : "Claim"} #
+                  {claim.display_id}
                 </Text>
-                <Badge color={typeColorMap[claim.type] || "grey"}>
-                  {t.has(`type.${claim.type}`) ? t(`type.${claim.type}`) : claim.type}
+                <Badge color={claim.type === "refund" ? "blue" : "purple"}>
+                  {t.has(`type.${claim.type}`)
+                    ? t(`type.${claim.type}`)
+                    : claim.type}
                 </Badge>
               </div>
-              <Badge color={statusColorMap[status] || "grey"}>
+              <Badge color={status === "canceled" ? "red" : "orange"}>
                 {t.has(`status.${status}`) ? t(`status.${status}`) : status}
               </Badge>
             </div>
 
-            <Text className="mb-2 text-sm text-ui-fg-subtle">
-              {t.has("submittedOn") ? t("submittedOn") : "Submitted on"}{" "}
-              {new Date(claim.created_at).toLocaleDateString()}
-            </Text>
-
-            {claim.claim_items && claim.claim_items.length > 0 && (
-              <div className="mt-2 space-y-1">
-                <Text className="text-xs font-medium text-ui-fg-muted">
-                  {t.has("claimedItems") ? t("claimedItems") : "Claimed items"}
-                </Text>
-                {claim.claim_items.map((item) => (
-                  <div key={item.id} className="flex justify-between text-sm text-ui-fg-subtle">
-                    <Text className="text-sm">Qty: {item.quantity}</Text>
-                    {item.reason && (
-                      <Text className="text-sm text-ui-fg-muted">{item.reason}</Text>
-                    )}
-                  </div>
-                ))}
-              </div>
-            )}
-
-            {claim.additional_items && claim.additional_items.length > 0 && (
-              <div className="mt-2 space-y-1">
-                <Text className="text-xs font-medium text-ui-fg-muted">
-                  {t.has("replacementItems")
-                    ? t("replacementItems")
-                    : "Replacement items"}
-                </Text>
-                {claim.additional_items.map((item) => (
-                  <div key={item.id} className="flex justify-between text-sm text-ui-fg-subtle">
-                    <Text className="text-sm">
-                      {item.title || item.variant_title || "Item"} × {item.quantity}
-                    </Text>
-                    <Text className="text-sm">
-                      {convertToLocale({
-                        amount: item.unit_price,
-                        currency_code: currencyCode,
-                      })}
-                    </Text>
-                  </div>
-                ))}
-              </div>
+            {!claim.canceled_at && (
+              <Text className="mb-2 text-sm text-ui-fg-subtle">
+                {t("claimProgress")}: Active → Completed
+              </Text>
             )}
 
             {claim.refund_amount != null && claim.refund_amount > 0 && (
-              <div className="mt-2 border-t border-ui-border-base pt-2">
-                <Text className="text-sm">
-                  {t.has("refundAmount") ? t("refundAmount") : "Refund amount"}: {" "}
+              <div className="mb-2 rounded border border-ui-border-base p-2">
+                <Text className="text-sm font-semibold">
+                  {t.has("refundAmount") ? t("refundAmount") : "Refund amount"}:{" "}
                   {convertToLocale({
                     amount: claim.refund_amount,
                     currency_code: currencyCode,
                   })}
                 </Text>
               </div>
+            )}
+
+            {claim.claim_items && claim.claim_items.length > 0 && (
+              <div className="mt-2 space-y-1">
+                {claim.claim_items.map((item) => (
+                  <div key={item.id} className="text-sm text-ui-fg-subtle">
+                    <Text>Qty: {item.quantity}</Text>
+                    {item.reason && (
+                      <Text>
+                        {t("claimReason")}: {item.reason}
+                      </Text>
+                    )}
+                    {item.note && (
+                      <Text>
+                        {t("claimNote")}: {item.note}
+                      </Text>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {claim.type === "replace" &&
+              claim.additional_items &&
+              claim.additional_items.length > 0 && (
+                <div className="mt-2 space-y-1">
+                  <Text className="text-xs font-medium text-ui-fg-muted">
+                    {t.has("replacementItems")
+                      ? t("replacementItems")
+                      : "Replacement items"}
+                  </Text>
+                  {claim.additional_items.map((item) => (
+                    <div
+                      key={item.id}
+                      className="flex justify-between text-sm text-ui-fg-subtle"
+                    >
+                      <Text className="text-sm">
+                        {item.title || item.variant_title || "Item"} ×{" "}
+                        {item.quantity}
+                      </Text>
+                      <Text className="text-sm">
+                        {convertToLocale({
+                          amount: item.unit_price,
+                          currency_code: currencyCode,
+                        })}
+                      </Text>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+            {!claim.canceled_at && (
+              <button
+                type="button"
+                onClick={openSupport}
+                className="mt-3 text-sm text-ui-fg-interactive hover:text-ui-fg-interactive-hover"
+              >
+                {t("contactSupport")}
+              </button>
             )}
           </div>
         )

--- a/src/modules/order/components/exchange-status/index.tsx
+++ b/src/modules/order/components/exchange-status/index.tsx
@@ -9,6 +9,10 @@ interface ExchangeItem {
   item_id: string
   quantity: number
   note?: string
+  item?: {
+    title?: string
+    variant_title?: string
+  }
 }
 
 interface AdditionalItem {
@@ -18,33 +22,20 @@ interface AdditionalItem {
   unit_price: number
   title?: string
   variant_title?: string
-  thumbnail?: string
 }
 
 interface Exchange {
   id: string
   display_id: number
-  order_version: number
   canceled_at: string | null
   created_at: string
+  items?: ExchangeItem[]
   additional_items?: AdditionalItem[]
 }
 
 type Props = {
   exchanges: Exchange[]
   currencyCode: string
-}
-
-const statusColorMap: Record<string, "green" | "orange" | "red" | "grey" | "blue"> = {
-  active: "orange",
-  completed: "green",
-  canceled: "red",
-}
-
-function getExchangeStatus(exchange: Exchange): string {
-  if (exchange.canceled_at) return "canceled"
-
-  return "active"
 }
 
 const ExchangeStatus = ({ exchanges, currencyCode }: Props) => {
@@ -54,6 +45,12 @@ const ExchangeStatus = ({ exchanges, currencyCode }: Props) => {
     return null
   }
 
+  const openSupport = () => {
+    if (typeof window !== "undefined" && (window as any).$crisp) {
+      ;(window as any).$crisp.push(["do", "chat:open"])
+    }
+  }
+
   return (
     <div className="flex flex-col gap-y-3">
       <Text className="txt-medium-plus">
@@ -61,44 +58,77 @@ const ExchangeStatus = ({ exchanges, currencyCode }: Props) => {
       </Text>
 
       {exchanges.map((exchange) => {
-        const status = getExchangeStatus(exchange)
+        const status = exchange.canceled_at ? "canceled" : "active"
 
         return (
-          <div key={exchange.id} className="rounded-lg border border-ui-border-base p-4">
+          <div
+            key={exchange.id}
+            className="rounded-lg border border-ui-border-base p-4"
+          >
             <div className="mb-3 flex items-center justify-between">
               <Text className="txt-compact-medium">
                 {t.has("exchangeLabel") ? t("exchangeLabel") : "Exchange"} #
                 {exchange.display_id}
               </Text>
-              <Badge color={statusColorMap[status] || "grey"}>
+              <Badge color={status === "canceled" ? "red" : "orange"}>
                 {t.has(`status.${status}`) ? t(`status.${status}`) : status}
               </Badge>
             </div>
 
-            <Text className="mb-2 text-sm text-ui-fg-subtle">
-              {t.has("submittedOn") ? t("submittedOn") : "Submitted on"}{" "}
-              {new Date(exchange.created_at).toLocaleDateString()}
-            </Text>
+            {!exchange.canceled_at && (
+              <Text className="mb-2 text-sm text-ui-fg-subtle">
+                {t("exchangeProgress")}: Active → Completed
+              </Text>
+            )}
 
-            {exchange.additional_items && exchange.additional_items.length > 0 && (
+            {exchange.items && exchange.items.length > 0 && (
               <div className="mt-2 space-y-1">
                 <Text className="text-xs font-medium text-ui-fg-muted">
-                  {t.has("newItems") ? t("newItems") : "New items"}
+                  {t("originalItems")}
                 </Text>
-                {exchange.additional_items.map((item) => (
-                  <div key={item.id} className="flex justify-between text-sm text-ui-fg-subtle">
-                    <Text className="text-sm">
-                      {item.title || item.variant_title || "Item"} × {item.quantity}
-                    </Text>
-                    <Text className="text-sm">
-                      {convertToLocale({
-                        amount: item.unit_price,
-                        currency_code: currencyCode,
-                      })}
-                    </Text>
-                  </div>
+                {exchange.items.map((item) => (
+                  <Text key={item.id} className="text-sm text-ui-fg-subtle">
+                    {item.item?.title || item.item?.variant_title || "Item"} ×{" "}
+                    {item.quantity}
+                  </Text>
                 ))}
               </div>
+            )}
+
+            {exchange.additional_items &&
+              exchange.additional_items.length > 0 && (
+                <div className="mt-2 space-y-1">
+                  <Text className="text-xs font-medium text-ui-fg-muted">
+                    {t.has("newItems") ? t("newItems") : "New items"}
+                  </Text>
+                  {exchange.additional_items.map((item) => (
+                    <div
+                      key={item.id}
+                      className="flex justify-between text-sm text-ui-fg-subtle"
+                    >
+                      <Text className="text-sm">
+                        {item.title || item.variant_title || "Item"} ×{" "}
+                        {item.quantity}
+                      </Text>
+                      <Text className="text-sm">
+                        {convertToLocale({
+                          amount: item.unit_price,
+                          currency_code: currencyCode,
+                        })}
+                      </Text>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+            {!exchange.canceled_at && (
+              <button
+                type="button"
+                onClick={openSupport}
+                className="mt-3 text-sm text-ui-fg-interactive hover:text-ui-fg-interactive-hover"
+              >
+                {t("contactSupport")}
+              </button>
             )}
           </div>
         )

--- a/src/modules/order/templates/return-request-template.tsx
+++ b/src/modules/order/templates/return-request-template.tsx
@@ -35,7 +35,12 @@ type Step =
   | "success"
   | "error"
 
-const steps: Step[] = ["select-items", "select-reason", "select-shipping", "confirm"]
+const steps: Step[] = [
+  "select-items",
+  "select-reason",
+  "select-shipping",
+  "confirm",
+]
 
 const RETURN_REASON_ZH: Record<string, string> = {
   "wrong-size": "尺寸不合适",
@@ -43,12 +48,12 @@ const RETURN_REASON_ZH: Record<string, string> = {
   "material-unsatisfactory": "材质不满意",
   "shipping-damage": "运输损坏",
   "wrong-item": "错发商品",
-  "size": "尺寸不合适",
-  "color": "颜色差异",
-  "quality": "质量问题",
-  "damaged": "运输损坏",
-  "wrong_item": "错发商品",
-  "other": "其他原因",
+  size: "尺寸不合适",
+  color: "颜色差异",
+  quality: "质量问题",
+  damaged: "运输损坏",
+  wrong_item: "错发商品",
+  other: "其他原因",
 }
 
 const getReturnReasonZh = (value: string): string | undefined => {
@@ -57,6 +62,17 @@ const getReturnReasonZh = (value: string): string | undefined => {
     RETURN_REASON_ZH[value.toLowerCase().replace(/\s+/g, "-")]
   )
 }
+
+const MAX_IMAGES = 3
+const MAX_IMAGE_SIZE = 5 * 1024 * 1024
+
+const fileToBase64 = (file: File) =>
+  new Promise<string>((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(String(reader.result))
+    reader.onerror = () => reject(new Error("Failed to read image"))
+    reader.readAsDataURL(file)
+  })
 
 const ReturnRequestTemplate = ({
   order,
@@ -70,6 +86,8 @@ const ReturnRequestTemplate = ({
   const [selectedShippingOptionId, setSelectedShippingOptionId] = useState("")
   const [submitting, setSubmitting] = useState(false)
   const [errorMessage, setErrorMessage] = useState("")
+  const [images, setImages] = useState<File[]>([])
+  const [imageError, setImageError] = useState("")
 
   const itemsWithInfo = getItemsWithReturnInfo(order.items || [])
   const returnableItems = itemsWithInfo.filter((i) => i.is_returnable)
@@ -119,18 +137,67 @@ const ReturnRequestTemplate = ({
     )
   }
 
+  const handleImageSelect = (files: FileList | null) => {
+    if (!files) return
+
+    setImageError("")
+    const nextImages = [...images]
+
+    for (const file of Array.from(files)) {
+      if (!file.type.startsWith("image/")) {
+        setImageError(t("imageTooLarge"))
+        continue
+      }
+
+      if (file.size > MAX_IMAGE_SIZE) {
+        setImageError(t("imageTooLarge"))
+        continue
+      }
+
+      if (nextImages.length >= MAX_IMAGES) {
+        setImageError(t("tooManyImages"))
+        break
+      }
+
+      nextImages.push(file)
+    }
+
+    setImages(nextImages)
+  }
+
+  const removeImage = (index: number) => {
+    setImages((prev) => prev.filter((_, idx) => idx !== index))
+  }
+
   const handleSubmit = async () => {
     setSubmitting(true)
     setErrorMessage("")
 
+    const imagePayload =
+      images.length > 0
+        ? await Promise.all(images.map((file) => fileToBase64(file)))
+        : []
+
     const result = await createReturnRequest({
       order_id: order.id,
-      items: selectedItems.map((s) => ({
-        id: s.id,
-        quantity: s.quantity,
-        ...(s.reason_id ? { reason_id: s.reason_id } : {}),
-        ...(s.note ? { note: s.note } : {}),
-      })),
+      items: selectedItems.map((s) => {
+        const baseNote = s.note?.trim() || ""
+        const imageMarker =
+          imagePayload.length > 0
+            ? `\n[Images attached: ${imagePayload.length}]\n${imagePayload.join(
+                "\n"
+              )}`
+            : ""
+
+        return {
+          id: s.id,
+          quantity: s.quantity,
+          ...(s.reason_id ? { reason_id: s.reason_id } : {}),
+          ...(baseNote || imageMarker
+            ? { note: `${baseNote}${imageMarker}`.trim() }
+            : {}),
+        }
+      }),
       return_shipping: {
         option_id: selectedShippingOptionId,
       },
@@ -177,7 +244,9 @@ const ReturnRequestTemplate = ({
         <div className="rounded-lg border border-ui-border-base p-6 text-center">
           <Text className="mb-2 txt-xlarge">✓</Text>
           <Text className="mb-2 txt-medium-plus">{t("successTitle")}</Text>
-          <Text className="mb-4 text-ui-fg-subtle">{t("successDescription")}</Text>
+          <Text className="mb-4 text-ui-fg-subtle">
+            {t("successDescription")}
+          </Text>
           <LocalizedClientLink href="/account/orders">
             <Button variant="secondary">{t("backToOrders")}</Button>
           </LocalizedClientLink>
@@ -223,7 +292,9 @@ const ReturnRequestTemplate = ({
           <div
             key={s}
             className={`h-1 flex-1 rounded-full ${
-              idx <= steps.indexOf(step) ? "bg-ui-fg-interactive" : "bg-ui-border-base"
+              idx <= steps.indexOf(step)
+                ? "bg-ui-fg-interactive"
+                : "bg-ui-border-base"
             }`}
           />
         ))}
@@ -232,7 +303,9 @@ const ReturnRequestTemplate = ({
       {step === "select-items" && (
         <div className="flex flex-col gap-y-3">
           <Text className="txt-medium-plus">{t("selectItemsTitle")}</Text>
-          <Text className="text-sm text-ui-fg-subtle">{t("selectItemsDescription")}</Text>
+          <Text className="text-sm text-ui-fg-subtle">
+            {t("selectItemsDescription")}
+          </Text>
 
           {returnableItems.map((item) => {
             const selected = selectedItems.find((s) => s.id === item.id)
@@ -257,7 +330,9 @@ const ReturnRequestTemplate = ({
                       />
                     )}
                     <div>
-                      <Text className="txt-compact-medium">{getItemName(item)}</Text>
+                      <Text className="txt-compact-medium">
+                        {getItemName(item)}
+                      </Text>
                       <Text className="text-sm text-ui-fg-subtle">
                         {getItemVariantTitle(item)}
                       </Text>
@@ -272,7 +347,10 @@ const ReturnRequestTemplate = ({
                         value={selected.quantity}
                         onClick={(e) => e.stopPropagation()}
                         onChange={(e) =>
-                          updateItemQuantity(item.id, Number.parseInt(e.target.value, 10))
+                          updateItemQuantity(
+                            item.id,
+                            Number.parseInt(e.target.value, 10)
+                          )
                         }
                         className="mt-1 rounded border border-ui-border-base px-2 py-1 text-sm"
                       >
@@ -314,9 +392,13 @@ const ReturnRequestTemplate = ({
             }
 
             return (
-              <div key={sel.id} className="rounded-lg border border-ui-border-base p-4">
+              <div
+                key={sel.id}
+                className="rounded-lg border border-ui-border-base p-4"
+              >
                 <Text className="mb-2 txt-compact-medium">
-                  {getItemName(item)} — {getItemVariantTitle(item)} × {sel.quantity}
+                  {getItemName(item)} — {getItemVariantTitle(item)} ×{" "}
+                  {sel.quantity}
                 </Text>
 
                 {returnReasons.length > 0 ? (
@@ -353,11 +435,60 @@ const ReturnRequestTemplate = ({
             )
           })}
 
+          <div className="rounded-lg border border-ui-border-base p-4">
+            <Text className="txt-compact-medium">{t("uploadImages")}</Text>
+            <Text className="mb-3 text-sm text-ui-fg-subtle">
+              {t("uploadImagesDescription")}
+            </Text>
+            <input
+              type="file"
+              accept="image/*"
+              multiple
+              onChange={(e) => {
+                handleImageSelect(e.target.files)
+                e.currentTarget.value = ""
+              }}
+              className="mb-2 w-full rounded border border-dashed border-ui-border-strong p-3 text-sm"
+            />
+            <Text className="text-xs text-ui-fg-subtle">
+              {t("maxFileSize")}
+            </Text>
+            {imageError && (
+              <Text className="mt-2 text-sm text-ui-fg-error">
+                {imageError}
+              </Text>
+            )}
+
+            {images.length > 0 && (
+              <div className="mt-3 grid grid-cols-3 gap-2">
+                {images.map((file, index) => (
+                  <div key={`${file.name}-${index}`} className="relative">
+                    <img
+                      src={URL.createObjectURL(file)}
+                      alt={file.name}
+                      className="h-20 w-full rounded object-cover"
+                    />
+                    <button
+                      type="button"
+                      className="absolute right-1 top-1 rounded bg-black/70 px-1 text-xs text-white"
+                      onClick={() => removeImage(index)}
+                      aria-label={t("removeImage")}
+                    >
+                      ×
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
           <div className="mt-2 flex gap-2">
             <Button variant="secondary" onClick={() => setStep("select-items")}>
               {t("back")}
             </Button>
-            <Button onClick={() => setStep("select-shipping")}>{t("continue")}</Button>
+            <Button onClick={() => setStep("select-shipping")}>
+              {t("continue")}
+            </Button>
           </div>
         </div>
       )}
@@ -392,17 +523,24 @@ const ReturnRequestTemplate = ({
             ))
           ) : (
             <div className="rounded-lg border border-ui-border-base p-4">
-              <Text className="text-sm text-ui-fg-muted">{t("noShippingOptions")}</Text>
+              <Text className="text-sm text-ui-fg-muted">
+                {t("noShippingOptions")}
+              </Text>
             </div>
           )}
 
           <div className="mt-2 flex gap-2">
-            <Button variant="secondary" onClick={() => setStep("select-reason")}>
+            <Button
+              variant="secondary"
+              onClick={() => setStep("select-reason")}
+            >
               {t("back")}
             </Button>
             <Button
               onClick={() => setStep("confirm")}
-              disabled={returnShippingOptions.length > 0 && !selectedShippingOptionId}
+              disabled={
+                returnShippingOptions.length > 0 && !selectedShippingOptionId
+              }
             >
               {t("continue")}
             </Button>
@@ -456,15 +594,19 @@ const ReturnRequestTemplate = ({
               <Text className="txt-compact-medium">{t("returnShipping")}</Text>
               <Text className="text-sm text-ui-fg-subtle">
                 {
-                  returnShippingOptions.find((o) => o.id === selectedShippingOptionId)
-                    ?.name
+                  returnShippingOptions.find(
+                    (o) => o.id === selectedShippingOptionId
+                  )?.name
                 }
               </Text>
             </div>
           )}
 
           <div className="mt-2 flex gap-2">
-            <Button variant="secondary" onClick={() => setStep("select-shipping")}>
+            <Button
+              variant="secondary"
+              onClick={() => setStep("select-shipping")}
+            >
               {t("back")}
             </Button>
             <Button onClick={handleSubmit} isLoading={submitting}>


### PR DESCRIPTION
### Motivation
- Enable customers to attach photos to return requests even though the Medusa Store API doesn't accept file uploads by embedding image data in the return `note` as a fallback.  
- Provide a single place for users to review all after-sales activity (returns, exchanges, claims) and improve visibility into exchange/claim statuses.  
- Complete account UX internationalization and add real password-change support to improve localization and account security flows.

### Description
- Added optional image upload UI (max 3 images, 5MB each) to the return flow and encode images as base64 in the item `note` with an `[Images attached: N]` marker; key file: `src/modules/order/templates/return-request-template.tsx`.  
- Implemented a new account page `/account/after-sales` with a tabbed All / Returns / Exchanges / Claims view, flattened/sorted after-sales records from orders, and cards linking to order details; files: `src/app/[locale]/[countryCode]/(main)/account/@dashboard/after-sales/page.tsx` and `src/modules/account/components/after-sales-history/index.tsx`.  
- Enhanced `ExchangeStatus` and `ClaimStatus` with original/replacement/claimed item displays, progress messaging, refund prominence, and a conditional Crisp `Contact Support` action; files: `src/modules/order/components/exchange-status/index.tsx` and `src/modules/order/components/claim-status/index.tsx`.  
- Enabled and i18n-ized profile metadata and UI, restored the password section, implemented server action `updateCustomerPassword` to validate and update passwords (with `sdk.auth.updateProvider` + HTTP fallback), and wired the UI to use `useActionState` and toasts; files: `src/app/[locale]/[countryCode]/(main)/account/@dashboard/profile/page.tsx`, `src/modules/account/components/profile-password/index.tsx`, and `src/lib/data/customer.ts`.  
- Replaced hardcoded account overview strings with translation keys and fixed orders pagination i18n by using `previousPage`/`nextPage`/`pageIndicator` keys; file: `src/modules/account/components/overview/index.tsx` and `src/app/[locale]/[countryCode]/(main)/account/@dashboard/orders/page.tsx`.  
- Added account nav entry for After-Sales (mobile + desktop), expanded `listOrders()` returned fields to include `returns`, `exchanges`, and `claims`, and added requested i18n keys to `messages/en.json` and `messages/zh.json`.

### Testing
- Ran `prettier --write` on all modified files and formatting succeeded.  
- Ran `eslint` which failed due to a local Next ESLint rule/plugin configuration issue (`@next/next/no-html-link-for-pages` path argument undefined), not due to the introduced code.  
- Ran `tsc --noEmit` which surfaced pre-existing repository-wide TypeScript issues; no new type errors specific to the modified files were identified in follow-up targeted checks.  
- Attempted to start the app with `yarn dev`, but startup is blocked by a missing required environment variable `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY` so runtime smoke tests were not possible in this environment.  
- Performed repository hygiene checks: `.gitignore` contains `node_modules`, `.env`, `/.next/`, and `/out/`, and no `node_modules` or env files were committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ae6e7998fc83339e581ca791da3c91)