### PR TITLE
feat(ci): sync check-roadmap-ref from backend repo

### DIFF
--- a/.github/workflows/check-roadmap-ref.yml
+++ b/.github/workflows/check-roadmap-ref.yml
@@ -70,7 +70,7 @@ jobs:
             console.log(`Found ${validIds.size} ROADMAP IDs in backend docs/ROADMAP.md`);
 
             // -- 5. Check each linked issue --
-            const exemptValues = ['HOTFIX', 'INFRA'];
+            const exemptValues = ['HOTFIX', 'INFRA', 'RESEARCH'];
 
             for (const match of matches) {
               const issueNumber = parseInt(match[1]);
@@ -92,7 +92,7 @@ jobs:
                 core.setFailed(
                   `Issue #${issueNumber} has no ROADMAP Ref field.\n` +
                   `Every issue must include a ROADMAP Ref (e.g., R-P1-01).\n` +
-                  `For urgent bugs use HOTFIX, for infra maintenance use INFRA.`
+                  `For urgent bugs use HOTFIX, for infra maintenance use INFRA, and for research work use RESEARCH.`
                 );
                 return;
               }
@@ -112,7 +112,7 @@ jobs:
                 core.setFailed(
                   `Issue #${issueNumber} has invalid ROADMAP Ref format: "${ref}"\n` +
                   `Expected format: R-Px-xx (e.g., R-P1-01)\n` +
-                  `Allowed exemptions: HOTFIX, INFRA`
+                  `Allowed exemptions: HOTFIX, INFRA, RESEARCH`
                 );
                 return;
               }


### PR DESCRIPTION
Closes #128

ROADMAP Ref: INFRA

Assignee: @Nickwenniyxiao-art

### Motivation
- Ensure the frontend `check-roadmap-ref` workflow matches backend behavior by allowing research work to be exempted from ROADMAP ID validation.

### Description
- Update `.github/workflows/check-roadmap-ref.yml` to add `'RESEARCH'` to the `exemptValues` array and update the user-facing error messages to list `RESEARCH` as an allowed exemption.

### Testing
- Attempted to fetch the backend workflow with `curl` but received a `403` due to remote access restrictions; this did not block local changes.
- Verified the file diff with `git diff` and committed the change with `git commit -m "feat(ci): sync check-roadmap-ref from backend repo"`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b61606edc0833391270219aecc7b3f)