### PR TITLE
Update BrandHero to restore default-brand hero treatment

### DIFF
--- a/src/modules/home/components/brand-hero/index.tsx
+++ b/src/modules/home/components/brand-hero/index.tsx
@@ -1,6 +1,7 @@
 "use client"
-
 import { Brand } from "@/config/brands"
+import { getDefaultBrand } from "@/config/brands"
+import { useTranslations } from "next-intl"
 import LocalizedClientLink from "@modules/common/components/localized-client-link"
 
 type BrandHeroProps = {
@@ -8,6 +9,45 @@ type BrandHeroProps = {
 }
 
 const BrandHero = ({ brand }: BrandHeroProps) => {
+  const t = useTranslations("home")
+  const defaultBrand = getDefaultBrand()
+  const isDefault = brand.id === defaultBrand.id
+
+  // Default NordHjem brand: original full-image hero
+  if (isDefault) {
+    return (
+      <div className="relative w-full">
+        <div
+          className="relative min-h-[75vh] flex flex-col justify-center items-center text-center px-6"
+          style={{
+            backgroundImage: "url('/images/hero-banner.jpg')",
+            backgroundSize: "cover",
+            backgroundPosition: "center",
+          }}
+        >
+          <div className="absolute inset-0 bg-black/30" />
+          <div className="relative z-10">
+            <h1 className="text-4xl md:text-6xl lg:text-7xl font-heading text-white mb-4 tracking-tight">
+              {t("heroTitle")}
+            </h1>
+            <p className="text-lg md:text-xl text-white/80 mb-2 font-light italic">
+              {t("heroSubtitle")}
+            </p>
+            <div className="mt-8">
+              <LocalizedClientLink
+                href="/store"
+                className="inline-block bg-white text-[#2C3E2D] px-10 py-4 text-base md:text-lg font-medium hover:bg-[#FAFAF8] transition-colors tracking-wide"
+              >
+                {t("heroCta")}
+              </LocalizedClientLink>
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  // Other brands: gradient + subtle background
   return (
     <section
       className="relative flex min-h-[60vh] items-center justify-center px-6 text-center"


### PR DESCRIPTION
### Motivation
- The home hero should display a special full-image layout for the configured default brand while keeping the gradient hero for other brands.
- Localized copy (title, subtitle, CTA) must be used for the default-brand hero so translations appear correctly.

### Description
- Import `getDefaultBrand` from `@/config/brands` and `useTranslations` from `next-intl` and detect `isDefault` by comparing `brand.id` to `getDefaultBrand().id` in `BrandHero`.
- Add a conditional branch that renders the original full-image hero for the default brand, using `t("heroTitle")`, `t("heroSubtitle")`, and `t("heroCta")` for localized strings.
- Preserve the existing gradient + subtle-background hero for non-default brands and keep the `LocalizedClientLink` CTA behavior unchanged.

### Testing
- Ran `yarn lint`, which failed in this environment due to a missing required env var `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY`.
- Ran `yarn tsc --noEmit`, which failed due to pre-existing TypeScript errors elsewhere in the repository unrelated to this change.
- Started the dev server with `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY=test yarn dev -p 3000`, which started successfully and was used to capture a screenshot of the home page showing the hero variant.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b0a193be5c833395c84affb1ee4ad5)