### PR TITLE
chore/add-docker-deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+node_modules
+.next
+.git
+.gitignore
+*.md
+.env
+.env.*
+.DS_Store
+.vscode
+.idea
+coverage
+test-results
+playwright-report
+blob-report
+playwright/.cache
+playwright/.auth
+dump.rdb

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,22 @@
+# === Medusa Backend ===
+NEXT_PUBLIC_MEDUSA_BACKEND_URL=http://localhost:9000
+NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY=pk_xxx
+
+# === Storefront Base URL ===
+NEXT_PUBLIC_BASE_URL=http://localhost:8000
+
+# === Default Region ===
+NEXT_PUBLIC_DEFAULT_REGION=us
+
+# === Crisp Chat Widget ===
+NEXT_PUBLIC_CRISP_WEBSITE_ID=
+
+# === Google Analytics ===
+NEXT_PUBLIC_GA4_MEASUREMENT_ID=
+
+# === Telegram Notifications (Crisp Webhook) ===
+TELEGRAM_BOT_TOKEN=
+TELEGRAM_CHAT_ID=
+
+# === ISR Revalidation ===
+REVALIDATE_SECRET=

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+FROM node:20-alpine AS base
+
+FROM base AS deps
+WORKDIR /app
+COPY package.json package-lock.json* yarn.lock* pnpm-lock.yaml* ./
+RUN \
+  if [ -f yarn.lock ]; then yarn install --frozen-lockfile; \
+  elif [ -f package-lock.json ]; then npm ci --legacy-peer-deps; \
+  elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm i --frozen-lockfile; \
+  else npm install --legacy-peer-deps; \
+  fi
+
+FROM base AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+ARG NEXT_PUBLIC_MEDUSA_BACKEND_URL
+ARG NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY
+ARG NEXT_PUBLIC_BASE_URL
+ARG NEXT_PUBLIC_DEFAULT_REGION
+ARG NEXT_PUBLIC_CRISP_WEBSITE_ID
+ARG NEXT_PUBLIC_GA4_MEASUREMENT_ID
+
+ENV NEXT_PUBLIC_MEDUSA_BACKEND_URL=${NEXT_PUBLIC_MEDUSA_BACKEND_URL}
+ENV NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY=${NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY}
+ENV NEXT_PUBLIC_BASE_URL=${NEXT_PUBLIC_BASE_URL}
+ENV NEXT_PUBLIC_DEFAULT_REGION=${NEXT_PUBLIC_DEFAULT_REGION:-us}
+ENV NEXT_PUBLIC_CRISP_WEBSITE_ID=${NEXT_PUBLIC_CRISP_WEBSITE_ID}
+ENV NEXT_PUBLIC_GA4_MEASUREMENT_ID=${NEXT_PUBLIC_GA4_MEASUREMENT_ID}
+
+RUN npm run build
+
+FROM base AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
+COPY --from=builder /app/public ./public
+RUN mkdir .next
+RUN chown nextjs:nodejs .next
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+USER nextjs
+EXPOSE 8000
+ENV PORT=8000
+ENV HOSTNAME="0.0.0.0"
+CMD ["node", "server.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: "3.8"
+
+services:
+  storefront:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        NEXT_PUBLIC_MEDUSA_BACKEND_URL: ${NEXT_PUBLIC_MEDUSA_BACKEND_URL:-http://localhost:9000}
+        NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY: ${NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY}
+        NEXT_PUBLIC_BASE_URL: ${NEXT_PUBLIC_BASE_URL:-http://localhost:8000}
+        NEXT_PUBLIC_DEFAULT_REGION: ${NEXT_PUBLIC_DEFAULT_REGION:-us}
+        NEXT_PUBLIC_CRISP_WEBSITE_ID: ${NEXT_PUBLIC_CRISP_WEBSITE_ID}
+        NEXT_PUBLIC_GA4_MEASUREMENT_ID: ${NEXT_PUBLIC_GA4_MEASUREMENT_ID}
+    container_name: nordhjem_storefront
+    restart: unless-stopped
+    ports:
+      - "8000:8000"
+    environment:
+      NEXT_PUBLIC_MEDUSA_BACKEND_URL: ${NEXT_PUBLIC_MEDUSA_BACKEND_URL:-http://localhost:9000}
+      NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY: ${NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY}
+      NEXT_PUBLIC_BASE_URL: ${NEXT_PUBLIC_BASE_URL:-http://localhost:8000}
+      NEXT_PUBLIC_DEFAULT_REGION: ${NEXT_PUBLIC_DEFAULT_REGION:-us}
+      REVALIDATE_SECRET: ${REVALIDATE_SECRET}
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s

--- a/next.config.js
+++ b/next.config.js
@@ -16,6 +16,7 @@ const S3_PATHNAME = process.env.MEDUSA_CLOUD_S3_PATHNAME
  */
 const nextConfig = {
   reactStrictMode: true,
+  output: "standalone",
   logging: {
     fetches: {
       fullUrl: true,


### PR DESCRIPTION
### Motivation
- Provide one-command local deployment for the Next.js storefront to satisfy repository hygiene rule G-017 by adding Docker deployment artifacts. 
- Ensure builds produce a minimal standalone runtime suitable for multi-stage Docker images. 
- Document required runtime environment variables to make cloning and running the project straightforward.

### Description
- Add a multi-stage `Dockerfile` that installs dependencies based on detected lockfile, builds the Next.js app, and runs the standalone output as a non-root user on port `8000`.
- Add `.dockerignore` to exclude `node_modules`, `.next`, env files, editor settings, test reports and other artifacts from the Docker build context.
- Add `docker-compose.yml` with a `storefront` service that includes build args, runtime env mappings, port mapping `8000:8000`, restart policy, and a healthcheck.
- Add `.env.example` documenting `NEXT_PUBLIC_MEDUSA_BACKEND_URL`, `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY`, `NEXT_PUBLIC_BASE_URL`, `NEXT_PUBLIC_DEFAULT_REGION`, `NEXT_PUBLIC_CRISP_WEBSITE_ID`, `NEXT_PUBLIC_GA4_MEASUREMENT_ID`, `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`, and `REVALIDATE_SECRET`, and update `next.config.js` to enable `output: "standalone"` for Docker multi-stage support.

### Testing
- Attempted `docker compose config` but the command failed in this environment because the Docker CLI is not available (error: `docker: command not found`).
- Verified `next.config.js` now contains `output: "standalone"` to enable copying `.next/standalone` in the runtime image.
- Verified the presence and contents of the new files `Dockerfile`, `.dockerignore`, `docker-compose.yml`, and `.env.example` via automated file inspection commands.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ae7b13151c8333aec115885f2688b5)