### PR TITLE
fix(cd): add branch promotion — develop → staging → main

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,3 +1,16 @@
+# =============================================================
+# CD Pipeline — Branch Promotion Model
+# =============================================================
+# Flow: develop → staging → main
+# 
+# 回退策略 / Rollback:
+# - Staging 验收不通过：不审批 promote-to-production，staging 保持当前版本。
+#   下次 develop 推进时会覆盖 staging。
+# - 生产出问题：
+#   1. 首选：使用 deploy-production.yml 手动触发回滚到上一版本
+#   2. 紧急：SSH 到 VPS 手动 git reset --hard <上一个 commit> 或 docker rollback
+#   3. Git：git revert 问题 commit，走正常 PR → CI → CD 流程
+# =============================================================
 name: CD Pipeline
 
 on:
@@ -126,12 +139,38 @@ jobs:
           path: e2e-monitor/playwright-report/
           retention-days: 30
 
+  promote-to-staging:
+    name: "🔀 Promote → Staging"
+    needs: e2e-test
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Merge develop into staging
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin staging
+          git checkout staging
+          git merge origin/develop --no-edit --ff-only
+          if [ $? -ne 0 ]; then
+            echo "❌ Fast-forward merge failed — staging has diverged from develop."
+            echo "Please manually resolve the conflict or reset staging."
+            exit 1
+          fi
+          git push origin staging
+
   # ============================================================
   # Stage 2: 部署到预生产环境
   # ============================================================
   deploy-staging:
     name: "🚀 Deploy → Staging"
-    needs: e2e-test
+    needs: promote-to-staging
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -145,9 +184,9 @@ jobs:
           script: |
             set -e
             cd /opt/nordhjem/storefront-staging
-            echo "=== Pulling latest (develop) ==="
-            git fetch origin develop
-            git reset --hard origin/develop
+            echo "=== Pulling latest (staging) ==="
+            git fetch origin staging
+            git reset --hard origin/staging
 
             echo "=== Ensuring .env is correct ==="
             grep -q "^MEDUSA_BACKEND_URL=" .env 2>/dev/null || echo "MEDUSA_BACKEND_URL=http://66.94.127.117:9002" >> .env
@@ -243,3 +282,81 @@ jobs:
           name: e2e-report-staging
           path: e2e-monitor/playwright-report/
           retention-days: 30
+
+  promote-to-production:
+    name: "🔀 Promote → Production"
+    needs: e2e-staging
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Merge staging into main
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin main
+          git checkout main
+          git merge origin/staging --no-edit --ff-only
+          if [ $? -ne 0 ]; then
+            echo "❌ Fast-forward merge failed — main has diverged from staging."
+            echo "Please manually resolve the conflict or reset main."
+            exit 1
+          fi
+          git push origin main
+
+  deploy-production:
+    name: "🚀 Deploy → Production"
+    needs: promote-to-production
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Deploy to production
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          command_timeout: 10m
+          script: |
+            set -e
+            cd /opt/nordhjem/storefront
+            echo "=== Pulling latest (main) ==="
+            git fetch origin main
+            git reset --hard origin/main
+            echo "=== Installing dependencies ==="
+            corepack enable
+            yarn install
+            echo "=== Building ==="
+            yarn build
+            echo "=== Restarting PM2 ==="
+            PORT=8000 pm2 restart storefront --update-env || \
+              PORT=8000 pm2 start npm --name storefront -- start
+            pm2 save
+            echo "=== Deploy to production complete ==="
+
+      - name: Health check (production)
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          command_timeout: 2m
+          script: |
+            sleep 10
+            for i in 1 2 3 4 5; do
+              STATUS=$(curl -sf -o /dev/null -w "%{http_code}" http://localhost:8000 2>/dev/null || echo "000")
+              if [ "$STATUS" = "200" ] || [ "$STATUS" = "307" ] || [ "$STATUS" = "301" ]; then
+                echo "✅ Production health check passed (HTTP $STATUS)"
+                exit 0
+              fi
+              echo "Attempt $i: HTTP $STATUS, waiting 10s..."
+              sleep 10
+            done
+            echo "❌ Health check failed"
+            pm2 logs storefront --lines 20 --nostream 2>/dev/null || true
+            exit 1


### PR DESCRIPTION
### Motivation

- Introduce a branch-promotion model so releases flow `develop` → `staging` → `main` with human approvals for staging and production.
- Prevent automatic force-resets by using fast-forward-only merges and explicit failure when branches diverge.

### Description

- Added rollout header comments and rollback strategy at the top of `.github/workflows/cd.yml` describing the `develop → staging → main` flow and rollback options.
- Added `promote-to-staging` job gated with `environment: staging` that performs a `git merge origin/develop --no-edit --ff-only` and pushes to `staging` on success, and updated `deploy-staging` to `needs: promote-to-staging` and to pull from `staging` (`git fetch origin staging` / `git reset --hard origin/staging`).
- Added `promote-to-production` job gated with `environment: production` that performs a `git merge origin/staging --no-edit --ff-only` and pushes to `main`, and added a frontend `deploy-production` job that pulls from `main`, builds, restarts PM2 on port `8000`, and runs a health check.
- All changes are applied to `.github/workflows/cd.yml` in this repository on branch `fix/cd-branch-promotion`; equivalent backend changes should be applied in the `nordhjem-medusa-backend` repo separately (it was not present in this workspace).

### Testing

- Parsed the modified workflow YAML successfully using Ruby's `YAML.load_file` to validate syntax.
- Reviewed the job dependency chain and confirmed `needs` order matches the requested flow and that `promote` jobs use `environment` gates and `--ff-only` merges.
- Performed a diff review of `.github/workflows/cd.yml` to confirm the staging deploy now pulls from `staging` and production deploy pulls from `main` and that health checks and ports are set as requested.
- Attempted YAML validation with a Python script but the environment lacked the `PyYAML` module; this did not block validation because Ruby parsing succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b4490d10648333a727b98e2826d5fa)