### PR TITLE
fix: check-project-board regex to match h3 and combined labels

### DIFF
--- a/.github/workflows/check-project-board.yml
+++ b/.github/workflows/check-project-board.yml
@@ -45,7 +45,7 @@ jobs:
             const issueBody = issueData.body || '';
 
             // Check 1: Issue body must contain background/motivation section
-            const bgRegex = /^#{2,3}\\s*(背景(\\/动机)?|动机|Background|Motivation)/mi;
+            const bgRegex = /^#{2,3}\s*(背景(\/动机)?|动机|Background|Motivation)/mi;
             if (!bgRegex.test(issueBody)) {
               core.setFailed(`Issue #${issueNumber} must contain a "## 背景" or "### 背景/动机" or "## Background" section`);
               return;


### PR DESCRIPTION
Closes #123

## 变更说明

修复 check-project-board.yml 中背景/动机段落的正则匹配。

### 问题
Issue 模板生成的段落标题是 `### 背景/动机`（h3 + 组合词），但正则只匹配 `## 背景`（h2 + 单独词）。

### 修复
正则从 `/^##\s*(背景|动机|Background|Motivation)/mi` 改为 `/^#{2,3}\s*(背景(\/动机)?|动机|Background|Motivation)/mi`，兼容 h2/h3 和组合标签。

后端仓库已在 PR #107 中一并修复。
