### PR TITLE
feat(ci): sync check-bug-postmortem from backend repo

### DIFF
--- a/.github/workflows/check-bug-postmortem.yml
+++ b/.github/workflows/check-bug-postmortem.yml
@@ -67,11 +67,16 @@ jobs:
             // --- 5. Check required postmortem sections ---
             const issueBody = issue.body || '';
             const requiredSections = [
+              { label: '影响范围（impact_scope）', pattern: /^###\s*影响范围（impact_scope）/m },
+              { label: '回归测试（regression_test）', pattern: /^###\s*回归测试（regression_test）/m },
               { label: '现象', pattern: /^##\s*现象/m },
               { label: '根因分析', pattern: /^##\s*根因分析/m },
               { label: '修复方案', pattern: /^##\s*修复方案/m },
               { label: '防止再发', pattern: /^##\s*防止再发/m }
             ];
+
+            const escapeRegExp = (str) =>
+              str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
             const missing = [];
             const found = [];
@@ -91,8 +96,9 @@ jobs:
               }
 
               // Extract section content (between this header and next ## or end)
+              const escapedLabel = escapeRegExp(section.label);
               const sectionRegex = new RegExp(
-                `^##\\s*${section.label}\\s*\\n([\\s\\S]*?)(?=^##\\s|$(?!\\n))`,
+                `^#{2,3}\\s*${escapedLabel}\\s*\\n([\\s\\S]*?)(?=^#{2,3}\\s|$(?!\\n))`,
                 'm'
               );
               const sectionMatch = issueBody.match(sectionRegex);
@@ -126,7 +132,9 @@ jobs:
               core.setFailed(
                 `❌ Bug Issue #${issueNumber} Postmortem 信息不完整\n\n` +
                 missingMsg + placeholderMsg + '\n' +
-                `Bug 类型的 Issue 在提交修复 PR 前必须包含以下四个段落的实际内容：\n` +
+                `Bug 类型的 Issue 在提交修复 PR 前必须包含以下六个段落的实际内容：\n` +
+                `  - ### 影响范围（impact_scope）（用户/系统受影响范围与优先级）\n` +
+                `  - ### 回归测试（regression_test）（修复后的验证与防回归方案）\n` +
                 `  - ## 现象（出了什么问题，怎么复现）\n` +
                 `  - ## 根因分析（为什么出了这个问题，排查过程）\n` +
                 `  - ## 修复方案（怎么修的，改了什么）\n` +


### PR DESCRIPTION
Closes #129

ROADMAP Ref: INFRA

### Motivation
- Keep the frontend CI workflow consistent with the backend by syncing the `check-bug-postmortem` job.
- Enforce fuller postmortem documentation for bug-type issues by validating two additional sections and improving parsing reliability.

### Description
- Fully replace `.github/workflows/check-bug-postmortem.yml` with the provided backend-synced workflow content.
- Add validation for `### 影响范围（impact_scope）` and `### 回归测试（regression_test）` as required sections.
- Escape section labels and expand the section-extraction regex to accept both `##` and `###` headings for more robust parsing.
- Update the failure message to explicitly require all six postmortem sections and list them in the error output.

### Testing
- Verified the file replacement and diff with `git diff -- .github/workflows/check-bug-postmortem.yml` and the diff output contained the intended changes (success).
- Confirmed repository status with `git status --short` and the change was staged and committed using `git commit -m "feat(ci): sync check-bug-postmortem from backend repo"` (success).
- Printed the new workflow with `nl -ba .github/workflows/check-bug-postmortem.yml` to validate content lines and structure (success).

Assignee: @Nickwenniyxiao-art

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b61cac0ee08333b8b138d650334562)