### PR TITLE
feat(ci): sync release workflow from backend repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.BOT_PAT }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install semantic-release
+        run: |
+          npm install --no-save \
+            semantic-release@24 \
+            @semantic-release/changelog@6 \
+            @semantic-release/git@10 \
+            @semantic-release/github@10 \
+            @semantic-release/commit-analyzer@13 \
+            @semantic-release/release-notes-generator@14
+
+      - name: Run semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOT_PAT }}
+        run: npx semantic-release

--- a/.github/workflows/trigger-release.yml
+++ b/.github/workflows/trigger-release.yml
@@ -1,0 +1,47 @@
+name: Trigger Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Release type'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ secrets.BOT_PAT }}
+
+      - name: Create release commit
+        run: |
+          git config user.name "nickwenniyxiao-bot"
+          git config user.email "bot@nordhjem.com"
+          
+          RELEASE_TYPE="${{ github.event.inputs.release_type }}"
+          
+          case $RELEASE_TYPE in
+            major)
+              COMMIT_MSG="feat!: trigger major release"
+              ;;
+            minor)
+              COMMIT_MSG="feat: trigger minor release"
+              ;;
+            patch)
+              COMMIT_MSG="fix: trigger patch release"
+              ;;
+          esac
+          
+          git commit --allow-empty -m "$COMMIT_MSG"
+          git push origin main

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,10 @@
+{
+  "branches": ["main"],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    ["@semantic-release/changelog", { "changelogFile": "CHANGELOG.md" }],
+    ["@semantic-release/git", { "assets": ["CHANGELOG.md"], "message": "chore(release): ${nextRelease.version} [skip ci]" }],
+    "@semantic-release/github"
+  ]
+}


### PR DESCRIPTION
Closes #143

ROADMAP Ref: INFRA

### Motivation
- Keep the frontend repository aligned with the backend release process by adding the same semantic-release workflows and configuration used in the backend repository.

### Description
- Add ` .github/workflows/release.yml` which installs `semantic-release` and runs it on `push` to `main` using `BOT_PAT` for authentication.
- Add ` .github/workflows/trigger-release.yml` which exposes a `workflow_dispatch` input (`patch`/`minor`/`major`) and creates an empty conventional-commit to trigger a release on `main`.
- Add `.releaserc.json` to configure `semantic-release` with the `commit-analyzer`, `release-notes-generator`, `changelog`, `git`, and `github` plugins targeting the `main` branch.

### Testing
- Verified the new files were created and their contents match the provided templates using `nl -ba .github/workflows/release.yml && nl -ba .github/workflows/trigger-release.yml && nl -ba .releaserc.json`, which succeeded.
- Confirmed repository cleanliness and staged commit using `git status --short` which returned no unexpected changes after commit.
- Committed the changes on branch `codex/143-sync-release-workflow` with the Conventional Commit message `feat(ci): sync release workflow from backend repo` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b63e4a5bd883339c9013bb7ccbb765)