### PR TITLE
test(e2e): add complete business regression E2E test suite (#90)

### DIFF
--- a/e2e-monitor/tests/api-integration.spec.ts
+++ b/e2e-monitor/tests/api-integration.spec.ts
@@ -1,0 +1,85 @@
+import { expect, test } from '@playwright/test'
+
+const API_URL = process.env.API_URL || 'http://localhost:9000'
+const API_KEY = process.env.PUBLISHABLE_API_KEY || ''
+const apiTimeout = 5000
+
+const apiHeaders: Record<string, string> = API_KEY
+  ? { 'x-publishable-api-key': API_KEY }
+  : {}
+
+test.describe('Store API 集成测试', () => {
+  test('GET /store/products — 商品列表', async ({ request }) => {
+    const res = await request.get(`${API_URL}/store/products?limit=5`, {
+      headers: apiHeaders,
+      timeout: apiTimeout,
+    })
+    expect(res.status()).toBe(200)
+    const data = await res.json()
+    expect(Array.isArray(data.products)).toBeTruthy()
+  })
+
+  test('GET /store/products/:id — 商品详情', async ({ request }) => {
+    const productsRes = await request.get(`${API_URL}/store/products?limit=1`, {
+      headers: apiHeaders,
+      timeout: apiTimeout,
+    })
+    expect(productsRes.status()).toBe(200)
+    const productsData = await productsRes.json()
+    const productId = productsData.products?.[0]?.id
+    expect(productId).toBeTruthy()
+
+    const detailRes = await request.get(`${API_URL}/store/products/${productId}`, {
+      headers: apiHeaders,
+      timeout: apiTimeout,
+    })
+    expect(detailRes.status()).toBe(200)
+  })
+
+  test('GET /store/regions — 地区列表', async ({ request }) => {
+    const res = await request.get(`${API_URL}/store/regions`, {
+      headers: apiHeaders,
+      timeout: apiTimeout,
+    })
+    expect(res.status()).toBe(200)
+    const data = await res.json()
+    expect(Array.isArray(data.regions)).toBeTruthy()
+  })
+
+  test('POST /store/carts + /line-items — 创建购物车并添加商品', async ({ request }) => {
+    const productsRes = await request.get(`${API_URL}/store/products?limit=1`, {
+      headers: apiHeaders,
+      timeout: apiTimeout,
+    })
+    const productsData = await productsRes.json()
+    const variantId = productsData.products?.[0]?.variants?.[0]?.id
+    expect(variantId).toBeTruthy()
+
+    const cartRes = await request.post(`${API_URL}/store/carts`, {
+      headers: apiHeaders,
+      timeout: apiTimeout,
+      data: {},
+    })
+    expect(cartRes.status()).toBe(200)
+    const cartData = await cartRes.json()
+    const cartId = cartData.cart?.id
+    expect(cartId).toBeTruthy()
+
+    const lineItemRes = await request.post(`${API_URL}/store/carts/${cartId}/line-items`, {
+      headers: apiHeaders,
+      timeout: apiTimeout,
+      data: { variant_id: variantId, quantity: 1 },
+    })
+    expect(lineItemRes.status()).toBe(200)
+  })
+
+  test('GET /store/collections — 集合列表', async ({ request }) => {
+    const res = await request.get(`${API_URL}/store/collections`, {
+      headers: apiHeaders,
+      timeout: apiTimeout,
+    })
+    expect(res.status()).toBe(200)
+    const data = await res.json()
+    expect(Array.isArray(data.collections)).toBeTruthy()
+  })
+})

--- a/e2e-monitor/tests/cart-operations.spec.ts
+++ b/e2e-monitor/tests/cart-operations.spec.ts
@@ -1,0 +1,74 @@
+import { expect, test, type Page } from '@playwright/test'
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:8000'
+const uiTimeout = 15000
+
+async function goToFirstProduct(page: Page) {
+  await page.goto(`${BASE_URL}/en/dk/store`, { timeout: uiTimeout })
+  await page.waitForLoadState('networkidle')
+  const product = page.locator('[data-testid="products-list"] li a, a[href*="/products/"]').first()
+  await expect(product).toBeVisible({ timeout: uiTimeout })
+  await product.click()
+  await page.waitForLoadState('networkidle')
+}
+
+async function addOneProduct(page: Page) {
+  const variant = page.locator('[data-testid="option-button"], [data-testid="variant-option"], [role="radio"]').first()
+  if (await variant.isVisible({ timeout: 3000 }).catch(() => false)) {
+    await variant.click()
+  }
+  const addToCart = page.locator('button[data-testid="add-product-button"], button:has-text("Add to cart"), button:has-text("加入购物车")').first()
+  await expect(addToCart).toBeVisible({ timeout: uiTimeout })
+  await addToCart.click()
+}
+
+test.describe('购物车操作', () => {
+  test('添加商品并显示在购物车中', async ({ page }) => {
+    await goToFirstProduct(page)
+    await addOneProduct(page)
+
+    await page.goto(`${BASE_URL}/en/dk/cart`, { timeout: uiTimeout })
+    await expect(page.locator('body')).toContainText(/cart|购物车/i)
+  })
+
+  test('修改商品数量', async ({ page }) => {
+    await goToFirstProduct(page)
+    await addOneProduct(page)
+    await page.goto(`${BASE_URL}/en/dk/cart`, { timeout: uiTimeout })
+
+    const increaseButton = page.locator('button:has-text("+"), button[aria-label*="increase" i]').first()
+    if (await increaseButton.isVisible({ timeout: 5000 }).catch(() => false)) {
+      await increaseButton.click()
+      await expect(page.locator('body')).toContainText(/2|qty|quantity/i)
+    }
+  })
+
+  test('删除商品并验证空状态', async ({ page }) => {
+    await goToFirstProduct(page)
+    await addOneProduct(page)
+    await page.goto(`${BASE_URL}/en/dk/cart`, { timeout: uiTimeout })
+
+    const removeButton = page.locator('button:has-text("Remove"), button:has-text("删除"), [data-testid="remove-item"]').first()
+    if (await removeButton.isVisible({ timeout: 5000 }).catch(() => false)) {
+      await removeButton.click()
+    }
+
+    await expect(page.locator('body')).toContainText(/empty|no items|空/i)
+  })
+
+  test('多商品购物车', async ({ page }) => {
+    await goToFirstProduct(page)
+    await addOneProduct(page)
+    await page.goto(`${BASE_URL}/en/dk/store`, { timeout: uiTimeout })
+    const secondProduct = page.locator('[data-testid="products-list"] li a, a[href*="/products/"]').nth(1)
+    if (await secondProduct.isVisible({ timeout: 5000 }).catch(() => false)) {
+      await secondProduct.click()
+      await page.waitForLoadState('networkidle')
+      await addOneProduct(page)
+    }
+
+    await page.goto(`${BASE_URL}/en/dk/cart`, { timeout: uiTimeout })
+    const lineItems = page.locator('[data-testid="cart-item"], li:has(button:has-text("Remove"))')
+    await expect(lineItems.first()).toBeVisible({ timeout: uiTimeout })
+  })
+})

--- a/e2e-monitor/tests/checkout-flow.spec.ts
+++ b/e2e-monitor/tests/checkout-flow.spec.ts
@@ -1,0 +1,97 @@
+import { expect, test, type Page } from '@playwright/test'
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:8000'
+const checkoutTimeout = 15000
+
+async function addFirstProductToCart(page: Page) {
+  await page.goto(`${BASE_URL}/en/dk/store`, { timeout: checkoutTimeout })
+  await page.waitForLoadState('networkidle')
+
+  const productLink = page
+    .locator('[data-testid="products-list"] li a, a[href*="/products/"]')
+    .first()
+  await expect(productLink).toBeVisible({ timeout: checkoutTimeout })
+  await productLink.click()
+
+  await page.waitForLoadState('networkidle')
+  const variantButton = page
+    .locator('[data-testid="option-button"], [data-testid="variant-option"], [role="radio"]')
+    .first()
+  if (await variantButton.isVisible({ timeout: 3000 }).catch(() => false)) {
+    await variantButton.click()
+  }
+
+  const addToCartButton = page
+    .locator(
+      'button[data-testid="add-product-button"], button:has-text("Add to cart"), button:has-text("加入购物车")',
+    )
+    .first()
+  await expect(addToCartButton).toBeVisible({ timeout: checkoutTimeout })
+  await addToCartButton.click()
+}
+
+test.describe('完整下单流程', () => {
+  test('首页到订单确认完整流转', async ({ page }) => {
+    await page.goto(`${BASE_URL}/en/dk`, { timeout: checkoutTimeout })
+    await expect(page).toHaveURL(/\/en\/dk/, { timeout: checkoutTimeout })
+
+    await addFirstProductToCart(page)
+
+    const cartOrCheckout = page
+      .locator('a[href*="/cart"], a[href*="/checkout"], button:has-text("Checkout"), button:has-text("结账")')
+      .first()
+    await expect(cartOrCheckout).toBeVisible({ timeout: checkoutTimeout })
+    await cartOrCheckout.click()
+
+    await page.waitForLoadState('networkidle')
+
+    const uniqueId = `test-${Date.now()}`
+    const emailInput = page.locator('input[type="email"], input[name="email"]').first()
+    if (await emailInput.isVisible({ timeout: 3000 }).catch(() => false)) {
+      await emailInput.fill(`${uniqueId}@example.com`)
+    }
+
+    const textInputs = page.locator('input[type="text"], input:not([type]), input[name*="name"], input[name*="address"]')
+    const count = await textInputs.count()
+    for (let i = 0; i < Math.min(count, 6); i += 1) {
+      const input = textInputs.nth(i)
+      if (await input.isVisible().catch(() => false)) {
+        await input.fill(`test-${i}`)
+      }
+    }
+
+    const continueButtons = page.locator('button:has-text("Continue"), button:has-text("Next"), button:has-text("继续")')
+    const continueCount = await continueButtons.count()
+    for (let i = 0; i < Math.min(continueCount, 3); i += 1) {
+      const button = continueButtons.nth(i)
+      if (await button.isVisible().catch(() => false)) {
+        await button.click()
+        await page.waitForTimeout(500)
+      }
+    }
+
+    const deliveryOption = page
+      .locator('[data-testid="delivery-option"] input, [name*="shipping"] input, input[type="radio"]')
+      .first()
+    if (await deliveryOption.isVisible({ timeout: 3000 }).catch(() => false)) {
+      await deliveryOption.check()
+    }
+
+    const paymentSection = page.locator('text=Stripe, text=Payment, text=支付').first()
+    await expect(paymentSection).toBeVisible({ timeout: checkoutTimeout })
+
+    const placeOrderButton = page
+      .locator('button:has-text("Place order"), button:has-text("Complete order"), button:has-text("提交订单")')
+      .first()
+
+    if (await placeOrderButton.isVisible({ timeout: 5000 }).catch(() => false)) {
+      await placeOrderButton.click()
+      await page.waitForLoadState('networkidle')
+      await expect(page.locator('text=Order, text=Thank you, text=订单')).toBeVisible({ timeout: checkoutTimeout })
+      await expect(page.locator('body')).toContainText(/#|order|订单/i)
+    } else {
+      // 如果环境未启用真实支付，至少确保已到支付步骤
+      await expect(paymentSection).toBeVisible({ timeout: checkoutTimeout })
+    }
+  })
+})

--- a/e2e-monitor/tests/multi-currency.spec.ts
+++ b/e2e-monitor/tests/multi-currency.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from '@playwright/test'
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:8000'
+const uiTimeout = 12000
+
+test.describe('多币种与多地区', () => {
+  test('DK 地区展示 EUR 价格符号', async ({ page }) => {
+    await page.goto(`${BASE_URL}/en/dk/store`, { timeout: uiTimeout })
+    await page.waitForLoadState('networkidle')
+    await expect(page.locator('body')).toContainText(/€|eur/i)
+  })
+
+  test('US 地区展示 USD 价格符号', async ({ page }) => {
+    await page.goto(`${BASE_URL}/en/us/store`, { timeout: uiTimeout })
+    await page.waitForLoadState('networkidle')
+    await expect(page.locator('body')).toContainText(/\$|usd/i)
+  })
+
+  test('购物车价格随地区切换变化', async ({ page }) => {
+    await page.goto(`${BASE_URL}/en/dk/store`, { timeout: uiTimeout })
+    await page.waitForLoadState('networkidle')
+    const dkPrice = await page.locator('[data-testid="product-price"], [data-value="price"]').first().textContent()
+
+    await page.goto(`${BASE_URL}/en/us/store`, { timeout: uiTimeout })
+    await page.waitForLoadState('networkidle')
+    const usPrice = await page.locator('[data-testid="product-price"], [data-value="price"]').first().textContent()
+
+    expect(dkPrice || '').not.toEqual('')
+    expect(usPrice || '').not.toEqual('')
+    expect(dkPrice).not.toEqual(usPrice)
+  })
+})

--- a/e2e-monitor/tests/navigation.spec.ts
+++ b/e2e-monitor/tests/navigation.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from '@playwright/test'
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:8000'
+const uiTimeout = 12000
+
+test.describe('页面导航与 SEO', () => {
+  test('首页加载、标题和 meta description', async ({ page }) => {
+    await page.goto(`${BASE_URL}/en/dk`, { timeout: uiTimeout })
+    await expect(page).toHaveTitle(/.+/, { timeout: uiTimeout })
+    const description = page.locator('meta[name="description"]')
+    await expect(description).toHaveCount(1)
+  })
+
+  test('导航菜单链接可访问且页面切换不白屏', async ({ page }) => {
+    await page.goto(`${BASE_URL}/en/dk`, { timeout: uiTimeout })
+    const navLinks = page.locator('header a[href], nav a[href]')
+    const total = await navLinks.count()
+
+    expect(total).toBeGreaterThan(0)
+    const visitCount = Math.min(total, 4)
+
+    for (let i = 0; i < visitCount; i += 1) {
+      const href = await navLinks.nth(i).getAttribute('href')
+      if (!href || href.startsWith('#')) continue
+      await page.goto(new URL(href, `${BASE_URL}/en/dk`).toString(), { timeout: uiTimeout })
+      await expect(page.locator('body')).not.toBeEmpty()
+      await expect(page.locator('body')).not.toContainText('Something went wrong')
+    }
+  })
+
+  test('404 页面处理', async ({ page }) => {
+    await page.goto(`${BASE_URL}/en/dk/non-existent-${Date.now()}`, { timeout: uiTimeout })
+    await expect(page.locator('body')).toContainText(/404|not found|不存在/i)
+  })
+})

--- a/e2e-monitor/tests/product-catalog.spec.ts
+++ b/e2e-monitor/tests/product-catalog.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from '@playwright/test'
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:8000'
+const uiTimeout = 15000
+
+test.describe('商品目录测试', () => {
+  test('商品列表页加载', async ({ page }) => {
+    await page.goto(`${BASE_URL}/en/dk/store`, { timeout: uiTimeout })
+    await page.waitForLoadState('networkidle')
+    await expect(page.locator('[data-testid="products-list"] li, a[href*="/products/"]').first()).toBeVisible({ timeout: uiTimeout })
+  })
+
+  test('商品详情页加载、图片加载和变体选择', async ({ page }) => {
+    await page.goto(`${BASE_URL}/en/dk/store`, { timeout: uiTimeout })
+    await page.locator('[data-testid="products-list"] li a, a[href*="/products/"]').first().click()
+    await page.waitForLoadState('networkidle')
+
+    await expect(page.locator('h1').first()).toBeVisible({ timeout: uiTimeout })
+    const image = page.locator('img').first()
+    await expect(image).toBeVisible({ timeout: uiTimeout })
+
+    const variant = page.locator('[data-testid="option-button"], [data-testid="variant-option"], [role="radio"]').first()
+    if (await variant.isVisible({ timeout: 3000 }).catch(() => false)) {
+      await variant.click()
+      await expect(variant).toBeVisible()
+    }
+  })
+
+  test('无效商品页返回 404 或 Not Found', async ({ page }) => {
+    const res = await page.goto(`${BASE_URL}/en/dk/products/non-existent-product-${Date.now()}`, { timeout: uiTimeout })
+    expect([404, 200]).toContain(res?.status() || 200)
+    await expect(page.locator('body')).toContainText(/404|not found|不存在/i)
+  })
+})

--- a/e2e-monitor/tests/user-auth.spec.ts
+++ b/e2e-monitor/tests/user-auth.spec.ts
@@ -1,0 +1,56 @@
+import { expect, test } from '@playwright/test'
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:8000'
+const uiTimeout = 15000
+
+test.describe('用户认证流程', () => {
+  test('注册新用户（唯一邮箱）', async ({ page }) => {
+    const unique = `test-${Date.now()}`
+    await page.goto(`${BASE_URL}/en/dk/account`, { timeout: uiTimeout })
+
+    const registerTrigger = page.locator('text=Register, text=Sign up, text=注册').first()
+    if (await registerTrigger.isVisible({ timeout: 5000 }).catch(() => false)) {
+      await registerTrigger.click()
+    }
+
+    const email = page.locator('input[type="email"], input[name="email"]').first()
+    await email.fill(`${unique}@example.com`)
+
+    const password = page.locator('input[type="password"]').first()
+    await password.fill('Test1234!')
+
+    const submit = page.locator('button:has-text("Register"), button:has-text("Sign up"), button:has-text("注册")').first()
+    await submit.click()
+
+    await expect(page.locator('body')).toContainText(/account|welcome|我的账户|登录/i)
+  })
+
+  test('登录失败（错误密码）', async ({ page }) => {
+    await page.goto(`${BASE_URL}/en/dk/account`, { timeout: uiTimeout })
+    await page.locator('input[type="email"], input[name="email"]').first().fill(`wrong-${Date.now()}@example.com`)
+    await page.locator('input[type="password"]').first().fill('WrongPassword!')
+    await page.locator('button:has-text("Sign in"), button:has-text("Login"), button:has-text("登录")').first().click()
+    await expect(page.locator('body')).toContainText(/invalid|incorrect|failed|错误/i)
+  })
+
+  test('登录、退出与状态持久化', async ({ page, context }) => {
+    const email = process.env.E2E_EXISTING_USER_EMAIL || 'existing-user@example.com'
+    const password = process.env.E2E_EXISTING_USER_PASSWORD || 'Test1234!'
+
+    await page.goto(`${BASE_URL}/en/dk/account`, { timeout: uiTimeout })
+    await page.locator('input[type="email"], input[name="email"]').first().fill(email)
+    await page.locator('input[type="password"]').first().fill(password)
+    await page.locator('button:has-text("Sign in"), button:has-text("Login"), button:has-text("登录")').first().click()
+
+    await expect(page.locator('body')).toContainText(/account|orders|我的账户/i)
+
+    const cookies = await context.cookies()
+    expect(cookies.length).toBeGreaterThan(0)
+
+    const logout = page.locator('button:has-text("Sign out"), button:has-text("Logout"), text=退出').first()
+    if (await logout.isVisible({ timeout: 5000 }).catch(() => false)) {
+      await logout.click()
+      await expect(page.locator('body')).toContainText(/sign in|login|登录/i)
+    }
+  })
+})


### PR DESCRIPTION
Closes #90

### Motivation
- Add a complete Playwright E2E regression suite to cover the full storefront purchase flow and core user journeys so CI/regression can validate changes end-to-end.
- Provide coverage for cart operations, multi-currency/region display, product catalog, user auth, navigation/SEO, and Store API endpoints to catch integration regressions earlier.

### Description
- Added 7 new Playwright spec files under `e2e-monitor/tests/`: `checkout-flow.spec.ts`, `cart-operations.spec.ts`, `multi-currency.spec.ts`, `product-catalog.spec.ts`, `user-auth.spec.ts`, `navigation.spec.ts`, and `api-integration.spec.ts` implementing the scenarios described in the Issue. 
- Tests use environment variables (`BASE_URL`, `API_URL`, `PUBLISHABLE_API_KEY`, `E2E_EXISTING_USER_*`) with sensible defaults and timeouts (UI 10–15s, API 5s), and unique test identifiers (`test-${Date.now()}`) where needed. 
- Did not modify existing `e2e-monitor/tests/smoke.spec.ts` or `e2e-monitor/playwright.config.ts`, and added lightweight TypeScript typing corrections (`Page`) in UI specs. 
- Files were committed with conventional commit message `test(e2e): add complete business regression test suite`.

### Testing
- Ran `cd e2e-monitor && npx playwright test --list` which listed the new tests successfully. 
- Ran `npx playwright test tests/api-integration.spec.ts --project=chromium --workers=1` with environment variables set, which failed due to an external network routing error (`ENETUNREACH`) when reaching the configured API host (external connectivity issue), so API assertions could not complete.

ROADMAP Ref: INFRA

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b7b0a6d4248333bc79ce5cb8dda4e2)