### PR TITLE
fix(ci): update codex-autofix trigger to monitor CI workflow

### DIFF
--- a/.github/workflows/codex-autofix.yml
+++ b/.github/workflows/codex-autofix.yml
@@ -2,7 +2,7 @@ name: Codex Auto-Fix on Failure
 
 on:
   workflow_run:
-    workflows: ["CD Pipeline"]
+    workflows: ["CI"]
     types: [completed]
 
 permissions:


### PR DESCRIPTION
### Motivation
- The Codex auto-fix workflow was listening for `"CD Pipeline"` but the pipeline was split into separate workflows, so the auto-fix never ran; monitoring `"CI"` ensures auto-fix triggers on code-level CI failures.

### Description
- Update the `workflow_run.workflows` value in `.github/workflows/codex-autofix.yml` from `["CD Pipeline"]` to `["CI"]` and leave all other workflow content unchanged.
- The change was applied in the frontend repository `nextjs-starter-medusa`; the backend repository `nordhjem-medusa-backend` could not be modified in this environment due to network restrictions.

### Testing
- Verified the repository diff shows only the `workflow_run.workflows` value was changed and no other files were modified (succeeded).
- Opened and inspected `.github/workflows/codex-autofix.yml` to confirm `workflow_run.workflows` is now set to `["CI"]` (succeeded).
- Attempted to clone `Nickwenniyxiao-art/nordhjem-medusa-backend` to apply the same change but the clone failed with `CONNECT tunnel failed, response 403` due to network/proxy restrictions (failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b4891d454083339b7356ec8c85a07c)