### PR TITLE
fix: resolve phase1 remaining frontend bugs (#4-#7)

### DIFF
--- a/src/app/[locale]/[countryCode]/(main)/about/page.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/about/page.tsx
@@ -1,15 +1,31 @@
-import { getTranslations, getLocale } from "next-intl/server"
+import { getLocale, getTranslations } from "next-intl/server"
 import { Metadata } from "next"
 
 export const metadata: Metadata = {
   title: "About Us | NordHjem",
-  description: "Discover the story behind NordHjem — Nordic minimalist home furnishing, designed with simplicity and warmth.",
+  description:
+    "Discover the story behind NordHjem — Nordic minimalist home furnishing, designed with simplicity and warmth.",
 }
 
 const TEAM_MEMBERS = [
-  { name: "Erik Larsson", nameZh: "Erik Larsson", role: "Founder & CEO", roleZh: "创始人兼首席执行官" },
-  { name: "Ingrid Holm", nameZh: "Ingrid Holm", role: "Head of Design", roleZh: "设计总监" },
-  { name: "Nils Andersen", nameZh: "Nils Andersen", role: "Head of Sustainability", roleZh: "可持续发展总监" },
+  {
+    name: "Erik Larsson",
+    nameZh: "Erik Larsson",
+    role: "Founder & CEO",
+    roleZh: "创始人兼首席执行官",
+  },
+  {
+    name: "Ingrid Holm",
+    nameZh: "Ingrid Holm",
+    role: "Head of Design",
+    roleZh: "设计总监",
+  },
+  {
+    name: "Nils Andersen",
+    nameZh: "Nils Andersen",
+    role: "Head of Sustainability",
+    roleZh: "可持续发展总监",
+  },
 ]
 
 const BRAND_VALUES = [
@@ -25,8 +41,78 @@ export default async function AboutPage() {
 
   return (
     <main className="bg-[#FAFAF8]">
-      <section className="relative min-h-[40vh] flex items-center justify-center text-center"><div className="absolute inset-0 bg-[#2C3E2D]" /><div className="relative z-10 px-6 py-16"><h1 className="text-4xl md:text-5xl font-heading text-white mb-4">{t("title")}</h1><p className="text-lg text-white/70 max-w-2xl mx-auto">{t("subtitle")}</p></div></section>
-      <div className="content-container py-16"><section className="mb-16"><h2 className="text-2xl font-heading text-[#2C3E2D] text-center mb-10">{t("sections.values.title")}</h2><div className="grid grid-cols-2 md:grid-cols-4 gap-6">{BRAND_VALUES.map((value)=><div key={value.key} className="bg-white rounded-lg p-6 text-center shadow-sm"><span className="text-3xl mb-3 block">{value.icon}</span><h3 className="font-semibold text-[#2C3E2D] mb-1">{t(`values.${value.key}.title`)}</h3><p className="text-sm text-[#2C3E2D]/60">{t(`values.${value.key}.description`)}</p></div>)}</div></section><section className="mb-16"><h2 className="text-2xl font-heading text-[#2C3E2D] text-center mb-10">{t("team.title")}</h2><div className="grid grid-cols-1 md:grid-cols-3 gap-8 max-w-3xl mx-auto">{TEAM_MEMBERS.map((member)=><div key={member.name} className="text-center"><div className="w-24 h-24 rounded-full bg-[#2C3E2D]/10 mx-auto mb-4 flex items-center justify-center">👤</div><h3 className="font-semibold text-[#2C3E2D]">{isZh ? member.nameZh : member.name}</h3><p className="text-sm text-[#2C3E2D]/60">{isZh ? member.roleZh : member.role}</p></div>)}</div></section></div>
+      <section className="relative flex min-h-[40vh] items-center justify-center text-center">
+        <div className="absolute inset-0 bg-[#2C3E2D]" />
+        <div className="relative z-10 px-6 py-16">
+          <h1 className="mb-4 text-4xl font-heading text-white md:text-5xl">
+            {t("title")}
+          </h1>
+          <p className="mx-auto max-w-2xl text-lg text-white/70">{t("subtitle")}</p>
+        </div>
+      </section>
+
+      <div className="content-container py-16">
+        <section className="mb-16 grid gap-6 md:grid-cols-2">
+          <article className="rounded-xl bg-white p-6 shadow-sm">
+            <h2 className="mb-3 text-2xl font-heading text-[#2C3E2D]">
+              {t("sections.story.title")}
+            </h2>
+            <p className="text-[#2C3E2D]/70">{t("sections.story.body")}</p>
+          </article>
+          <article className="rounded-xl bg-white p-6 shadow-sm">
+            <h2 className="mb-3 text-2xl font-heading text-[#2C3E2D]">
+              {t("sections.mission.title")}
+            </h2>
+            <p className="text-[#2C3E2D]/70">{t("sections.mission.body")}</p>
+          </article>
+        </section>
+
+        <section className="mb-16">
+          <h2 className="mb-10 text-center text-2xl font-heading text-[#2C3E2D]">
+            {t("sections.values.title")}
+          </h2>
+          <p className="mx-auto mb-8 max-w-3xl text-center text-[#2C3E2D]/70">
+            {t("sections.values.body")}
+          </p>
+          <div className="grid grid-cols-2 gap-6 md:grid-cols-4">
+            {BRAND_VALUES.map((value) => (
+              <div
+                key={value.key}
+                className="rounded-lg bg-white p-6 text-center shadow-sm"
+              >
+                <span className="mb-3 block text-3xl">{value.icon}</span>
+                <h3 className="mb-1 font-semibold text-[#2C3E2D]">
+                  {t(`values.${value.key}.title`)}
+                </h3>
+                <p className="text-sm text-[#2C3E2D]/60">
+                  {t(`values.${value.key}.description`)}
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="mb-16">
+          <h2 className="mb-10 text-center text-2xl font-heading text-[#2C3E2D]">
+            {t("team.title")}
+          </h2>
+          <div className="mx-auto grid max-w-3xl grid-cols-1 gap-8 md:grid-cols-3">
+            {TEAM_MEMBERS.map((member) => (
+              <div key={member.name} className="text-center">
+                <div className="mx-auto mb-4 flex h-24 w-24 items-center justify-center rounded-full bg-[#2C3E2D]/10">
+                  👤
+                </div>
+                <h3 className="font-semibold text-[#2C3E2D]">
+                  {isZh ? member.nameZh : member.name}
+                </h3>
+                <p className="text-sm text-[#2C3E2D]/60">
+                  {isZh ? member.roleZh : member.role}
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
+      </div>
     </main>
   )
 }

--- a/src/app/[locale]/[countryCode]/(main)/products/[handle]/page.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/products/[handle]/page.tsx
@@ -37,7 +37,13 @@ function getImagesForVariant(
   }
 
   const imageIdsMap = new Map(variant.images.map((i) => [i.id, true]))
-  return product.images!.filter((i) => imageIdsMap.has(i.id))
+  const matchedImages = product.images?.filter((i) => imageIdsMap.has(i.id)) || []
+
+  if (matchedImages.length) {
+    return matchedImages
+  }
+
+  return variant.images
 }
 
 export async function generateMetadata(props: Props): Promise<Metadata> {

--- a/src/app/[locale]/[countryCode]/(main)/store/page.tsx
+++ b/src/app/[locale]/[countryCode]/(main)/store/page.tsx
@@ -11,6 +11,7 @@ type Params = {
     max_price?: string
     q?: string
     colors?: string
+    materials?: string
   }>
   params: Promise<{ countryCode: string; locale: string }>
 }
@@ -28,7 +29,7 @@ export async function generateMetadata(props: Params): Promise<Metadata> {
 export default async function StorePage(props: Params) {
   const params = await props.params
   const searchParams = await props.searchParams
-  const { sortBy, page, min_price, max_price, q, colors } = searchParams
+  const { sortBy, page, min_price, max_price, q, colors, materials } = searchParams
 
   return (
     <StoreTemplate
@@ -39,6 +40,7 @@ export default async function StorePage(props: Params) {
       maxPrice={max_price}
       searchQuery={q}
       colors={colors}
+      materials={materials}
     />
   )
 }

--- a/src/modules/search/components/search-modal/index.tsx
+++ b/src/modules/search/components/search-modal/index.tsx
@@ -8,9 +8,20 @@ import { MagnifyingGlassMini, XMark } from "@medusajs/icons"
 const POPULAR_SEARCHES = ["sofa", "table", "chair", "lamp"]
 const POPULAR_SEARCHES_ZH = ["沙发", "桌子", "椅子", "灯具"]
 
-type SearchResult = { id: string; title: string; handle: string; thumbnail: string | null }
+type SearchResult = {
+  id: string
+  title: string
+  handle: string
+  thumbnail: string | null
+}
 
-export default function SearchModal({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) {
+export default function SearchModal({
+  isOpen,
+  onClose,
+}: {
+  isOpen: boolean
+  onClose: () => void
+}) {
   const t = useTranslations("search")
   const router = useRouter()
   const params = useParams()
@@ -23,12 +34,156 @@ export default function SearchModal({ isOpen, onClose }: { isOpen: boolean; onCl
   const countryCode = (params?.countryCode as string) || "no"
   const popular = locale.startsWith("zh") ? POPULAR_SEARCHES_ZH : POPULAR_SEARCHES
 
-  useEffect(() => { if (typeof window !== "undefined") { const saved = localStorage.getItem("nordhjem-recent-searches"); if (saved) setRecentSearches(JSON.parse(saved)) } }, [])
-  useEffect(() => { if (isOpen) setTimeout(() => inputRef.current?.focus(), 50) }, [isOpen])
-  useEffect(() => { const k = (e: KeyboardEvent) => e.key === "Escape" && onClose(); if (isOpen) window.addEventListener("keydown", k); return () => window.removeEventListener("keydown", k) }, [isOpen, onClose])
-  useEffect(() => { if (!query.trim() || query.length < 2) return setResults([]); const timer = setTimeout(async () => { setIsLoading(true); const res = await fetch(`/api/products/search?q=${encodeURIComponent(query)}&limit=6`); if (res.ok) setResults((await res.json()).products || []); setIsLoading(false) }, 300); return () => clearTimeout(timer) }, [query])
-  const handleSearch = useCallback((q: string) => { if (!q.trim()) return; const updated = [q, ...recentSearches.filter((s) => s !== q)].slice(0, 5); setRecentSearches(updated); if (typeof window !== "undefined") localStorage.setItem("nordhjem-recent-searches", JSON.stringify(updated)); router.push(`/${locale}/${countryCode}/store?q=${encodeURIComponent(q)}`); onClose() }, [router, locale, countryCode, onClose, recentSearches])
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const saved = localStorage.getItem("nordhjem-recent-searches")
+      if (saved) {
+        setRecentSearches(JSON.parse(saved))
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    if (isOpen) {
+      setTimeout(() => inputRef.current?.focus(), 50)
+    }
+  }, [isOpen])
+
+  useEffect(() => {
+    const handleKeydown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose()
+      }
+    }
+
+    if (isOpen) {
+      window.addEventListener("keydown", handleKeydown)
+    }
+
+    return () => window.removeEventListener("keydown", handleKeydown)
+  }, [isOpen, onClose])
+
+  useEffect(() => {
+    if (!query.trim() || query.length < 2) {
+      setResults([])
+      return
+    }
+
+    const timer = setTimeout(async () => {
+      setIsLoading(true)
+      const res = await fetch(
+        `/api/products/search?q=${encodeURIComponent(query)}&limit=6`
+      )
+
+      if (res.ok) {
+        const data = await res.json()
+        setResults(data.products || [])
+      }
+
+      setIsLoading(false)
+    }, 300)
+
+    return () => clearTimeout(timer)
+  }, [query])
+
+  const handleSearch = useCallback(
+    (q: string) => {
+      if (!q.trim()) return
+
+      const updated = [q, ...recentSearches.filter((s) => s !== q)].slice(0, 5)
+      setRecentSearches(updated)
+
+      if (typeof window !== "undefined") {
+        localStorage.setItem("nordhjem-recent-searches", JSON.stringify(updated))
+      }
+
+      router.push(`/${locale}/${countryCode}/store?q=${encodeURIComponent(q)}`)
+      onClose()
+    },
+    [router, locale, countryCode, onClose, recentSearches]
+  )
 
   if (!isOpen) return null
-  return <div className="fixed inset-0 z-[100]" role="dialog" aria-modal="true"><div className="absolute inset-0 bg-black/40" onClick={onClose} /><div className="relative mx-auto mt-20 max-w-2xl bg-white rounded-xl"><div className="flex items-center gap-3 px-5 py-4 border-b"><MagnifyingGlassMini className="w-5 h-5" /><input ref={inputRef} value={query} onChange={(e) => setQuery(e.target.value)} onKeyDown={(e) => e.key === "Enter" && handleSearch(query)} placeholder={t("placeholder")} className="flex-1" />{query && <button onClick={() => setQuery("")}><XMark className="w-5 h-5" /></button>}</div><div className="p-4 space-y-4">{isLoading ? (<p className="text-sm text-gray-500">Searching...</p>) : results.length > 0 ? (<div className="space-y-1">{results.map((r) => (<button key={r.id} onClick={() => handleSearch(r.title)} className="block w-full text-left px-3 py-2 text-sm rounded-lg hover:bg-gray-100 transition-colors">{r.title}</button>))}</div>) : null}{!query && (<div><p className="text-xs text-gray-400 uppercase tracking-wide mb-2">Popular</p><div className="flex flex-wrap gap-2">{popular.map((term) => (<button key={term} onClick={() => handleSearch(term)} className="px-3 py-1.5 text-sm bg-gray-100 rounded-full hover:bg-gray-200 transition-colors">{term}</button>))}</div></div>)}{recentSearches.length > 0 && (<div><p className="text-xs text-gray-400 uppercase tracking-wide mb-2">Recent</p><div className="flex flex-wrap gap-2">{recentSearches.map((term) => (<button key={term} onClick={() => handleSearch(term)} className="px-3 py-1.5 text-sm bg-gray-50 rounded-full hover:bg-gray-100 transition-colors text-gray-600">{term}</button>))}</div></div>)}</div></div></div>
+
+  return (
+    <div className="fixed inset-0 z-[100]" role="dialog" aria-modal="true">
+      <div className="absolute inset-0 bg-black/40" onClick={onClose} />
+
+      <div className="relative mx-auto mt-20 max-w-2xl rounded-xl bg-white">
+        <div className="flex items-center gap-3 border-b px-5 py-4">
+          <MagnifyingGlassMini className="h-5 w-5" />
+          <input
+            ref={inputRef}
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && handleSearch(query)}
+            placeholder={t("placeholder")}
+            className="flex-1"
+          />
+          {query && (
+            <button onClick={() => setQuery("")}>
+              <XMark className="h-5 w-5" />
+            </button>
+          )}
+        </div>
+
+        <div className="space-y-4 p-4">
+          {isLoading ? (
+            <p className="text-sm text-gray-500">Searching...</p>
+          ) : results.length > 0 ? (
+            <ul className="flex flex-col gap-2">
+              {results.map((r) => (
+                <li key={r.id}>
+                  <button
+                    onClick={() => handleSearch(r.title)}
+                    className="block w-full rounded-lg px-3 py-2 text-left text-sm transition-colors hover:bg-gray-100"
+                  >
+                    {r.title}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+
+          {!query && (
+            <div>
+              <p className="mb-2 text-xs uppercase tracking-wide text-gray-400">
+                Popular
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {popular.map((term) => (
+                  <button
+                    key={term}
+                    onClick={() => handleSearch(term)}
+                    className="rounded-full bg-gray-100 px-3 py-1.5 text-sm transition-colors hover:bg-gray-200"
+                  >
+                    {term}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {recentSearches.length > 0 && (
+            <div>
+              <p className="mb-2 text-xs uppercase tracking-wide text-gray-400">
+                Recent
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {recentSearches.map((term) => (
+                  <button
+                    key={term}
+                    onClick={() => handleSearch(term)}
+                    className="rounded-full bg-gray-50 px-3 py-1.5 text-sm text-gray-600 transition-colors hover:bg-gray-100"
+                  >
+                    {term}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
 }

--- a/src/modules/store/components/refinement-list/index.tsx
+++ b/src/modules/store/components/refinement-list/index.tsx
@@ -6,7 +6,6 @@ import PriceFilter from "./price-filter"
 import SortProducts, { SortOptions } from "./sort-products"
 
 const COLOR_OPTIONS = [
-  // Neutrals
   { value: "white", label: "White", labelZh: "白色", hex: "#FFFFFF" },
   { value: "black", label: "Black", labelZh: "黑色", hex: "#000000" },
   { value: "snow", label: "Snow", labelZh: "雪白色", hex: "#FFFAFA" },
@@ -16,50 +15,34 @@ const COLOR_OPTIONS = [
   { value: "sand", label: "Sand", labelZh: "沙色", hex: "#C2B280" },
   { value: "oat", label: "Oat", labelZh: "燕麦色", hex: "#D4C5A9" },
   { value: "linen", label: "Linen", labelZh: "亚麻色", hex: "#E9DCC9" },
-  // Browns & Tans
   { value: "caramel", label: "Caramel", labelZh: "焦糖色", hex: "#FFD59A" },
   { value: "brown", label: "Brown", labelZh: "棕色", hex: "#8B4513" },
   { value: "walnut", label: "Walnut", labelZh: "胡桃色", hex: "#5C4033" },
   { value: "teak", label: "Teak", labelZh: "柚木色", hex: "#B8860B" },
   { value: "oak", label: "Oak", labelZh: "橡木色", hex: "#C8AD7F" },
   { value: "pine", label: "Pine", labelZh: "松木色", hex: "#BDB76B" },
-  // Grays
-  {
-    value: "dark gray",
-    label: "Dark Gray",
-    labelZh: "深灰色",
-    hex: "#505050",
-  },
-  {
-    value: "charcoal",
-    label: "Charcoal",
-    labelZh: "炭灰色",
-    hex: "#36454F",
-  },
-  {
-    value: "graphite",
-    label: "Graphite",
-    labelZh: "石墨色",
-    hex: "#383838",
-  },
-  // Metals
+  { value: "dark gray", label: "Dark Gray", labelZh: "深灰色", hex: "#505050" },
+  { value: "charcoal", label: "Charcoal", labelZh: "炭灰色", hex: "#36454F" },
+  { value: "graphite", label: "Graphite", labelZh: "石墨色", hex: "#383838" },
   { value: "brass", label: "Brass", labelZh: "黄铜色", hex: "#B5A642" },
   { value: "pearl", label: "Pearl", labelZh: "珍珠色", hex: "#F0EAD6" },
-  // Greens & Blues
-  {
-    value: "forest",
-    label: "Forest",
-    labelZh: "森林绿",
-    hex: "#228B22",
-  },
+  { value: "forest", label: "Forest", labelZh: "森林绿", hex: "#228B22" },
   { value: "sage", label: "Sage", labelZh: "鼠尾草绿", hex: "#BCB88A" },
-  {
-    value: "emerald",
-    label: "Emerald",
-    labelZh: "翡翠绿",
-    hex: "#50C878",
-  },
+  { value: "emerald", label: "Emerald", labelZh: "翡翠绿", hex: "#50C878" },
   { value: "navy", label: "Navy", labelZh: "海军蓝", hex: "#000080" },
+]
+
+const MATERIAL_OPTIONS = [
+  { value: "wood", label: "Wood", labelZh: "木质" },
+  { value: "oak", label: "Oak", labelZh: "橡木" },
+  { value: "walnut", label: "Walnut", labelZh: "胡桃木" },
+  { value: "ash", label: "Ash", labelZh: "白蜡木" },
+  { value: "metal", label: "Metal", labelZh: "金属" },
+  { value: "glass", label: "Glass", labelZh: "玻璃" },
+  { value: "fabric", label: "Fabric", labelZh: "织物" },
+  { value: "leather", label: "Leather", labelZh: "皮革" },
+  { value: "stone", label: "Stone", labelZh: "石材" },
+  { value: "ceramic", label: "Ceramic", labelZh: "陶瓷" },
 ]
 
 const RefinementList = ({
@@ -105,6 +88,8 @@ const RefinementList = ({
   }
 
   const activeColors = searchParams?.get("colors")?.split(",").filter(Boolean) || []
+  const activeMaterials =
+    searchParams?.get("materials")?.split(",").filter(Boolean) || []
 
   return (
     <div className="flex small:flex-col gap-12 py-4 mb-8 small:px-0 pl-6 small:min-w-[250px] small:ml-[1.675rem]">
@@ -120,9 +105,7 @@ const RefinementList = ({
         clearQueryParam={clearQueryParam}
       />
       <div>
-        <h3 className="text-sm font-semibold text-[#2C3E2D] mb-3">
-          {t("filterColor")}
-        </h3>
+        <h3 className="text-sm font-semibold text-[#2C3E2D] mb-3">{t("filterColor")}</h3>
         <div className="flex flex-col gap-1.5 max-h-[300px] overflow-y-auto">
           {COLOR_OPTIONS.map((c) => (
             <button
@@ -139,6 +122,24 @@ const RefinementList = ({
                 style={{ backgroundColor: c.hex }}
               />
               <span>{isZh ? c.labelZh : c.label}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+      <div>
+        <h3 className="text-sm font-semibold text-[#2C3E2D] mb-3">{t("filterMaterial")}</h3>
+        <div className="flex flex-col gap-1.5 max-h-[300px] overflow-y-auto">
+          {MATERIAL_OPTIONS.map((m) => (
+            <button
+              key={m.value}
+              onClick={() => toggleArrayParam("materials", m.value)}
+              className={`px-2 py-1 rounded text-sm text-left transition-colors ${
+                activeMaterials.includes(m.value)
+                  ? "bg-[#2C3E2D]/10 text-[#2C3E2D] font-medium"
+                  : "text-gray-600 hover:text-[#2C3E2D]"
+              }`}
+            >
+              {isZh ? m.labelZh : m.label}
             </button>
           ))}
         </div>

--- a/src/modules/store/templates/index.tsx
+++ b/src/modules/store/templates/index.tsx
@@ -13,6 +13,7 @@ const StoreTemplate = async ({
   maxPrice,
   searchQuery,
   colors,
+  materials,
 }: {
   sortBy?: SortOptions
   page?: string
@@ -21,6 +22,7 @@ const StoreTemplate = async ({
   maxPrice?: string
   searchQuery?: string
   colors?: string
+  materials?: string
 }) => {
   const t = await getTranslations("store")
   const pageNumber = page ? parseInt(page) : 1
@@ -56,6 +58,7 @@ const StoreTemplate = async ({
             maxPrice={maxPrice}
             searchQuery={searchQuery}
             colors={colors}
+            materials={materials}
           />
         </Suspense>
       </div>

--- a/src/modules/store/templates/paginated-products.tsx
+++ b/src/modules/store/templates/paginated-products.tsx
@@ -28,6 +28,7 @@ export default async function PaginatedProducts({
   maxPrice,
   searchQuery,
   colors,
+  materials,
 }: {
   sortBy?: SortOptions
   page: number
@@ -39,6 +40,7 @@ export default async function PaginatedProducts({
   maxPrice?: string
   searchQuery?: string
   colors?: string
+  materials?: string
 }) {
   const queryParams: PaginatedProductsParams = {
     limit: 100,
@@ -97,10 +99,23 @@ export default async function PaginatedProducts({
     const colorList = colors.split(",").map((c) => c.trim().toLowerCase())
     products = products.filter((product) => {
       const opts = product.options || []
-      const colorOpt = opts.find((o: any) => o.title?.toLowerCase() === "color")
+      const colorOpt = opts.find((o: any) => o.title?.toLowerCase() === "color" || o.title?.toLowerCase() === "颜色")
       if (!colorOpt) return false
       const vals = colorOpt.values?.map((v: any) => v.value?.toLowerCase()) || []
       return colorList.some((c) => vals.includes(c))
+    })
+  }
+
+  if (materials) {
+    const materialList = materials.split(",").map((m) => m.trim().toLowerCase())
+    products = products.filter((product) => {
+      const opts = product.options || []
+      const materialOpt = opts.find(
+        (o: any) => o.title?.toLowerCase() === "material" || o.title?.toLowerCase() === "材质"
+      )
+      if (!materialOpt) return false
+      const vals = materialOpt.values?.map((v: any) => v.value?.toLowerCase()) || []
+      return materialList.some((m) => vals.includes(m))
     })
   }
 


### PR DESCRIPTION
### Motivation
- Fix four frontend issues reported in TASK-P2-002: About page i18n keys showing raw keys, color/material filters not applying, search suggestions rendering as one line, and product detail variant images mismatching. These regressions affect user experience on About, Store, Search and Product pages.

### Description
- About page: reworked rendering to use `getTranslations("about")` nested keys (`sections.story.*`, `sections.mission.*`, `sections.values.*`, `values.*`) to ensure translations are resolved; updated layout for clearer semantics (`src/app/[locale]/[countryCode]/(main)/about/page.tsx`).
- Store filtering: added material filter UI and `materials` multi-select query handling in the refinement list, propagated `materials` through the Store page and template into the product list component, and implemented client-side filtering for both `colors` and `materials` (with Chinese title compatibility) (`src/modules/store/components/refinement-list/index.tsx`, `src/app/[locale]/[countryCode]/(main)/store/page.tsx`, `src/modules/store/templates/index.tsx`, `src/modules/store/templates/paginated-products.tsx`).
- Search modal: changed results rendering to semantic vertical list (`ul`/`li`) with spacing so each suggestion occupies its own line and remains clickable (`src/modules/search/components/search-modal/index.tsx`).
- Product images: hardened variant image selection logic to return matched product images when IDs align, otherwise fall back to `variant.images` to avoid returning an empty/mismatched set (`src/app/[locale]/[countryCode]/(main)/products/[handle]/page.tsx`).

### Testing
- Ran `yarn eslint` against all modified files and it completed successfully for the touched files (`src/app/...`, `src/modules/store/...`, `src/modules/search/...`).
- Attempted `yarn build`, which failed in this environment due to missing required environment variable `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY` (build blocked for that reason).
- Started the dev server with dummy env vars (`NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY=dummy MEDUSA_BACKEND_URL=http://127.0.0.1:9000`) to perform quick runtime checks; Next compiled pages but backend requests to `127.0.0.1:9000` were refused (no local Medusa), causing 500s for some pages — this confirms changes compile but full integration requires reachable Medusa.
- Ran a Playwright smoke script to capture the About page screenshot; screenshot artifact produced at `browser:/tmp/codex_browser_invocations/1d90b607952840d7/artifacts/artifacts/about-page.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b3d988ef9c8333b8ebf8bcabf02857)