### PR TITLE
feat(ci): add bug-archive workflow

### DIFF
--- a/.github/workflows/bug-archive.yml
+++ b/.github/workflows/bug-archive.yml
@@ -1,0 +1,79 @@
+name: Bug Archive
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  contents: write
+  issues: read
+
+jobs:
+  archive-bug:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: github.event.issue.pull_request == null
+    steps:
+      - name: Check issue type and build archive row
+        id: row
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const labels = (issue.labels || []).map((l) => l.name.toLowerCase());
+            const isBug = labels.some((l) =>
+              l === 'type: bug' || l === 'type:bug' ||
+              l === 'type: bugfix' || l === 'type:bugfix'
+            );
+
+            if (!isBug) {
+              core.notice(`Issue #${issue.number} is not bug type. Skip archive.`);
+              core.setOutput('should_archive', 'false');
+              return;
+            }
+
+            const issueBody = issue.body || '';
+            const extractSection = (header) => {
+              const regex = new RegExp(`^##\\s*${header}\\s*\\n([\\s\\S]*?)(?=^##\\s|$)`, 'm');
+              const match = issueBody.match(regex);
+              if (!match) return 'N/A';
+              const cleaned = match[1]
+                .trim()
+                .replace(/\r?\n+/g, ' / ')
+                .replace(/\|/g, '\\|');
+              return cleaned || 'N/A';
+            };
+
+            const escape = (value) =>
+              String(value ?? '')
+                .replace(/\|/g, '\\|')
+                .replace(/\r?\n+/g, ' ')
+                .trim();
+
+            const closedDate = new Date(issue.closed_at || Date.now()).toISOString().slice(0, 10);
+            const issueLink = `[#${issue.number}](${issue.html_url})`;
+            const title = escape(issue.title);
+            const labelList = escape((issue.labels || []).map((l) => l.name).join(', '));
+
+            const row = `| ${closedDate} | ${issueLink} | ${title} | ${labelList} | ${extractSection('现象')} | ${extractSection('根因分析')} | ${extractSection('修复方案')} | ${extractSection('防止再发')} |`;
+
+            core.setOutput('should_archive', 'true');
+            core.setOutput('row', row);
+
+      - name: Checkout repository
+        if: steps.row.outputs.should_archive == 'true'
+        uses: actions/checkout@v4
+
+      - name: Append bug archive row
+        if: steps.row.outputs.should_archive == 'true'
+        run: |
+          echo "${{ steps.row.outputs.row }}" >> docs/bugs/bug-archive.md
+
+      - name: Commit and push archive update
+        if: steps.row.outputs.should_archive == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add docs/bugs/bug-archive.md
+          git diff --staged --quiet || git commit -m "chore(ci): archive bug issue #${{ github.event.issue.number }}"
+          git push

--- a/docs/bugs/bug-archive.md
+++ b/docs/bugs/bug-archive.md
@@ -1,0 +1,7 @@
+# Bug Archive
+
+This file is automatically maintained by `.github/workflows/bug-archive.yml`.
+It records closed bug issues and key postmortem details for future reference.
+
+| Closed Date | Issue | Title | Labels | 现象 | 根因分析 | 修复方案 | 防止再发 |
+| --- | --- | --- | --- | --- | --- | --- | --- |


### PR DESCRIPTION
Closes #127

ROADMAP Ref: INFRA

Assignee: Nickwenniyxiao-art

### Motivation
- Provide an automated, persistent record of closed bug issues and key postmortem details so the team can track regressions and learnings. 
- Ensure the archive captures structured sections from Chinese issue templates (`现象`, `根因分析`, `修复方案`, `防止再发`) for consistent retrospective entries.

### Description
- Add `.github/workflows/bug-archive.yml` which triggers on issue `closed` events (skips PRs) and only processes issues labeled as bug (`type: bug`, `type:bug`, `type: bugfix`, `type:bugfix`).
- Workflow extracts `现象 / 根因分析 / 修复方案 / 防止再发` sections from the issue body, builds a Markdown table row, appends it to `docs/bugs/bug-archive.md`, and updates the repository when an archive row is added.
- Create `docs/bugs/bug-archive.md` with a header and table columns to receive appended rows from the workflow.

### Testing
- Verified the two new files exist and their contents match the intended templates using local file inspections, and the checks completed successfully. 
- Performed repository state validation and file content listings to confirm the workflow file and archive document were added, and those checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b61c72c4fc833390fedeb25ec97608)