### PR TITLE
feat(ci): extend codex-autofix to monitor AI Code Review

### DIFF
--- a/.github/workflows/codex-autofix.yml
+++ b/.github/workflows/codex-autofix.yml
@@ -2,7 +2,7 @@ name: Codex Auto-Fix on Failure
 
 on:
   workflow_run:
-    workflows: ["CI"]
+    workflows: ["CI", "AI Code Review"]
     types: [completed]
 
 permissions:


### PR DESCRIPTION
Closes #131

### Motivation
- Ensure the Codex auto-fix workflow also triggers for failures of the `AI Code Review` workflow (in addition to `CI`) so automated fixes cover AI review failures.

### Description
- Updated `.github/workflows/codex-autofix.yml` to set `workflow_run.workflows` to `["CI", "AI Code Review"]` and committed with message `feat(ci): extend codex-autofix to monitor AI Code Review`; Assignee: `@Nickwenniyxiao-art`; ROADMAP Ref: `INFRA`.

### Testing
- Confirmed the file change via `git diff`, validated YAML parsing with Ruby (`YAML.load_file`) and committed successfully, and noted that direct `curl` download from the upstream repo returned `403` so the file was updated locally and tested in-repo.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b615afb2708333b2384560bebeb55c)