### PR TITLE
feat: M1 frontend polish — custom 404, skeleton loading screens, and error boundaries

### DIFF
--- a/src/app/[locale]/[countryCode]/(main)/cart/loading.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/cart/loading.tsx
@@ -1,5 +1,5 @@
-import SkeletonCartPage from "@modules/skeletons/templates/skeleton-cart-page"
+import PageSkeleton from "@modules/common/components/skeleton/page-skeleton"
 
 export default function Loading() {
-  return <SkeletonCartPage />
+  return <PageSkeleton />
 }

--- a/src/app/[locale]/[countryCode]/(main)/collections/[handle]/loading.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/collections/[handle]/loading.tsx
@@ -1,0 +1,11 @@
+import ProductCardSkeleton from "@modules/common/components/skeleton/product-card-skeleton"
+
+export default function Loading() {
+  return (
+    <div className="content-container py-8 grid grid-cols-2 small:grid-cols-3 lg:grid-cols-4 gap-6">
+      {Array.from({ length: 8 }).map((_, index) => (
+        <ProductCardSkeleton key={index} />
+      ))}
+    </div>
+  )
+}

--- a/src/app/[locale]/[countryCode]/(main)/layout.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/layout.tsx
@@ -8,6 +8,7 @@ import { BrandProvider } from "@lib/util/brand-context"
 import { StoreCartShippingOption } from "@medusajs/types"
 import CartMismatchBanner from "@modules/layout/components/cart-mismatch-banner"
 import CookieConsent from "@modules/common/components/cookie-consent"
+import ErrorBoundary from "@modules/common/components/error-boundary"
 import Footer from "@modules/layout/templates/footer"
 import Nav from "@modules/layout/templates/nav"
 import FreeShippingPriceNudge from "@modules/shipping/components/free-shipping-price-nudge"
@@ -44,21 +45,23 @@ export default async function PageLayout(props: { children: React.ReactNode }) {
 
   return (
     <BrandProvider brand={brand}>
-      <Nav />
-      {customer && cart && (
-        <CartMismatchBanner customer={customer} cart={cart} />
-      )}
+      <ErrorBoundary>
+        <Nav />
+        {customer && cart && (
+          <CartMismatchBanner customer={customer} cart={cart} />
+        )}
 
-      {cart && (
-        <FreeShippingPriceNudge
-          variant="popup"
-          cart={cart}
-          shippingOptions={shippingOptions}
-        />
-      )}
-      {props.children}
-      <Footer />
-      <CookieConsent />
+        {cart && (
+          <FreeShippingPriceNudge
+            variant="popup"
+            cart={cart}
+            shippingOptions={shippingOptions}
+          />
+        )}
+        {props.children}
+        <Footer />
+        <CookieConsent />
+      </ErrorBoundary>
     </BrandProvider>
   )
 }

--- a/src/app/[locale]/[countryCode]/(main)/products/[handle]/loading.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/products/[handle]/loading.tsx
@@ -1,0 +1,5 @@
+import ProductDetailSkeleton from "@modules/common/components/skeleton/product-detail-skeleton"
+
+export default function Loading() {
+  return <ProductDetailSkeleton />
+}

--- a/src/app/[locale]/[countryCode]/(main)/products/loading.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/products/loading.tsx
@@ -1,0 +1,11 @@
+import ProductCardSkeleton from "@modules/common/components/skeleton/product-card-skeleton"
+
+export default function Loading() {
+  return (
+    <div className="content-container py-8 grid grid-cols-2 small:grid-cols-3 lg:grid-cols-4 gap-6">
+      {Array.from({ length: 8 }).map((_, index) => (
+        <ProductCardSkeleton key={index} />
+      ))}
+    </div>
+  )
+}

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import Link from "next/link"
+
+type ErrorPageProps = {
+  error: Error & { digest?: string }
+  reset: () => void
+}
+
+export default function Error({ error, reset }: ErrorPageProps) {
+  console.error("App error boundary:", error)
+
+  return (
+    <main className="min-h-screen bg-gray-100 text-gray-900 dark:bg-gray-900 dark:text-gray-100 flex items-center justify-center px-4 py-12">
+      <div className="w-full max-w-xl text-center space-y-4">
+        <h1 className="text-2xl sm:text-3xl font-semibold">
+          出了点问题 / Something went wrong
+        </h1>
+        <p className="text-sm sm:text-base text-gray-600 dark:text-gray-300">
+          请刷新页面重试 / Please refresh and try again
+        </p>
+        <div className="flex flex-col sm:flex-row gap-3 justify-center pt-2">
+          <button
+            onClick={reset}
+            className="rounded-md bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 px-5 py-2.5 text-sm font-medium hover:opacity-90"
+          >
+            重新尝试
+          </button>
+          <button
+            onClick={() => window.location.reload()}
+            className="rounded-md border border-gray-900 dark:border-gray-100 px-5 py-2.5 text-sm font-medium hover:bg-gray-900 hover:text-white dark:hover:bg-gray-100 dark:hover:text-gray-900"
+          >
+            刷新页面
+          </button>
+          <Link
+            href="/"
+            className="rounded-md border border-gray-900 dark:border-gray-100 px-5 py-2.5 text-sm font-medium hover:bg-gray-900 hover:text-white dark:hover:bg-gray-100 dark:hover:text-gray-900"
+          >
+            返回首页
+          </Link>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,47 @@
+"use client"
+
+import Link from "next/link"
+
+type GlobalErrorProps = {
+  error: Error & { digest?: string }
+  reset: () => void
+}
+
+export default function GlobalError({ error, reset }: GlobalErrorProps) {
+  console.error("Global error boundary:", error)
+
+  return (
+    <html lang="en">
+      <body className="min-h-screen bg-gray-100 text-gray-900 dark:bg-gray-900 dark:text-gray-100 flex items-center justify-center px-4 py-12">
+        <main className="w-full max-w-xl text-center space-y-4">
+          <h1 className="text-2xl sm:text-3xl font-semibold">
+            出了点问题 / Something went wrong
+          </h1>
+          <p className="text-sm sm:text-base text-gray-600 dark:text-gray-300">
+            请刷新页面重试 / Please refresh and try again
+          </p>
+          <div className="flex flex-col sm:flex-row gap-3 justify-center pt-2">
+            <button
+              onClick={reset}
+              className="rounded-md bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 px-5 py-2.5 text-sm font-medium hover:opacity-90"
+            >
+              重新尝试
+            </button>
+            <button
+              onClick={() => window.location.reload()}
+              className="rounded-md border border-gray-900 dark:border-gray-100 px-5 py-2.5 text-sm font-medium hover:bg-gray-900 hover:text-white dark:hover:bg-gray-100 dark:hover:text-gray-900"
+            >
+              刷新页面
+            </button>
+            <Link
+              href="/"
+              className="rounded-md border border-gray-900 dark:border-gray-100 px-5 py-2.5 text-sm font-medium hover:bg-gray-900 hover:text-white dark:hover:bg-gray-100 dark:hover:text-gray-900"
+            >
+              返回首页
+            </Link>
+          </div>
+        </main>
+      </body>
+    </html>
+  )
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,30 +1,68 @@
-import { ArrowUpRightMini } from "@medusajs/icons"
-import { Text } from "@medusajs/ui"
-import { Metadata } from "next"
-import Link from "next/link"
+"use client"
 
-export const metadata: Metadata = {
-  title: "404",
-  description: "Something went wrong",
-}
+import Link from "next/link"
+import { FormEvent, useState } from "react"
+import { useRouter } from "next/navigation"
 
 export default function NotFound() {
+  const router = useRouter()
+  const [query, setQuery] = useState("")
+
+  const handleSearch = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    const trimmed = query.trim()
+
+    if (!trimmed) {
+      return
+    }
+
+    router.push(`/search?q=${encodeURIComponent(trimmed)}`)
+  }
+
   return (
-    <div className="flex flex-col gap-4 items-center justify-center min-h-[calc(100vh-64px)]">
-      <h1 className="text-2xl-semi text-ui-fg-base">Page not found</h1>
-      <p className="text-small-regular text-ui-fg-base">
-        The page you tried to access does not exist.
-      </p>
-      <Link
-        className="flex gap-x-1 items-center group"
-        href="/"
-      >
-        <Text className="text-ui-fg-interactive">Go to frontpage</Text>
-        <ArrowUpRightMini
-          className="group-hover:rotate-45 ease-in-out duration-150"
-          color="var(--fg-interactive)"
-        />
-      </Link>
-    </div>
+    <main className="min-h-screen bg-gray-100 text-gray-900 dark:bg-gray-900 dark:text-gray-100 flex items-center justify-center px-4 py-12">
+      <div className="w-full max-w-xl text-center space-y-6">
+        <p className="text-7xl sm:text-8xl font-semibold tracking-tight">404</p>
+        <div className="space-y-2">
+          <h1 className="text-xl sm:text-2xl font-medium">
+            页面未找到 / Page Not Found
+          </h1>
+          <p className="text-sm sm:text-base text-gray-600 dark:text-gray-300">
+            抱歉，您访问的页面不存在。请输入关键词继续浏览。
+          </p>
+        </div>
+
+        <div className="flex flex-col sm:flex-row gap-3 justify-center">
+          <Link
+            href="/"
+            className="inline-flex items-center justify-center rounded-md border border-gray-900 dark:border-gray-100 px-5 py-2.5 text-sm font-medium transition-colors hover:bg-gray-900 hover:text-white dark:hover:bg-gray-100 dark:hover:text-gray-900"
+          >
+            返回首页
+          </Link>
+        </div>
+
+        <form onSubmit={handleSearch} className="mx-auto w-full max-w-md">
+          <label htmlFor="not-found-search" className="sr-only">
+            搜索 / Search
+          </label>
+          <div className="flex items-center gap-2">
+            <input
+              id="not-found-search"
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="搜索商品 / Search products"
+              className="w-full rounded-md border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm outline-none ring-0 focus:border-gray-500"
+            />
+            <button
+              type="submit"
+              className="rounded-md bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 px-4 py-2 text-sm font-medium transition-opacity hover:opacity-85"
+            >
+              搜索
+            </button>
+          </div>
+        </form>
+      </div>
+    </main>
   )
 }

--- a/src/modules/common/components/error-boundary/index.tsx
+++ b/src/modules/common/components/error-boundary/index.tsx
@@ -1,0 +1,70 @@
+"use client"
+
+import Link from "next/link"
+import { Component, ErrorInfo, ReactNode } from "react"
+
+type ErrorBoundaryProps = {
+  children: ReactNode
+  fallback?: ReactNode
+}
+
+type ErrorBoundaryState = {
+  hasError: boolean
+}
+
+class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  public state: ErrorBoundaryState = {
+    hasError: false,
+  }
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error("ErrorBoundary caught an error:", error, errorInfo)
+  }
+
+  handleRefresh = () => {
+    window.location.reload()
+  }
+
+  render() {
+    if (this.state.hasError) {
+      if (this.props.fallback) {
+        return this.props.fallback
+      }
+
+      return (
+        <div className="min-h-[50vh] bg-gray-100 text-gray-900 dark:bg-gray-900 dark:text-gray-100 flex items-center justify-center px-4 py-10">
+          <div className="w-full max-w-lg text-center space-y-4">
+            <h2 className="text-2xl sm:text-3xl font-semibold">
+              出了点问题 / Something went wrong
+            </h2>
+            <p className="text-sm sm:text-base text-gray-600 dark:text-gray-300">
+              请刷新页面重试 / Please refresh and try again
+            </p>
+            <div className="flex flex-col sm:flex-row gap-3 justify-center pt-2">
+              <button
+                onClick={this.handleRefresh}
+                className="rounded-md bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 px-5 py-2.5 text-sm font-medium hover:opacity-90"
+              >
+                刷新页面
+              </button>
+              <Link
+                href="/"
+                className="rounded-md border border-gray-900 dark:border-gray-100 px-5 py-2.5 text-sm font-medium hover:bg-gray-900 hover:text-white dark:hover:bg-gray-100 dark:hover:text-gray-900"
+              >
+                返回首页
+              </Link>
+            </div>
+          </div>
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}
+
+export default ErrorBoundary

--- a/src/modules/common/components/skeleton/index.tsx
+++ b/src/modules/common/components/skeleton/index.tsx
@@ -1,0 +1,34 @@
+import { CSSProperties } from "react"
+
+type SkeletonProps = {
+  width?: number | string
+  height?: number | string
+  className?: string
+  variant?: "text" | "rect" | "circle"
+}
+
+const variantClassMap: Record<NonNullable<SkeletonProps["variant"]>, string> = {
+  text: "rounded",
+  rect: "rounded-lg",
+  circle: "rounded-full",
+}
+
+export default function Skeleton({
+  width,
+  height,
+  className = "",
+  variant = "rect",
+}: SkeletonProps) {
+  const style: CSSProperties = {
+    width,
+    height,
+  }
+
+  return (
+    <div
+      aria-hidden="true"
+      className={`animate-pulse bg-gray-200 dark:bg-gray-700 ${variantClassMap[variant]} ${className}`}
+      style={style}
+    />
+  )
+}

--- a/src/modules/common/components/skeleton/page-skeleton.tsx
+++ b/src/modules/common/components/skeleton/page-skeleton.tsx
@@ -1,0 +1,14 @@
+import Skeleton from "@modules/common/components/skeleton"
+
+export default function PageSkeleton() {
+  return (
+    <div className="content-container py-8 space-y-6">
+      <Skeleton variant="rect" className="h-10 w-1/2" />
+      <div className="space-y-4">
+        <Skeleton variant="rect" className="h-24 w-full" />
+        <Skeleton variant="rect" className="h-24 w-full" />
+        <Skeleton variant="rect" className="h-24 w-full" />
+      </div>
+    </div>
+  )
+}

--- a/src/modules/common/components/skeleton/product-card-skeleton.tsx
+++ b/src/modules/common/components/skeleton/product-card-skeleton.tsx
@@ -1,0 +1,11 @@
+import Skeleton from "@modules/common/components/skeleton"
+
+export default function ProductCardSkeleton() {
+  return (
+    <div className="space-y-3">
+      <Skeleton variant="rect" className="w-full aspect-[4/5]" />
+      <Skeleton variant="text" className="h-4 w-3/4" />
+      <Skeleton variant="text" className="h-4 w-1/3" />
+    </div>
+  )
+}

--- a/src/modules/common/components/skeleton/product-detail-skeleton.tsx
+++ b/src/modules/common/components/skeleton/product-detail-skeleton.tsx
@@ -1,0 +1,19 @@
+import Skeleton from "@modules/common/components/skeleton"
+
+export default function ProductDetailSkeleton() {
+  return (
+    <div className="content-container py-8 grid grid-cols-1 lg:grid-cols-2 gap-8">
+      <Skeleton variant="rect" className="w-full aspect-square" />
+      <div className="space-y-4">
+        <Skeleton variant="text" className="h-8 w-2/3" />
+        <Skeleton variant="text" className="h-6 w-1/4" />
+        <div className="space-y-2 pt-2">
+          <Skeleton variant="text" className="h-4 w-full" />
+          <Skeleton variant="text" className="h-4 w-[90%]" />
+          <Skeleton variant="text" className="h-4 w-[70%]" />
+        </div>
+        <Skeleton variant="rect" className="h-11 w-full sm:w-56" />
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
### Motivation
- Provide a polished M1 frontend finish: a friendly bilingual 404, consistent skeleton loading states across store routes, and robust runtime error handling.  
- Improve perceived performance and UX during data fetches by introducing reusable skeleton components and route-level loading UIs.  
- Prevent child-component runtime failures from breaking the whole app shell by adding an Error Boundary around the main layout.

### Description
- Replaced the default 404 with a Nordic-minimal bilingual page at `src/app/not-found.tsx` featuring a large centered “404”, a Chinese/English subtitle, a "返回首页" CTA, and an inline search form that trims input and guards against empty submissions.  
- Added a reusable `Skeleton` component (`src/modules/common/components/skeleton/index.tsx`) supporting `width`, `height`, `className`, and `variant: "text" | "rect" | "circle"` and using `animate-pulse` with dark-mode colors.  
- Added skeleton templates: `product-card-skeleton.tsx`, `product-detail-skeleton.tsx`, and `page-skeleton.tsx` under `src/modules/common/components/skeleton/`.  
- Wired skeletons into route-level loading screens for store areas under the site routing structure: products list, product detail, collections, and cart (new `loading.tsx` files under `src/app/[locale]/[countryCode]/(main)/...`).  
- Implemented a class-based `ErrorBoundary` (`src/modules/common/components/error-boundary/index.tsx`) with `getDerivedStateFromError`, `componentDidCatch`, console logging, optional `fallback`, and reload/home buttons; wrapped the main layout children with `<ErrorBoundary>` in `src/app/[locale]/[countryCode]/(main)/layout.tsx`.  
- Added Next.js App Router error boundaries `src/app/error.tsx` and `src/app/global-error.tsx` with the same friendly UI and `reset`/reload/home actions.

### Testing
- Ran `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY=dummy npm run dev` and verified the dev server started and the new 404 page visually; a screenshot was captured at `browser:/tmp/codex_browser_invocations/8741d674893518f4/artifacts/artifacts/not-found-page.png`. (succeeded)  
- Attempted `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY=dummy npm run build` which failed due to network blocking of Google Fonts required by `next/font` in this environment (network/font fetch error), not changes introduced by this patch. (failed: environment/network)  
- Ran `npx tsc --noEmit` which reported pre-existing TypeScript errors in unrelated modules in the repository (these type errors existed before these changes). (failed: unrelated type errors)  
- Ran `npx eslint` against changed files which surfaced an environment/config ESLint rule-loading issue (`@next/next/no-html-link-for-pages` loader error) in this environment. (failed: lint config/environment)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b022cfa85483339e177b491b2f62cf)