### PR TITLE
ci: switch workflow to Yarn and add Medusa publishable key env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
   lint-and-typecheck:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY: "pk_test_placeholder"
 
     steps:
       - name: Checkout
@@ -22,6 +24,9 @@ jobs:
         with:
           node-version: 20
 
+      - name: Setup Yarn
+        run: corepack enable
+
       - name: Cache node_modules
         uses: actions/cache@v4
         with:
@@ -31,10 +36,10 @@ jobs:
             ${{ runner.os }}-node-modules-
 
       - name: Install dependencies
-        run: npm ci
+        run: yarn install --immutable
 
       - name: Lint
-        run: npm run lint
+        run: yarn lint
 
       - name: Type check
-        run: npx tsc --noEmit || true
+        run: yarn tsc --noEmit || true


### PR DESCRIPTION
### Motivation
- Fix CI failure caused by `npm ci` running in a repository that uses Yarn and only contains `yarn.lock`, and prevent build/lint failures in CI when `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY` is not set.

### Description
- Updated `.github/workflows/ci.yml` to run `corepack enable` before installs and replace `npm ci` with `yarn install --immutable` to respect the repo `yarn.lock`.
- Switched lint/typecheck steps to use `yarn lint` and `yarn tsc --noEmit || true` so commands run via Yarn in CI.
- Added `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY: "pk_test_placeholder"` to the workflow `env` to avoid missing-environment-variable failures during CI.

### Testing
- Ran `yarn lint` locally which failed due to an existing Next/ESLint rule loading issue unrelated to the installer change (test failed).
- Ran `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY=pk_test_placeholder yarn lint` which still failed for the same pre-existing ESLint issue (test failed).
- Ran `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY=pk_test_placeholder yarn tsc --noEmit` which reported existing TypeScript errors; the workflow retains `|| true` so typecheck remains non-blocking (test reported errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b133e22a1c8333bab68dc6b31a64a9)