### PR TITLE
fix: resolve brand ReferenceError in multi-brand components

### DIFF
--- a/src/app/[locale]/[countryCode]/(main)/layout.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/layout.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from "next"
+import { cookies } from "next/headers"
 
 import { listCartOptions, retrieveCart } from "@lib/data/cart"
 import { retrieveCustomer } from "@lib/data/customer"
@@ -10,6 +11,7 @@ import ErrorBoundary from "@modules/common/components/error-boundary"
 import Footer from "@modules/layout/templates/footer"
 import Nav from "@modules/layout/templates/nav"
 import FreeShippingPriceNudge from "@modules/shipping/components/free-shipping-price-nudge"
+import { getBrandConfig } from "@/config/brands"
 
 export const metadata: Metadata = {
   metadataBase: new URL("https://nordhjem.store"),
@@ -28,6 +30,8 @@ export const metadata: Metadata = {
 }
 
 export default async function PageLayout(props: { children: React.ReactNode }) {
+  const cookieStore = await cookies()
+  const brand = getBrandConfig(cookieStore.get("nordhjem-brand")?.value)
   const customer = await retrieveCustomer()
   const cart = await retrieveCart()
   let shippingOptions: StoreCartShippingOption[] = []

--- a/src/config/brands.ts
+++ b/src/config/brands.ts
@@ -55,3 +55,7 @@ export const getBrandBySlug = (slug?: string | null): Brand => {
 
   return brands.find((brand) => brand.slug === slug) ?? getDefaultBrand()
 }
+
+export const getBrandConfig = (slug?: string | null): Brand => {
+  return getBrandBySlug(slug)
+}

--- a/src/lib/context/brand-context.tsx
+++ b/src/lib/context/brand-context.tsx
@@ -10,6 +10,7 @@ type BrandContextValue = {
 }
 
 const STORAGE_KEY = "nordhjem-brand"
+const COOKIE_MAX_AGE = 60 * 60 * 24 * 365
 
 const BrandContext = createContext<BrandContextValue | null>(null)
 
@@ -23,27 +24,40 @@ const applyBrandCssVariables = (brand: Brand) => {
   root.style.setProperty("--brand-font", `'${brand.fontFamily}', sans-serif`)
 }
 
-export function BrandProvider({ children }: { children: ReactNode }) {
-  const [currentBrand, setCurrentBrand] = useState<Brand>(() => getDefaultBrand())
+const persistBrandSlug = (slug: string) => {
+  if (typeof window === "undefined") return
+
+  window.localStorage.setItem(STORAGE_KEY, slug)
+  document.cookie = `${STORAGE_KEY}=${slug}; path=/; max-age=${COOKIE_MAX_AGE}; samesite=lax`
+}
+
+export function BrandProvider({
+  children,
+  brand,
+}: {
+  children: ReactNode
+  brand?: Brand
+}) {
+  const [currentBrand, setCurrentBrand] = useState<Brand>(() => brand ?? getDefaultBrand())
 
   useEffect(() => {
     const savedSlug = window.localStorage.getItem(STORAGE_KEY)
-    const initialBrand = getBrandBySlug(savedSlug)
+    const initialBrand = getBrandBySlug(savedSlug ?? brand?.slug)
 
     setCurrentBrand(initialBrand)
     applyBrandCssVariables(initialBrand)
 
     if (!savedSlug || savedSlug !== initialBrand.slug) {
-      window.localStorage.setItem(STORAGE_KEY, initialBrand.slug)
+      persistBrandSlug(initialBrand.slug)
     }
-  }, [])
+  }, [brand?.slug])
 
   const switchBrand = (slug: string) => {
     const nextBrand = getBrandBySlug(slug)
 
     setCurrentBrand(nextBrand)
     applyBrandCssVariables(nextBrand)
-    window.localStorage.setItem(STORAGE_KEY, nextBrand.slug)
+    persistBrandSlug(nextBrand.slug)
   }
 
   const value = useMemo(


### PR DESCRIPTION
### Motivation
- A server-side `ReferenceError: brand is not defined` occurred because the main locale/country layout referenced a `brand` variable that wasn't defined during SSR, causing 500 responses. 
- The intent is to make brand resolution server-safe with a default fallback and ensure client/provider wiring remains compatible with runtime switching.

### Description
- `src/app/[locale]/[countryCode]/(main)/layout.tsx`: read `nordhjem-brand` from request cookies using `cookies()` and resolve the brand with `getBrandConfig(...)`, then pass the resolved brand into `BrandProvider` to avoid undefined `brand` on the server. 
- `src/config/brands.ts`: added `getBrandConfig(slug?: string | null)` which delegates to `getBrandBySlug(...)` and preserves the existing `getDefaultBrand()` fallback (NordHjem). 
- `src/lib/context/brand-context.tsx`: updated `BrandProvider` to accept an optional initial `brand` prop for SSR, derive initial state from that prop or localStorage, and persist selected brand slug to both `localStorage` and a cookie so SSR can pick up the selection later; kept CSS variable application and runtime `switchBrand` behavior. 

### Testing
- Searched occurrences with `rg -n "\bbrand\b|getBrandConfig|brand-context|brands" src` and verified references were located and scoped correctly (succeeds). 
- Ran `npm run build` which failed due to missing required environment variable `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY` (build precheck stops). 
- Ran `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY=dummy npm run build` which started but failed in this environment due to network font fetch errors from Google Fonts (Next.js font download retries exhausted). 
- Ran `npx tsc --noEmit` to validate types and observed unrelated, pre-existing TypeScript errors in the repository that are outside the scope of this fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b053f40e388333b09faf8fa2b89b4b)