### PR TITLE
fix: resolve "use server" export constraints in products data module

### DIFF
--- a/src/lib/data/product-fields.ts
+++ b/src/lib/data/product-fields.ts
@@ -1,0 +1,5 @@
+export const PRODUCT_LIST_FIELDS =
+  "id,title,handle,thumbnail,collection_id,metadata,*variants.calculated_price"
+
+export const PRODUCT_DETAIL_FIELDS =
+  "*variants.calculated_price,+variants.inventory_quantity,*variants.images,+metadata,+tags,"

--- a/src/lib/data/products.ts
+++ b/src/lib/data/products.ts
@@ -5,13 +5,8 @@ import { sortProducts } from "@lib/util/sort-products"
 import { HttpTypes } from "@medusajs/types"
 import { SortOptions } from "@modules/store/components/refinement-list/sort-products"
 import { getAuthHeaders, getCacheOptions } from "./cookies"
+import { PRODUCT_DETAIL_FIELDS } from "./product-fields"
 import { getRegion, retrieveRegion } from "./regions"
-
-export const PRODUCT_LIST_FIELDS =
-  "id,title,handle,thumbnail,collection_id,metadata,*variants.calculated_price"
-
-export const PRODUCT_DETAIL_FIELDS =
-  "*variants.calculated_price,+variants.inventory_quantity,*variants.images,+metadata,+tags,"
 
 export const listProducts = async ({
   pageParam = 1,

--- a/src/modules/store/templates/paginated-products.tsx
+++ b/src/modules/store/templates/paginated-products.tsx
@@ -1,4 +1,5 @@
-import { PRODUCT_LIST_FIELDS, listProducts } from "@lib/data/products"
+import { PRODUCT_LIST_FIELDS } from "@lib/data/product-fields"
+import { listProducts } from "@lib/data/products"
 import { getRegion } from "@lib/data/regions"
 import ProductPreview from "@modules/products/components/product-preview"
 import { Pagination } from "@modules/store/components/pagination"


### PR DESCRIPTION
### Motivation
- `src/lib/data/products.ts` contained `"use server"` but exported non-async constants, which violates Next.js rules for server modules and caused builds to fail.

### Description
- Added `src/lib/data/product-fields.ts` and moved `PRODUCT_LIST_FIELDS` and `PRODUCT_DETAIL_FIELDS` into it so they are not exported from a `"use server"` module.
- Updated `src/lib/data/products.ts` to import `PRODUCT_DETAIL_FIELDS` from `./product-fields` and removed the constant exports from the server file.
- Updated `src/modules/store/templates/paginated-products.tsx` to import `PRODUCT_LIST_FIELDS` from `@lib/data/product-fields` and retain `listProducts` import from `@lib/data/products`.

### Testing
- Ran `yarn build` and confirmed the prior server-export error is no longer present, but the build was blocked by missing environment variable and external font fetch failures in this environment.
- Ran `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY=dummy NEXT_DISABLE_FONT_DOWNLOADS=1 yarn build` which still failed due to font fetch/network issues in the environment.
- Ran `yarn tsc --noEmit` which failed with unrelated pre-existing TypeScript errors not introduced by this refactor.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b0db3cdf808333869a519a7bf77d8d)