### PR TITLE
fix(analytics): remove exported constant from "use server" file and simplify finance CSV export

### DIFF
--- a/src/lib/data/analytics.ts
+++ b/src/lib/data/analytics.ts
@@ -41,7 +41,7 @@ export interface AnalyticsData {
   funnel: FunnelStage[]
 }
 
-export const USE_MOCK = true
+const USE_MOCK = true
 
 function generateMockSalesTrend(days: number): SalesTrendPoint[] {
   const points: SalesTrendPoint[] = []
@@ -182,16 +182,4 @@ export async function getFinanceData(page: number = 1, pageSize: number = 20): P
   // return { overview: overview.data, monthly: monthly.data, transactions: txns.data, totalTransactions: txns.count }
 
   return MOCK_FINANCE
-}
-
-export async function exportFinanceCsvData(): Promise<Transaction[]> {
-  if (USE_MOCK) {
-    return MOCK_FINANCE.transactions
-  }
-
-  const res = await adminFetch<{ data: Transaction[] }>("/admin/finance/export", {
-    query: { format: "csv" },
-  })
-
-  return res.data
 }

--- a/src/modules/account/components/finance-dashboard/index.tsx
+++ b/src/modules/account/components/finance-dashboard/index.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { FinanceData, Transaction, USE_MOCK } from "@lib/data/analytics"
+import { FinanceData, Transaction } from "@lib/data/analytics"
 import { Badge, Button } from "@medusajs/ui"
 import {
   Bar,
@@ -34,19 +34,7 @@ export default function FinanceDashboard({ data, page, pageSize }: Props) {
   const totalPages = Math.max(1, Math.ceil(data.totalTransactions / pageSize))
   const { locale, countryCode } = useParams() as { locale: string; countryCode: string }
 
-  const exportCsv = async () => {
-    if (!USE_MOCK) {
-      const res = await fetch("/admin/finance/export?format=csv")
-      const blob = await res.blob()
-      const url = URL.createObjectURL(blob)
-      const a = document.createElement("a")
-      a.href = url
-      a.download = `finance-transactions-${new Date().toISOString().slice(0, 10)}.csv`
-      a.click()
-      URL.revokeObjectURL(url)
-      return
-    }
-
+  const exportCsv = () => {
     const rows = [
       [t("orderNumber"), t("date"), t("amount"), t("currency"), t("status")],
       ...data.transactions.map((txn) => [


### PR DESCRIPTION
### Motivation

- Fix Next.js build failure caused by exporting a non-async constant from a `"use server"` module by removing the `export` from the `USE_MOCK` constant so only async functions are exported.
- Remove an unused server-side CSV export helper and simplify the finance UI to avoid relying on a server export value.

### Description

- Changed `export const USE_MOCK = true` to a file-local `const USE_MOCK = true` in `src/lib/data/analytics.ts` so the module no longer exports non-async members.
- Removed the unused `exportFinanceCsvData` function from `src/lib/data/analytics.ts` since CSV export is handled client-side in the dashboard.
- Updated `src/modules/account/components/finance-dashboard/index.tsx` to stop importing `USE_MOCK` and replaced the previous `async`/server-conditional `exportCsv` with a synchronous client-side CSV generator that uses already-loaded `data.transactions`.
- Confirmed no other files import `USE_MOCK` after the change by scanning the source tree.

### Testing

- Ran `rg -n "USE_MOCK" src` to verify `USE_MOCK` is no longer exported/imported externally, and the scan showed only internal references inside `analytics.ts` (success).
- Attempted a full build with `npm run build`, which initially failed due to missing required env var `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY` (expected in this environment).
- Re-ran the build with `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY=dummy npm run build`, which progressed but failed due to unrelated environment issues (Google Fonts fetch/network errors and missing `recharts` dependency), so a full production build could not be completed here; the original `"use server"` export error is addressed by the code changes above (partial validation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69af2a421e108333a310da708494616f)