### PR TITLE
fix(ci): resolve extract-diff bugs in ai-review workflow

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
-      diff: ${{ steps.diff.outputs.diff }}
+      diff_b64: ${{ steps.diff.outputs.diff_b64 }}
       files_changed: ${{ steps.diff.outputs.files_changed }}
       has_code_changes: ${{ steps.diff.outputs.has_code_changes }}
     steps:
@@ -53,16 +53,15 @@ jobs:
           # Get changed files list
           FILES=$(gh pr diff ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --name-only 2>/dev/null || echo "")
 
-          # Check if there are meaningful code changes (not just config/lock files)
+          # Check if there are meaningful code changes using exclusion-based rules
           HAS_CODE=false
           for f in $FILES; do
             case "$f" in
-              *.ts|*.tsx|*.js|*.jsx|*.css|*.json)
-                # Skip lock files and generated files
-                case "$f" in
-                  yarn.lock|package-lock.json|*.min.js|*.min.css) ;;
-                  *) HAS_CODE=true ;;
-                esac
+              yarn.lock|package-lock.json|*.min.js|*.min.css|*.png|*.jpg|*.jpeg|*.gif|*.svg|*.ico|*.woff|*.woff2|*.ttf|*.eot)
+                # Skip lock files, minified assets, and static resources
+                ;;
+              *)
+                HAS_CODE=true
                 ;;
             esac
           done
@@ -70,17 +69,11 @@ jobs:
           # Save diff to file (too large for env vars)
           echo "$DIFF" > /tmp/pr_diff.txt
 
-          # Truncate to ~8000 chars for API context limit
-          DIFF_TRUNCATED=$(head -c 8000 /tmp/pr_diff.txt)
+          # Truncate to ~8000 chars for API context limit and encode to base64
+          DIFF_B64=$(head -c 8000 /tmp/pr_diff.txt | base64 -w 0)
 
-          # Use EOF delimiter for multiline output
-          {
-            echo "diff<<DIFF_EOF"
-            echo "$DIFF_TRUNCATED"
-            echo "DIFF_EOF"
-          } >> "$GITHUB_OUTPUT"
-
-          echo "files_changed=$FILES" >> "$GITHUB_OUTPUT"
+          echo "diff_b64=$DIFF_B64" >> "$GITHUB_OUTPUT"
+          echo "files_changed=$(echo "$FILES" | tr '\n' ',')" >> "$GITHUB_OUTPUT"
           echo "has_code_changes=$HAS_CODE" >> "$GITHUB_OUTPUT"
 
           echo "📊 Changed files: $(echo "$FILES" | wc -w)"
@@ -132,7 +125,7 @@ jobs:
           )
 
           # Call OpenAI API
-          DIFF='${{ needs.extract-diff.outputs.diff }}'
+          DIFF=$(echo '${{ needs.extract-diff.outputs.diff_b64 }}' | base64 -d)
 
           RESPONSE=$(curl -s https://api.openai.com/v1/chat/completions \
             -H "Authorization: Bearer $OPENAI_API_KEY" \


### PR DESCRIPTION
### Motivation

- Fix unreliable file-type detection in the `extract-diff` job so non-JS/TS changes like workflows, docs, SQL, and shell scripts are recognized as code changes.  
- Prevent GitHub Actions `GITHUB_OUTPUT` parsing errors when multiline diff content contains sequences that look like workflow file commands.  
- Ensure downstream reviewer jobs receive a safe, truncated diff payload without losing the original skip behavior for static assets.

### Description

- Replace the previous whitelist file check with an exclusion-based rule that only skips known non-reviewable files such as lock files, minified assets, and static resources (images/fonts); all other changed files set `has_code_changes=true`.  
- Change the `extract-diff` outputs to expose a base64-encoded truncated diff as `diff_b64` instead of writing multiline diff directly to `GITHUB_OUTPUT`.  
- Truncate the diff to ~8000 bytes and encode with `base64 -w 0` before emitting `diff_b64`, and make `files_changed` a single-line, comma-separated string.  
- Update the reviewer job to decode `diff_b64` with `base64 -d` before sending the diff to the AI API.

### Testing

- Ran a search to confirm no remaining legacy `diff` output references and the check passed using `rg` (no legacy `needs.extract-diff.outputs.diff` or `steps.diff.outputs.diff` found).  
- Verified workflow contains the encode/decode markers by running a small assertion script that checked for `diff_b64`, `base64 -w 0`, and `base64 -d` in the file.  
- Confirmed the modified `extract-diff` script produces `files_changed` as a single-line comma-separated list and exposes `diff_b64` for downstream decoding (validation commands returned success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b469aef5408333b825a476b3a72246)