### PR TITLE
perf: optimize product listing page load time

### DIFF
--- a/src/lib/data/products.ts
+++ b/src/lib/data/products.ts
@@ -7,6 +7,12 @@ import { SortOptions } from "@modules/store/components/refinement-list/sort-prod
 import { getAuthHeaders, getCacheOptions } from "./cookies"
 import { getRegion, retrieveRegion } from "./regions"
 
+export const PRODUCT_LIST_FIELDS =
+  "id,title,handle,thumbnail,collection_id,metadata,*variants.calculated_price"
+
+export const PRODUCT_DETAIL_FIELDS =
+  "*variants.calculated_price,+variants.inventory_quantity,*variants.images,+metadata,+tags,"
+
 export const listProducts = async ({
   pageParam = 1,
   queryParams,
@@ -62,8 +68,7 @@ export const listProducts = async ({
           limit,
           offset,
           region_id: region?.id,
-          fields:
-            "*variants.calculated_price,+variants.inventory_quantity,*variants.images,+metadata,+tags,",
+          fields: queryParams?.fields || PRODUCT_DETAIL_FIELDS,
           ...queryParams,
         },
         headers,

--- a/src/modules/store/components/pagination/index.tsx
+++ b/src/modules/store/components/pagination/index.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { clx } from "@medusajs/ui"
+import { useEffect, useTransition } from "react"
 import { usePathname, useRouter, useSearchParams } from "next/navigation"
 
 export function Pagination({
@@ -15,6 +16,18 @@ export function Pagination({
   const router = useRouter()
   const pathname = usePathname()
   const searchParams = useSearchParams()
+  const [isPending, startTransition] = useTransition()
+
+  useEffect(() => {
+    const productGrid = document.querySelector('[data-testid="products-list"]')
+
+    if (!productGrid) {
+      return
+    }
+
+    productGrid.classList.toggle("opacity-50", isPending)
+    productGrid.classList.toggle("pointer-events-none", isPending)
+  }, [isPending])
 
   // Helper function to generate an array of numbers within a range
   const arrayRange = (start: number, stop: number) =>
@@ -24,7 +37,9 @@ export function Pagination({
   const handlePageChange = (newPage: number) => {
     const params = new URLSearchParams(searchParams)
     params.set("page", newPage.toString())
-    router.push(`${pathname}?${params.toString()}`)
+    startTransition(() => {
+      router.push(`${pathname}?${params.toString()}`, { scroll: false })
+    })
   }
 
   // Function to render a page button
@@ -108,7 +123,14 @@ export function Pagination({
   // Render the component
   return (
     <div className="flex justify-center w-full mt-12">
-      <div className="flex gap-3 items-end" data-testid={dataTestid}>{renderPageButtons()}</div>
+      <div className="flex gap-3 items-end" data-testid={dataTestid}>
+        {renderPageButtons()}
+        {isPending && (
+          <span className="text-sm text-ui-fg-muted" aria-live="polite">
+            Loading...
+          </span>
+        )}
+      </div>
     </div>
   )
 }

--- a/src/modules/store/templates/paginated-products.tsx
+++ b/src/modules/store/templates/paginated-products.tsx
@@ -1,4 +1,4 @@
-import { listProductsWithSort } from "@lib/data/products"
+import { PRODUCT_LIST_FIELDS, listProducts } from "@lib/data/products"
 import { getRegion } from "@lib/data/regions"
 import ProductPreview from "@modules/products/components/product-preview"
 import { Pagination } from "@modules/store/components/pagination"
@@ -12,6 +12,8 @@ type PaginatedProductsParams = {
   category_id?: string[]
   id?: string[]
   order?: string
+  q?: string
+  fields?: string
 }
 
 export default async function PaginatedProducts({
@@ -37,6 +39,7 @@ export default async function PaginatedProducts({
 }) {
   const queryParams: PaginatedProductsParams = {
     limit: 12,
+    fields: PRODUCT_LIST_FIELDS,
   }
 
   if (collectionId) {
@@ -51,8 +54,20 @@ export default async function PaginatedProducts({
     queryParams["id"] = productsIds
   }
 
+  if (searchQuery?.trim()) {
+    queryParams["q"] = searchQuery.trim()
+  }
+
   if (sortBy === "created_at") {
-    queryParams["order"] = "created_at"
+    queryParams["order"] = "-created_at"
+  }
+
+  if (sortBy === "price_asc") {
+    queryParams["order"] = "variants.calculated_price"
+  }
+
+  if (sortBy === "price_desc") {
+    queryParams["order"] = "-variants.calculated_price"
   }
 
   const region = await getRegion(countryCode)
@@ -63,21 +78,12 @@ export default async function PaginatedProducts({
 
   let {
     response: { products, count },
-  } = await listProductsWithSort({
-    page: 1,
-    queryParams: { ...queryParams, limit: 100 },
-    sortBy,
+  } = await listProducts({
+    pageParam: page,
+    queryParams,
     countryCode,
   })
 
-
-  if (searchQuery?.trim()) {
-    const q = searchQuery.toLowerCase()
-    products = products.filter((product) =>
-      product.title?.toLowerCase().includes(q)
-    )
-    count = products.length
-  }
   const minPriceNum = minPrice ? parseInt(minPrice) : undefined
   const maxPriceNum = maxPrice ? parseInt(maxPrice) : undefined
 
@@ -89,13 +95,9 @@ export default async function PaginatedProducts({
       if (maxPriceNum !== undefined && price > maxPriceNum) return false
       return true
     })
-    count = products.length
   }
 
-  const limit = 12
-  const offset = (page - 1) * limit
-  products = products.slice(offset, offset + limit)
-  const totalPages = Math.ceil(count / limit)
+  const totalPages = Math.ceil(count / 12)
 
   if (products.length === 0) {
     return <EmptyResults query={searchQuery} />


### PR DESCRIPTION
### Motivation
- Reduce ~1.5s delay on Store/Categories pages by switching from client-side heavy pagination to server-side pagination and slimming listing API payloads.
- Provide visual feedback during page transitions so users see loading state while server-side pagination occurs.

### Description
- Added `PRODUCT_LIST_FIELDS` and `PRODUCT_DETAIL_FIELDS` constants and updated `listProducts` to use `queryParams.fields` when provided while keeping detail defaults. (src/lib/data/products.ts)
- Replaced `listProductsWithSort` usage with `listProducts` in `PaginatedProducts` and switched to server-side pagination: pass `pageParam: page`, `limit: 12`, `fields: PRODUCT_LIST_FIELDS`, use Medusa `q` for non-empty `searchQuery`, and map `sortBy` to Medusa `order` (`created_at` -> `-created_at`, `price_asc` -> `variants.calculated_price`, `price_desc` -> `-variants.calculated_price`). Removed manual client-side search/slicing logic and compute `totalPages = Math.ceil(count / 12)`. (src/modules/store/templates/paginated-products.tsx)
- Improved pagination UX by adding `useTransition`, wrapping `router.push` in `startTransition` with `{ scroll: false }`, exposing a pending indicator and applying `opacity-50` + `pointer-events-none` to the product grid during transition. (src/modules/store/components/pagination/index.tsx)
- Preserved `listProducts` signature and kept full detail fields for product detail pages; only listing pages request the slimmed `PRODUCT_LIST_FIELDS`.

### Testing
- Ran `npm run build`, which failed in this environment due to a missing required env var `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY` (build error reported by Next.js).
- Started dev server with `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY=dummy npm run dev` which booted successfully and was used for visual verification.
- Captured a visual verification screenshot of `/en/store` using an automated Playwright script (artifact: `browser:/tmp/codex_browser_invocations/ab1633e338806de9/artifacts/artifacts/store-pagination.png`).
- Attempted an automated `curl` measurement for `/en/store?page=1`, which returned no content in this environment (size 0) and could not be used to validate the <0.5s SSR timing requirement here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b0c1eddec0833398adeca8de106a92)