### PR TITLE
feat(governance): expand CODEOWNERS to lock core docs (#153)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,3 +6,15 @@
 
 # Issue template protection
 /.github/ISSUE_TEMPLATE/ @Nickwenniyxiao-art
+
+# --- 以下为新增规则 ---
+
+# Documentation standards - Owner exclusive
+/docs/standards/ @Nickwenniyxiao-art
+
+# AI collaboration spec
+/AGENTS.md @Nickwenniyxiao-art
+
+# Document registry and library - governance core
+/DOC-REGISTRY.json @Nickwenniyxiao-art
+/docs/standards/DOC-LIBRARY.json @Nickwenniyxiao-art


### PR DESCRIPTION
Closes #153

### Motivation
- Extend CODEOWNERS to lock governance-critical documentation paths so changes require explicit Owner approval.

### Description
- Appended new ownership rules to `.github/CODEOWNERS` for `/docs/standards/`, `/AGENTS.md`, `/DOC-REGISTRY.json`, and `/docs/standards/DOC-LIBRARY.json` all assigned to `@Nickwenniyxiao-art`.
- Preserved the existing three protections for workflows, CODEOWNERS self-protection, and issue templates and modified only `.github/CODEOWNERS`.

### Testing
- Ran `sed -n '1,200p' .github/CODEOWNERS`, `nl -ba .github/CODEOWNERS`, `git status --short`, and `git log -1 --oneline` to validate the file content and commit, and all commands succeeded.

ROADMAP Ref: INFRA

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b7adacb3048333aa7a9c5c8ac50b3e)