### PR TITLE
fix(store): resolve price sort crash and make color filters functional

### DIFF
--- a/src/app/[locale]/[countryCode]/(main)/store/page.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/store/page.tsx
@@ -4,19 +4,41 @@ import { SortOptions } from "@modules/store/components/refinement-list/sort-prod
 import StoreTemplate from "@modules/store/templates"
 
 type Params = {
-  searchParams: Promise<{ sortBy?: SortOptions; page?: string; min_price?: string; max_price?: string; q?: string; colors?: string; materials?: string }>
+  searchParams: Promise<{
+    sortBy?: SortOptions
+    page?: string
+    min_price?: string
+    max_price?: string
+    q?: string
+    colors?: string
+  }>
   params: Promise<{ countryCode: string; locale: string }>
 }
 
 export async function generateMetadata(props: Params): Promise<Metadata> {
   const params = await props.params
   const t = await getTranslations({ locale: params.locale, namespace: "store" })
-  return { title: `${t("allProducts")} | NordHjem`, description: t("allProducts") }
+
+  return {
+    title: `${t("allProducts")} | NordHjem`,
+    description: t("allProducts"),
+  }
 }
 
 export default async function StorePage(props: Params) {
   const params = await props.params
   const searchParams = await props.searchParams
-  const { sortBy, page, min_price, max_price, q, colors, materials } = searchParams
-  return <StoreTemplate sortBy={sortBy} page={page} countryCode={params.countryCode} minPrice={min_price} maxPrice={max_price} searchQuery={q} colors={colors} materials={materials} />
+  const { sortBy, page, min_price, max_price, q, colors } = searchParams
+
+  return (
+    <StoreTemplate
+      sortBy={sortBy}
+      page={page}
+      countryCode={params.countryCode}
+      minPrice={min_price}
+      maxPrice={max_price}
+      searchQuery={q}
+      colors={colors}
+    />
+  )
 }

--- a/src/lib/data/product-fields.ts
+++ b/src/lib/data/product-fields.ts
@@ -1,5 +1,5 @@
 export const PRODUCT_LIST_FIELDS =
-  "id,title,handle,thumbnail,collection_id,metadata,*variants.calculated_price"
+  "id,title,handle,thumbnail,collection_id,metadata,*variants.calculated_price,+options.title,+options.values.value"
 
 export const PRODUCT_DETAIL_FIELDS =
   "*variants.calculated_price,+variants.inventory_quantity,*variants.images,+metadata,+tags,"

--- a/src/modules/store/components/refinement-list/index.tsx
+++ b/src/modules/store/components/refinement-list/index.tsx
@@ -2,35 +2,149 @@
 
 import { usePathname, useRouter, useSearchParams } from "next/navigation"
 import { useTranslations } from "next-intl"
-import SortProducts, { SortOptions } from "./sort-products"
 import PriceFilter from "./price-filter"
+import SortProducts, { SortOptions } from "./sort-products"
 
 const COLOR_OPTIONS = [
+  // Neutrals
   { value: "white", label: "White", labelZh: "白色", hex: "#FFFFFF" },
   { value: "black", label: "Black", labelZh: "黑色", hex: "#000000" },
-  { value: "gray", label: "Gray", labelZh: "灰色", hex: "#808080" },
+  { value: "snow", label: "Snow", labelZh: "雪白色", hex: "#FFFAFA" },
+  { value: "ivory", label: "Ivory", labelZh: "象牙白", hex: "#FFFFF0" },
+  { value: "cream", label: "Cream", labelZh: "奶油色", hex: "#FFFDD0" },
   { value: "beige", label: "Beige", labelZh: "米色", hex: "#F5F5DC" },
-]
-const MATERIAL_OPTIONS = [
-  { value: "wood", label: "Wood", labelZh: "木材" },
-  { value: "metal", label: "Metal", labelZh: "金属" },
-  { value: "fabric", label: "Fabric", labelZh: "面料" },
+  { value: "sand", label: "Sand", labelZh: "沙色", hex: "#C2B280" },
+  { value: "oat", label: "Oat", labelZh: "燕麦色", hex: "#D4C5A9" },
+  { value: "linen", label: "Linen", labelZh: "亚麻色", hex: "#E9DCC9" },
+  // Browns & Tans
+  { value: "caramel", label: "Caramel", labelZh: "焦糖色", hex: "#FFD59A" },
+  { value: "brown", label: "Brown", labelZh: "棕色", hex: "#8B4513" },
+  { value: "walnut", label: "Walnut", labelZh: "胡桃色", hex: "#5C4033" },
+  { value: "teak", label: "Teak", labelZh: "柚木色", hex: "#B8860B" },
+  { value: "oak", label: "Oak", labelZh: "橡木色", hex: "#C8AD7F" },
+  { value: "pine", label: "Pine", labelZh: "松木色", hex: "#BDB76B" },
+  // Grays
+  {
+    value: "dark gray",
+    label: "Dark Gray",
+    labelZh: "深灰色",
+    hex: "#505050",
+  },
+  {
+    value: "charcoal",
+    label: "Charcoal",
+    labelZh: "炭灰色",
+    hex: "#36454F",
+  },
+  {
+    value: "graphite",
+    label: "Graphite",
+    labelZh: "石墨色",
+    hex: "#383838",
+  },
+  // Metals
+  { value: "brass", label: "Brass", labelZh: "黄铜色", hex: "#B5A642" },
+  { value: "pearl", label: "Pearl", labelZh: "珍珠色", hex: "#F0EAD6" },
+  // Greens & Blues
+  {
+    value: "forest",
+    label: "Forest",
+    labelZh: "森林绿",
+    hex: "#228B22",
+  },
+  { value: "sage", label: "Sage", labelZh: "鼠尾草绿", hex: "#BCB88A" },
+  {
+    value: "emerald",
+    label: "Emerald",
+    labelZh: "翡翠绿",
+    hex: "#50C878",
+  },
+  { value: "navy", label: "Navy", labelZh: "海军蓝", hex: "#000080" },
 ]
 
-const RefinementList = ({ sortBy, "data-testid": dataTestId }: { sortBy: SortOptions; search?: boolean; "data-testid"?: string }) => {
+const RefinementList = ({
+  sortBy,
+  "data-testid": dataTestId,
+}: {
+  sortBy: SortOptions
+  search?: boolean
+  "data-testid"?: string
+}) => {
   const t = useTranslations("store")
   const router = useRouter()
   const pathname = usePathname()
   const searchParams = useSearchParams()
   const isZh = pathname?.includes("/zh/") || false
 
-  const setQueryParams = (name: string, value: string) => { const params = new URLSearchParams(searchParams?.toString()); params.set(name, value); router.push(`${pathname}?${params.toString()}`) }
-  const clearQueryParam = (name: string) => { const params = new URLSearchParams(searchParams?.toString()); params.delete(name); router.push(`${pathname}?${params.toString()}`) }
-  const toggleArrayParam = (name: string, value: string) => { const params = new URLSearchParams(searchParams?.toString()); const current = params.get(name)?.split(",").filter(Boolean) || []; const updated = current.includes(value) ? current.filter((v) => v !== value) : [...current, value]; updated.length ? params.set(name, updated.join(",")) : params.delete(name); router.push(`${pathname}?${params.toString()}`) }
-  const activeColors = searchParams?.get("colors")?.split(",").filter(Boolean) || []
-  const activeMaterials = searchParams?.get("materials")?.split(",").filter(Boolean) || []
+  const setQueryParams = (name: string, value: string) => {
+    const params = new URLSearchParams(searchParams?.toString())
+    params.set(name, value)
+    router.push(`${pathname}?${params.toString()}`)
+  }
 
-  return <div className="flex small:flex-col gap-12 py-4 mb-8 small:px-0 pl-6 small:min-w-[250px] small:ml-[1.675rem]"><SortProducts sortBy={sortBy} setQueryParams={setQueryParams} data-testid={dataTestId} /><PriceFilter minPrice={searchParams?.get("min_price") || undefined} maxPrice={searchParams?.get("max_price") || undefined} setQueryParams={setQueryParams} clearQueryParam={clearQueryParam} /><div><h3 className="text-sm font-semibold text-[#2C3E2D] mb-3">{t("filterColor")}</h3><div className="flex flex-wrap gap-2">{COLOR_OPTIONS.map((c)=><button key={c.value} onClick={() => toggleArrayParam("colors", c.value)} className={`w-7 h-7 rounded-full border-2 ${activeColors.includes(c.value)?"border-[#2C3E2D]":"border-gray-200"}`} style={{backgroundColor:c.hex}} title={isZh?c.labelZh:c.label} />)}</div></div><div><h3 className="text-sm font-semibold text-[#2C3E2D] mb-3">{t("filterMaterial")}</h3>{MATERIAL_OPTIONS.map((m)=><label key={m.value} className="flex items-center gap-2"><input type="checkbox" checked={activeMaterials.includes(m.value)} onChange={() => toggleArrayParam("materials", m.value)} /><span>{isZh?m.labelZh:m.label}</span></label>)}</div></div>
+  const clearQueryParam = (name: string) => {
+    const params = new URLSearchParams(searchParams?.toString())
+    params.delete(name)
+    router.push(`${pathname}?${params.toString()}`)
+  }
+
+  const toggleArrayParam = (name: string, value: string) => {
+    const params = new URLSearchParams(searchParams?.toString())
+    const current = params.get(name)?.split(",").filter(Boolean) || []
+    const updated = current.includes(value)
+      ? current.filter((v) => v !== value)
+      : [...current, value]
+
+    if (updated.length) {
+      params.set(name, updated.join(","))
+    } else {
+      params.delete(name)
+    }
+
+    router.push(`${pathname}?${params.toString()}`)
+  }
+
+  const activeColors = searchParams?.get("colors")?.split(",").filter(Boolean) || []
+
+  return (
+    <div className="flex small:flex-col gap-12 py-4 mb-8 small:px-0 pl-6 small:min-w-[250px] small:ml-[1.675rem]">
+      <SortProducts
+        sortBy={sortBy}
+        setQueryParams={setQueryParams}
+        data-testid={dataTestId}
+      />
+      <PriceFilter
+        minPrice={searchParams?.get("min_price") || undefined}
+        maxPrice={searchParams?.get("max_price") || undefined}
+        setQueryParams={setQueryParams}
+        clearQueryParam={clearQueryParam}
+      />
+      <div>
+        <h3 className="text-sm font-semibold text-[#2C3E2D] mb-3">
+          {t("filterColor")}
+        </h3>
+        <div className="flex flex-col gap-1.5 max-h-[300px] overflow-y-auto">
+          {COLOR_OPTIONS.map((c) => (
+            <button
+              key={c.value}
+              onClick={() => toggleArrayParam("colors", c.value)}
+              className={`flex items-center gap-2 px-2 py-1 rounded text-sm text-left transition-colors ${
+                activeColors.includes(c.value)
+                  ? "bg-[#2C3E2D]/10 text-[#2C3E2D] font-medium"
+                  : "text-gray-600 hover:text-[#2C3E2D]"
+              }`}
+            >
+              <span
+                className="w-4 h-4 rounded-full border border-gray-300 flex-shrink-0"
+                style={{ backgroundColor: c.hex }}
+              />
+              <span>{isZh ? c.labelZh : c.label}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
 }
 
 export default RefinementList

--- a/src/modules/store/templates/index.tsx
+++ b/src/modules/store/templates/index.tsx
@@ -1,15 +1,66 @@
 import { Suspense } from "react"
+import { getTranslations } from "next-intl/server"
 import SkeletonProductGrid from "@modules/skeletons/templates/skeleton-product-grid"
 import RefinementList from "@modules/store/components/refinement-list"
 import { SortOptions } from "@modules/store/components/refinement-list/sort-products"
-import { getTranslations } from "next-intl/server"
 import PaginatedProducts from "./paginated-products"
 
-const StoreTemplate = async ({ sortBy, page, countryCode, minPrice, maxPrice, searchQuery, colors, materials }: { sortBy?: SortOptions; page?: string; countryCode: string; minPrice?: string; maxPrice?: string; searchQuery?: string; colors?: string; materials?: string }) => {
+const StoreTemplate = async ({
+  sortBy,
+  page,
+  countryCode,
+  minPrice,
+  maxPrice,
+  searchQuery,
+  colors,
+}: {
+  sortBy?: SortOptions
+  page?: string
+  countryCode: string
+  minPrice?: string
+  maxPrice?: string
+  searchQuery?: string
+  colors?: string
+}) => {
   const t = await getTranslations("store")
   const pageNumber = page ? parseInt(page) : 1
   const sort = sortBy || "recommended"
-  return <div className="flex flex-col small:flex-row small:items-start py-6 content-container bg-[#FAFAF8]" data-testid="category-container"><RefinementList sortBy={sort} /><div className="w-full"><div className="mb-8 text-2xl-semi text-[#2C3E2D] font-heading">{searchQuery ? <><h1 data-testid="store-page-title">{t("searchResultsFor", { query: searchQuery })}</h1><p className="text-sm text-[#2C3E2D]/50 font-normal mt-1">{t("searchResultsHint")}</p></> : <h1 data-testid="store-page-title">{t("allProducts")}</h1>}</div><Suspense fallback={<SkeletonProductGrid />}><PaginatedProducts sortBy={sort} page={pageNumber} countryCode={countryCode} minPrice={minPrice} maxPrice={maxPrice} searchQuery={searchQuery} colors={colors} materials={materials} /></Suspense></div></div>
+
+  return (
+    <div
+      className="flex flex-col small:flex-row small:items-start py-6 content-container bg-[#FAFAF8]"
+      data-testid="category-container"
+    >
+      <RefinementList sortBy={sort} />
+      <div className="w-full">
+        <div className="mb-8 text-2xl-semi text-[#2C3E2D] font-heading">
+          {searchQuery ? (
+            <>
+              <h1 data-testid="store-page-title">
+                {t("searchResultsFor", { query: searchQuery })}
+              </h1>
+              <p className="text-sm text-[#2C3E2D]/50 font-normal mt-1">
+                {t("searchResultsHint")}
+              </p>
+            </>
+          ) : (
+            <h1 data-testid="store-page-title">{t("allProducts")}</h1>
+          )}
+        </div>
+        <Suspense fallback={<SkeletonProductGrid />}>
+          <PaginatedProducts
+            sortBy={sort}
+            page={pageNumber}
+            countryCode={countryCode}
+            minPrice={minPrice}
+            maxPrice={maxPrice}
+            searchQuery={searchQuery}
+            colors={colors}
+          />
+        </Suspense>
+      </div>
+    </div>
+  )
 }
 
 export default StoreTemplate

--- a/src/modules/store/templates/paginated-products.tsx
+++ b/src/modules/store/templates/paginated-products.tsx
@@ -1,6 +1,7 @@
 import { PRODUCT_LIST_FIELDS } from "@lib/data/product-fields"
 import { listProducts } from "@lib/data/products"
 import { getRegion } from "@lib/data/regions"
+import { sortProducts } from "@lib/util/sort-products"
 import ProductPreview from "@modules/products/components/product-preview"
 import { Pagination } from "@modules/store/components/pagination"
 import { SortOptions } from "@modules/store/components/refinement-list/sort-products"
@@ -27,7 +28,6 @@ export default async function PaginatedProducts({
   maxPrice,
   searchQuery,
   colors,
-  materials,
 }: {
   sortBy?: SortOptions
   page: number
@@ -39,10 +39,9 @@ export default async function PaginatedProducts({
   maxPrice?: string
   searchQuery?: string
   colors?: string
-  materials?: string
 }) {
   const queryParams: PaginatedProductsParams = {
-    limit: 12,
+    limit: 100,
     fields: PRODUCT_LIST_FIELDS,
   }
 
@@ -62,18 +61,6 @@ export default async function PaginatedProducts({
     queryParams["q"] = searchQuery.trim()
   }
 
-  if (sortBy === "created_at") {
-    queryParams["order"] = "-created_at"
-  }
-
-  if (sortBy === "price_asc") {
-    queryParams["order"] = "variants.calculated_price"
-  }
-
-  if (sortBy === "price_desc") {
-    queryParams["order"] = "-variants.calculated_price"
-  }
-
   const region = await getRegion(countryCode)
 
   if (!region) {
@@ -87,6 +74,11 @@ export default async function PaginatedProducts({
     queryParams,
     countryCode,
   })
+
+  // Client-side sort (Medusa v2 Store API does not support sort by calculated_price)
+  if (sortBy && sortBy !== "recommended") {
+    products = sortProducts(products, sortBy)
+  }
 
   const minPriceNum = minPrice ? parseInt(minPrice) : undefined
   const maxPriceNum = maxPrice ? parseInt(maxPrice) : undefined
@@ -112,20 +104,12 @@ export default async function PaginatedProducts({
     })
   }
 
-  if (materials) {
-    const materialList = materials.split(",").map((m) => m.trim().toLowerCase())
-    products = products.filter((product) => {
-      const opts = product.options || []
-      const matOpt = opts.find((o: any) => o.title?.toLowerCase() === "material")
-      if (!matOpt) return false
-      const vals = matOpt.values?.map((v: any) => v.value?.toLowerCase()) || []
-      return materialList.some((m) => vals.includes(m))
-    })
-  }
-
   count = products.length
 
-  const totalPages = Math.ceil(count / 12)
+  const ITEMS_PER_PAGE = 12
+  const startIndex = (page - 1) * ITEMS_PER_PAGE
+  products = products.slice(startIndex, startIndex + ITEMS_PER_PAGE)
+  const totalPages = Math.ceil(count / ITEMS_PER_PAGE)
 
   if (products.length === 0) {
     return <EmptyResults query={searchQuery} />


### PR DESCRIPTION
### Motivation
- Fix a critical crash when sorting by price that was caused by sending unsupported `order` fields (e.g. `variants.calculated_price`) to the Medusa v2 Store API.
- Make color filtering functional by ensuring product `options` are fetched and by aligning the UI with the actual catalog colors.
- Remove the ineffective material filter because the dataset contains no Material option, and ensure sorting/filtering happen correctly before pagination.

### Description
- Move sorting into the client: import and use `sortProducts()` in `src/modules/store/templates/paginated-products.tsx`, remove the invalid API `order` usage for `price_asc`, `price_desc`, and `created_at`, fetch more products (`limit: 100`), then apply client-side sorting and manual pagination (`ITEMS_PER_PAGE = 12`).
- Include product options in list responses by updating `PRODUCT_LIST_FIELDS` in `src/lib/data/product-fields.ts` to add `+options.title,+options.values.value`.
- Replace the color refinement component in `src/modules/store/components/refinement-list/index.tsx` with a 24-color `COLOR_OPTIONS` set and a new UI that shows a swatch plus a text label per color, and remove the `MATERIAL_OPTIONS` UI.
- Remove the `materials` prop/parameter from the page and template: update `src/modules/store/templates/index.tsx` and `src/app/[locale]/[countryCode]/(main)/store/page.tsx` to stop collecting or passing `materials`, and remove material filtering logic from `paginated-products.tsx`.

### Testing
- Attempted production build with `npm run build`, which failed due to missing `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY` environment variable (automated check).
- Attempted production build with `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY=pk_test npm run build`, which started but failed in this environment because Google Fonts fetches are blocked during build (network/font fetch errors) and prevented a full successful build.
- Started the dev server (`NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY=pk_test npm run dev`) successfully in this environment, but requests to the store page returned 500 because the local Medusa backend (`localhost:9000`) was not available in the test environment.
- Ran a headless Playwright script to load `/en/dk/store` and capture a screenshot of the updated refinement panel, which completed and produced an artifact demonstrating the new color UI.
- Ran automated search checks (`rg`) to confirm `materials` usages were removed from the modified code paths, which returned the expected results.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b245bfdda083339b160650193229a3)