### PR TITLE
feat(ci): add Lighthouse CI performance baseline

### DIFF
--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -1,0 +1,71 @@
+name: Lighthouse CI
+
+on:
+  pull_request:
+    branches:
+      - develop
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build
+        run: yarn build
+
+      - name: Install Lighthouse CI CLI
+        run: yarn add --dev @lhci/cli
+
+      - name: Run Lighthouse CI (warn-only)
+        id: lhci
+        run: |
+          set +e
+          yarn lhci autorun 2>&1 | tee lhci_output.txt
+          LHCI_EXIT_CODE=${PIPESTATUS[0]}
+          {
+            echo "exit_code=${LHCI_EXIT_CODE}"
+            echo "result<<EOF"
+            sed -n '1,200p' lhci_output.txt
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Comment Lighthouse results on PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const exitCode = `${{ steps.lhci.outputs.exit_code }}`
+            const result = `${{ steps.lhci.outputs.result }}`
+            const body = [
+              '## Lighthouse CI Result',
+              '',
+              `- Exit code: ${exitCode} (warn-only mode, does not block PR)`,
+              '',
+              '```text',
+              result,
+              '```'
+            ].join('\n')
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            })

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,0 +1,21 @@
+{
+  "ci": {
+    "collect": {
+      "url": ["http://localhost:3000"],
+      "numberOfRuns": 3,
+      "startServerCommand": "yarn start",
+      "startServerReadyPattern": "ready on"
+    },
+    "assert": {
+      "assertions": {
+        "categories:performance": ["warn", {"minScore": 0.7}],
+        "categories:accessibility": ["warn", {"minScore": 0.9}],
+        "categories:best-practices": ["warn", {"minScore": 0.8}],
+        "categories:seo": ["warn", {"minScore": 0.8}]
+      }
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}


### PR DESCRIPTION
Closes #147

### Motivation
- Add a Lighthouse CI baseline to detect frontend performance/regression signals on PRs targeting `develop` and provide actionable, non-blocking feedback. 
- Keep checks in warn-only mode so PRs are not blocked while surfacing metrics in the PR discussion.

### Description
- Add a GitHub Actions workflow at `.github/workflows/lighthouse-ci.yml` that runs on `pull_request` to `develop` and performs checkout, Node setup, `yarn install --frozen-lockfile`, `yarn build`, installs `@lhci/cli`, runs `yarn lhci autorun`, and posts the run output as a PR comment. 
- Ensure the workflow always exits successfully (`exit 0`) so Lighthouse results are informational (warn-only). 
- Add `lighthouserc.json` containing `ci.collect`, `ci.assert` (warn thresholds for performance/accessibility/best-practices/seo), and `ci.upload` set to `temporary-public-storage` with `numberOfRuns: 3` and `startServerCommand: "yarn start"`.

### Testing
- Validated `lighthouserc.json` parses as JSON using `node -e "JSON.parse(require('fs').readFileSync('lighthouserc.json','utf8'))"`, which succeeded. 
- No GitHub Actions run was executed locally; the workflow will execute on PRs targeting `develop` and report results as a comment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b6467f7ea48333ba9162103d28a519)

ROADMAP Ref: INFRA