### PR TITLE
feat(docs): add workflow status badges to README [S2-3]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # NordHjem Storefront
 
+[![CI](https://github.com/Nickwenniyxiao-art/nextjs-starter-medusa/actions/workflows/ci.yml/badge.svg)](https://github.com/Nickwenniyxiao-art/nextjs-starter-medusa/actions/workflows/ci.yml)
+[![CD — Staging](https://github.com/Nickwenniyxiao-art/nextjs-starter-medusa/actions/workflows/cd-staging.yml/badge.svg)](https://github.com/Nickwenniyxiao-art/nextjs-starter-medusa/actions/workflows/cd-staging.yml)
+[![CD — Production](https://github.com/Nickwenniyxiao-art/nextjs-starter-medusa/actions/workflows/cd-production.yml/badge.svg)](https://github.com/Nickwenniyxiao-art/nextjs-starter-medusa/actions/workflows/cd-production.yml)
+[![Playwright Site Monitor](https://github.com/Nickwenniyxiao-art/nextjs-starter-medusa/actions/workflows/playwright-monitor.yml/badge.svg)](https://github.com/Nickwenniyxiao-art/nextjs-starter-medusa/actions/workflows/playwright-monitor.yml)
+[![Lighthouse CI](https://github.com/Nickwenniyxiao-art/nextjs-starter-medusa/actions/workflows/lighthouse-ci.yml/badge.svg)](https://github.com/Nickwenniyxiao-art/nextjs-starter-medusa/actions/workflows/lighthouse-ci.yml)
+
 NordHjem 北欧电商平台前端，基于 [Next.js 14](https://nextjs.org/) + [Medusa.js v2 Storefront](https://docs.medusajs.com/storefront) 构建。
 
 ## 技术栈


### PR DESCRIPTION
Closes #0

### Motivation
- Add GitHub Actions workflow status badges to the top of the frontend README to surface CI/CD health at a glance.

### Description
- Inserted five badges under `# NordHjem Storefront` in `README.md` linking to workflows: `ci.yml`, `cd-staging.yml`, `cd-production.yml`, `playwright-monitor.yml`, and `lighthouse-ci.yml`.

### Testing
- Ran `sed -n '1,30p' README.md`, `rg -n "^\[!\[" README.md`, and `nl -ba README.md | sed -n '1,25p'` to verify the badges are present and the links point to the expected workflow URLs, all commands succeeded.

ROADMAP Ref: INFRA

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b86c5fa78883338afa3f5252e97fb6)