### PR TITLE
feat(admin): add admin dashboard home, layout and unified sidebar

### DIFF
--- a/src/app/[locale]/[countryCode]/(main)/account/@dashboard/admin/layout.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/account/@dashboard/admin/layout.tsx
@@ -1,0 +1,14 @@
+import AdminSidebar from "@modules/admin/components/admin-sidebar"
+
+export default function AdminDashboardLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <div className="grid grid-cols-1 gap-6 lg:grid-cols-[260px_1fr]">
+      <AdminSidebar />
+      <div>{children}</div>
+    </div>
+  )
+}

--- a/src/app/[locale]/[countryCode]/(main)/account/@dashboard/admin/page.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/account/@dashboard/admin/page.tsx
@@ -1,0 +1,140 @@
+import { isAdmin } from "@lib/util/admin-guard"
+import Link from "next/link"
+import { redirect } from "next/navigation"
+
+const kpiCards = [
+  {
+    label: "今日订单数",
+    value: "128",
+    change: "+12.6%",
+    trend: "↑",
+    trendUp: true,
+    // TODO: Replace with GET /admin/analytics/orders-today
+  },
+  {
+    label: "今日收入",
+    value: "¥86,420",
+    change: "+8.3%",
+    trend: "↑",
+    trendUp: true,
+    // TODO: Replace with GET /admin/analytics/revenue-today
+  },
+  {
+    label: "在线访客数",
+    value: "342",
+    change: "-3.1%",
+    trend: "↓",
+    trendUp: false,
+    // TODO: Replace mock data with realtime visitor service
+  },
+  {
+    label: "待处理工单数",
+    value: "17",
+    change: "+5.9%",
+    trend: "↑",
+    trendUp: true,
+    // TODO: Replace with GET /admin/after-sales/tickets?status=open
+  },
+]
+
+const recentOrders = [
+  { id: "100901", customer: "Lina Wang", amount: "¥1,299", status: "待发货", time: "10:32" },
+  { id: "100900", customer: "Mia Chen", amount: "¥899", status: "已付款", time: "10:20" },
+  { id: "100899", customer: "Kevin Yu", amount: "¥2,399", status: "已发货", time: "10:14" },
+  { id: "100898", customer: "Alex Wu", amount: "¥429", status: "退款中", time: "09:58" },
+  { id: "100897", customer: "Ivy Li", amount: "¥3,120", status: "待发货", time: "09:31" },
+  { id: "100896", customer: "Sophie Yan", amount: "¥749", status: "已完成", time: "09:05" },
+  { id: "100895", customer: "Noah Gu", amount: "¥1,050", status: "已付款", time: "08:47" },
+  { id: "100894", customer: "Emma Hao", amount: "¥1,589", status: "已发货", time: "08:22" },
+  { id: "100893", customer: "Chris Zhao", amount: "¥629", status: "待发货", time: "08:09" },
+  { id: "100892", customer: "Olivia Xu", amount: "¥2,060", status: "已完成", time: "07:43" },
+  // TODO: Replace with GET /admin/orders?limit=10
+]
+
+const openTickets = [
+  { id: "AS-2201", customer: "Lina Wang", type: "退货", priority: "高" },
+  { id: "AS-2200", customer: "Mia Chen", type: "维修", priority: "中" },
+  { id: "AS-2198", customer: "Kevin Yu", type: "咨询", priority: "低" },
+  { id: "AS-2197", customer: "Ivy Li", type: "退货", priority: "高" },
+  { id: "AS-2196", customer: "Alex Wu", type: "维修", priority: "中" },
+  // TODO: Replace with GET /admin/after-sales/tickets?status=open&limit=5
+]
+
+export default async function AdminHomePage({
+  params,
+}: {
+  params: Promise<{ countryCode: string }>
+}) {
+  const { countryCode } = await params
+
+  if (!(await isAdmin())) {
+    redirect(`/${countryCode}/account`)
+  }
+
+  return (
+    <div className="space-y-6">
+      <section className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+        {kpiCards.map((card) => (
+          <article key={card.label} className="rounded-2xl border border-grey-20 bg-white p-5 shadow-sm">
+            <p className="text-sm text-grey-50">{card.label}</p>
+            <p className="mt-3 text-3xl font-semibold text-forest">{card.value}</p>
+            <p className={card.trendUp ? "mt-2 text-sm text-emerald-700" : "mt-2 text-sm text-rose-700"}>
+              {card.trend} {card.change}
+            </p>
+          </article>
+        ))}
+      </section>
+
+      <section className="rounded-2xl border border-grey-20 bg-white p-5 shadow-sm">
+        <h3 className="mb-4 text-lg font-semibold text-grey-80">最近订单</h3>
+        <div className="overflow-x-auto">
+          <table className="min-w-full text-left text-sm">
+            <thead>
+              <tr className="border-b border-grey-20 text-grey-50">
+                <th className="py-2">订单号</th>
+                <th className="py-2">客户名</th>
+                <th className="py-2">金额</th>
+                <th className="py-2">状态</th>
+                <th className="py-2">时间</th>
+              </tr>
+            </thead>
+            <tbody>
+              {recentOrders.map((order) => (
+                <tr key={order.id} className="border-b border-grey-10">
+                  <td className="py-3">
+                    <Link className="text-forest hover:underline" href={`/${countryCode}/account/admin/oms/orders/${order.id}`}>
+                      #{order.id}
+                    </Link>
+                  </td>
+                  <td className="py-3 text-grey-70">{order.customer}</td>
+                  <td className="py-3 text-grey-70">{order.amount}</td>
+                  <td className="py-3 text-grey-70">{order.status}</td>
+                  <td className="py-3 text-grey-50">{order.time}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="rounded-2xl border border-grey-20 bg-white p-5 shadow-sm">
+        <h3 className="mb-4 text-lg font-semibold text-grey-80">待处理工单</h3>
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+          {openTickets.map((ticket) => (
+            <Link
+              key={ticket.id}
+              href={`/${countryCode}/account/admin/after-sales`}
+              className="rounded-xl border border-grey-20 bg-warm px-4 py-3 transition hover:border-forest"
+            >
+              <p className="text-sm font-medium text-grey-80">{ticket.id}</p>
+              <p className="mt-1 text-sm text-grey-60">{ticket.customer}</p>
+              <p className="mt-1 text-sm text-grey-50">
+                {ticket.type} · 紧急程度 {ticket.priority}
+              </p>
+            </Link>
+          ))}
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/modules/admin/components/admin-sidebar/index.tsx
+++ b/src/modules/admin/components/admin-sidebar/index.tsx
@@ -1,0 +1,96 @@
+"use client"
+
+import { clx } from "@medusajs/ui"
+import LocalizedClientLink from "@modules/common/components/localized-client-link"
+import { usePathname } from "next/navigation"
+
+const adminNav = [
+  { label: "🏠 仪表盘", href: "/account/admin" },
+  {
+    label: "📦 订单管理",
+    href: "/account/admin/oms",
+    children: [
+      { label: "订单列表", href: "/account/admin/oms/orders" },
+      { label: "发货管理", href: "/account/admin/oms/shipments" },
+    ],
+  },
+  { label: "🛍️ 产品管理", href: "/app/products", external: true },
+  { label: "👥 客户管理", href: "/account/admin/crm" },
+  { label: "📊 数据分析", href: "/account/admin/analytics" },
+  { label: "💰 财务报表", href: "/account/admin/finance" },
+  { label: "📦 库存管理", href: "/account/admin/inventory" },
+  { label: "🧾 售后工单", href: "/account/admin/after-sales" },
+  { label: "🔐 权限管理", href: "/account/admin/permissions" },
+]
+
+const isActivePath = (pathname: string, href: string) =>
+  pathname === href || pathname.startsWith(`${href}/`)
+
+export default function AdminSidebar() {
+  const pathname = usePathname()
+
+  return (
+    <aside className="rounded-2xl border border-grey-20 bg-white p-4">
+      <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-grey-60">
+        Admin Console
+      </h2>
+      <nav className="space-y-1">
+        {adminNav.map((item) => {
+          const active = isActivePath(pathname, item.href)
+
+          if (item.external) {
+            return (
+              <a
+                key={item.href}
+                className="block rounded-xl px-3 py-2 text-sm text-grey-70 transition hover:bg-warm-dark"
+                href={item.href}
+                target="_blank"
+                rel="noreferrer"
+              >
+                {item.label}
+              </a>
+            )
+          }
+
+          return (
+            <div key={item.href}>
+              <LocalizedClientLink
+                href={item.href}
+                className={clx(
+                  "block rounded-xl px-3 py-2 text-sm transition",
+                  active
+                    ? "bg-forest text-white"
+                    : "text-grey-70 hover:bg-warm-dark"
+                )}
+              >
+                {item.label}
+              </LocalizedClientLink>
+              {item.children && (
+                <div className="mt-1 space-y-1 pl-3">
+                  {item.children.map((child) => {
+                    const childActive = isActivePath(pathname, child.href)
+
+                    return (
+                      <LocalizedClientLink
+                        key={child.href}
+                        href={child.href}
+                        className={clx(
+                          "block rounded-lg px-3 py-1.5 text-sm transition",
+                          childActive
+                            ? "bg-warm-dark text-forest"
+                            : "text-grey-50 hover:bg-grey-10"
+                        )}
+                      >
+                        {child.label}
+                      </LocalizedClientLink>
+                    )
+                  })}
+                </div>
+              )}
+            </div>
+          )
+        })}
+      </nav>
+    </aside>
+  )
+}


### PR DESCRIPTION
### Motivation
- Provide a first-pass Admin Dashboard experience under the existing account dashboard segment so admins have a central homepage with KPIs, recent orders and open tickets.
- Introduce a unified left-side admin navigation to ensure consistent admin routing and highlight the active section across admin pages.
- Use mock/placeholder data and `TODO` markers so the UI can be reviewed and iterated before backend API wiring.

### Description
- Added an admin layout at `src/app/[locale]/[countryCode]/(main)/account/@dashboard/admin/layout.tsx` that composes the page with a left `AdminSidebar` and a right content area.
- Implemented the dashboard homepage at `src/app/[locale]/[countryCode]/(main)/account/@dashboard/admin/page.tsx` containing 4 KPI cards, a recent orders table (up to 10 rows linking to `/account/admin/oms/orders/[id]`), and an open tickets card list (up to 5 rows); all data is mocked and annotated with `TODO` comments for API integration.
- Introduced a reusable sidebar component at `src/modules/admin/components/admin-sidebar/index.tsx` with the requested navigation structure (Dashboard, OMS with children, Products → external Medusa Admin link, CRM, Analytics, Finance, Inventory, After-sales, Permissions) and active-path highlighting using `usePathname` and `LocalizedClientLink`.
- Styling uses the project Tailwind tokens (brand/forest/warm color usage) and existing UI utilities like `clx` from `@medusajs/ui`; access control checks use `isAdmin` and `redirect` from `next/navigation` to gate the page.

### Testing
- Ran `yarn lint` which failed due to missing environment variable `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY` so lint could not complete.
- Ran `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY=dummy yarn lint` which still returned a pre-existing ESLint rule/config error unrelated to these changes and therefore did not pass.
- Started the app with `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY=dummy yarn dev` and programmatically navigated to `/en/us/account/admin` and captured a full-page screenshot (successful), validating the UI renders and the sidebar/layout are displayed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b022e750588333bdedc8be6e708954)