### PR TITLE
feat(ci): sync stale bot from backend repo

### DIFF
--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -1,0 +1,27 @@
+name: Stale Bot
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # 每天 UTC 0:00
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 30
+          days-before-close: 30
+          stale-issue-message: '此 Issue 已超过 30 天无活动，已标记为 stale。如仍需处理请回复或移除 stale 标签，否则将在 30 天后自动关闭。'
+          stale-pr-message: '此 PR 已超过 30 天无活动，已标记为 stale。请尽快完成或关闭。'
+          close-issue-message: '此 Issue 因长期不活跃已自动关闭。如需重新打开请评论说明。'
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          exempt-issue-labels: 'pinned,security,priority: P0,type: incident'
+          exempt-pr-labels: 'pinned,security'
+          operations-per-run: 30


### PR DESCRIPTION
Closes #141

ROADMAP Ref: INFRA

### Motivation
- Add the repository-level stale bot workflow to keep issue/PR triage automation consistent with the backend repo.

### Description
- Add ` .github/workflows/stale-bot.yml` implementing `actions/stale@v9` with a daily schedule, 30-day stale/close timings, localized messages, `stale` labels, exemption labels, and `issues: write`/`pull-requests: write` permissions.

### Testing
- Verified the new file content with `sed -n '1,200p' .github/workflows/stale-bot.yml` and confirmed the file was staged/committed via `git status --short`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b63e3b1d5c833389848ff703b68c2f)