### PR TITLE
fix(ci): use CD_PAT in auto-merge to trigger downstream CD workflows

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Enable auto-merge (squash)
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.CD_PAT }}
         run: |
           echo "🔄 Enabling auto-merge for PR #${{ github.event.pull_request.number }}"
           gh pr merge ${{ github.event.pull_request.number }} \


### PR DESCRIPTION
### Motivation
- Replace `GH_TOKEN` value in the auto-merge workflow because `github.token`-created events do not trigger downstream workflows, which prevents CD pipelines from running after the merge.

### Description
- Updated `.github/workflows/auto-merge.yml` to set `GH_TOKEN: ${{ secrets.CD_PAT }}` instead of `GH_TOKEN: ${{ github.token }}` while keeping the workflow trigger, `permissions`, and merge commands unchanged.

### Testing
- Verified the change with `rg -n 'GH_TOKEN' .github/workflows/auto-merge.yml`, inspected the diff with `git diff -- .github/workflows/auto-merge.yml`, and confirmed the commit via `git show --stat --oneline HEAD`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b48f8ecf3c8333ba801f0b7db4f5bf)