### PR TITLE
feat(ci): add bundle size monitoring workflow

### DIFF
--- a/.github/workflows/bundle-size-check.yml
+++ b/.github/workflows/bundle-size-check.yml
@@ -1,0 +1,135 @@
+name: Bundle Size Check
+
+on:
+  pull_request:
+    branches:
+      - develop
+
+permissions:
+  pull-requests: write
+
+jobs:
+  bundle-size:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    env:
+      NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY: "pk_ci_placeholder"
+      NEXT_PUBLIC_MEDUSA_BACKEND_URL: "http://localhost:9000"
+      NEXT_PUBLIC_BASE_URL: "http://localhost:8000"
+      NEXT_PUBLIC_DEFAULT_REGION: "dk"
+      YARN_ENABLE_IMMUTABLE_INSTALLS: "true"
+
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Build PR branch
+        run: |
+          yarn install --frozen-lockfile
+          yarn build
+
+      - name: Record PR bundle size
+        id: pr_size
+        run: |
+          SIZE=$(du -sb .next/ | cut -f1)
+          echo "size=$SIZE" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout develop branch
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+          clean: true
+
+      - name: Build develop branch
+        run: |
+          yarn install --frozen-lockfile
+          yarn build
+
+      - name: Record develop bundle size
+        id: base_size
+        run: |
+          SIZE=$(du -sb .next/ | cut -f1)
+          echo "size=$SIZE" >> "$GITHUB_OUTPUT"
+
+      - name: Compare sizes and comment
+        id: compare
+        uses: actions/github-script@v7
+        env:
+          PR_SIZE: ${{ steps.pr_size.outputs.size }}
+          BASE_SIZE: ${{ steps.base_size.outputs.size }}
+        with:
+          script: |
+            const prSize = Number(process.env.PR_SIZE)
+            const baseSize = Number(process.env.BASE_SIZE)
+
+            if (!Number.isFinite(prSize) || !Number.isFinite(baseSize) || baseSize <= 0) {
+              core.setFailed('无法读取有效的 bundle size 数据。')
+              return
+            }
+
+            const changePct = ((prSize - baseSize) / baseSize) * 100
+            const changeAbs = changePct.toFixed(2)
+            const sign = changePct >= 0 ? '+' : ''
+
+            let status = '✅'
+            let level = 'info'
+            if (changePct > 15) {
+              status = '❌'
+              level = 'fail'
+            } else if (changePct >= 5) {
+              status = '⚠️'
+              level = 'warn'
+            }
+
+            const toMb = (bytes) => (bytes / (1024 * 1024)).toFixed(2)
+            const marker = '<!-- bundle-size-report -->'
+            const body = `${marker}\n📦 **Bundle Size 报告**\n\n| 指标 | develop | PR | 变化 |\n|------|---------|-----|------|\n| 总大小 | ${toMb(baseSize)} MB | ${toMb(prSize)} MB | ${sign}${changeAbs}% ${status} |`
+
+            const { owner, repo } = context.repo
+            const issue_number = context.issue.number
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            })
+
+            const botComment = comments.find(
+              (c) => c.user?.type === 'Bot' && c.body?.includes(marker)
+            )
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: botComment.id,
+                body,
+              })
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              })
+            }
+
+            core.info(`develop: ${baseSize}, pr: ${prSize}, change: ${sign}${changeAbs}%`)
+
+            if (level === 'fail') {
+              core.setFailed(`Bundle size 增长 ${sign}${changeAbs}% ，超过 15% 阈值。`)
+            } else if (level === 'warn') {
+              core.warning(`Bundle size 增长 ${sign}${changeAbs}% ，达到告警阈值（5%）。`)
+            }


### PR DESCRIPTION
Closes #148

### Motivation
- Prevent inadvertent Next.js build size regressions by asserting `.next/` output size differences between a PR and `develop`.
- Provide immediate, localized feedback in PRs so authors can address bundle growth early. 

### Description
- Add new workflow `.github/workflows/bundle-size-check.yml` that triggers on `pull_request` targeting `develop` and sets `pull-requests: write` permission. 
- Workflow builds the PR commit and `develop`, records `.next/` total bytes using `du -sb .next/`, computes percentage delta with `actions/github-script@v7`, and posts/updates a Chinese report comment in the PR. 
- Enforce thresholds: `< +5%` → info (`✅`), `+5% ~ +15%` → warning (`⚠️`), `> +15%` → CI failure (`❌`), and the comment is anchored with `<!-- bundle-size-report -->` to enable updates. 
- ROADMAP Ref: INFRA

### Testing
- `git diff --check` completed successfully. 
- YAML parsing via `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/bundle-size-check.yml'); puts 'YAML parse ok'"` succeeded. 
- `yarn -s prettier --check .github/workflows/bundle-size-check.yml` failed in this environment because `prettier` is not available as a Yarn command, so formatting check could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b64686bd188333b1c443704189c263)

ROADMAP Ref: INFRA