### PR TITLE
fix(ci): add enforce_admins bypass for semantic-release [V3-1]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,33 @@ jobs:
             @semantic-release/commit-analyzer@13 \
             @semantic-release/release-notes-generator@14
 
+      - name: Pre-check existing tags
+        run: |
+          echo "=== Fetching all tags ==="
+          git fetch --tags
+          echo "=== Existing tags ==="
+          git tag -l 'v*' | sort -V
+          LATEST_TAG=$(git tag -l 'v*' | sort -V | tail -1)
+          echo "Latest existing tag: $LATEST_TAG"
+          echo "latest_tag=$LATEST_TAG" >> $GITHUB_ENV
+
+      - name: Temporarily allow direct push
+        env:
+          GH_TOKEN: ${{ secrets.BOT_PAT }}
+        run: |
+          gh api repos/${{ github.repository }}/branches/main/protection/enforce_admins -X DELETE || true
+
       - name: Run semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_PAT }}
-        run: npx semantic-release
+        run: |
+          git fetch --tags --force
+          echo "Tags synced. Running semantic-release..."
+          npx semantic-release
+
+      - name: Re-enable branch protection
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.BOT_PAT }}
+        run: |
+          gh api repos/${{ github.repository }}/branches/main/protection/enforce_admins -X POST || true


### PR DESCRIPTION
Closes #3

### Motivation
- Prevent semantic-release from being blocked by branch protection when it pushes tags or changelogs to `main`.
- Bring the frontend `release.yml` behavior in line with the backend release workflow that temporarily relaxes `enforce_admins` during automated releases.
- Ensure tags are synchronized before release so `semantic-release` can determine and push the correct next tag.

### Description
- Add a `Pre-check existing tags` step that fetches and lists `v*` tags and exports the latest tag to `$GITHUB_ENV`.
- Temporarily disable branch protection `enforce_admins` on `main` using `gh api .../protection/enforce_admins -X DELETE` before running `semantic-release` with `GH_TOKEN: ${{ secrets.BOT_PAT }}`.
- Update the `Run semantic-release` step to perform `git fetch --tags --force` before invoking `npx semantic-release` to ensure local tags are in sync.
- Re-enable `enforce_admins` after the release using an `if: always()` step that posts to the same `gh api` endpoint, ensuring protection is restored even on failure.

### Testing
- Ran `git status --short && git diff -- .github/workflows/release.yml` to verify the workflow changes are present and the diff shows the intended insertions, which succeeded.
- Viewed the updated file with `nl -ba .github/workflows/release.yml` to confirm step ordering and `if: always()` placement, which succeeded.
- Attempted a YAML parse with a Python `yaml.safe_load` call to validate syntax, but the check failed due to missing `PyYAML` in the environment and not due to the workflow content itself.

ROADMAP Ref: INFRA

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b88a38163c833385323c32068a7ba5)