### PR TITLE
fix(ci): inject required env vars for Lighthouse CI build [V3-4]

### DIFF
--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -27,6 +27,10 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Build
+        env:
+          NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY: ${{ secrets.PUBLISHABLE_KEY_TEST || 'pk_test_placeholder' }}
+          NEXT_PUBLIC_MEDUSA_BACKEND_URL: ${{ secrets.MEDUSA_BACKEND_URL || 'http://localhost:9000' }}
+          NEXT_PUBLIC_BASE_URL: ${{ secrets.BASE_URL || 'http://localhost:8000' }}
         run: yarn build
 
       - name: Install Lighthouse CI CLI


### PR DESCRIPTION
Closes #34

### Motivation
- The Lighthouse CI workflow failed during `yarn build` because `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY` (and other `NEXT_PUBLIC_*` vars) were not injected into the workflow environment, causing the build to abort before Lighthouse runs.

### Description
- Injected build-time env vars in `.github/workflows/lighthouse-ci.yml` by adding `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY` (with fallback `pk_test_placeholder`), `NEXT_PUBLIC_MEDUSA_BACKEND_URL` (with fallback `http://localhost:9000`), and `NEXT_PUBLIC_BASE_URL` (with fallback `http://localhost:8000`) to the `Build` step so the Next.js build no longer errors on missing secrets.

### Testing
- Ran a local `yarn build` with `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY=pk_test_placeholder NEXT_PUBLIC_MEDUSA_BACKEND_URL=http://localhost:9000 NEXT_PUBLIC_BASE_URL=http://localhost:8000`, which confirmed the previous missing-env blocker was resolved but the build later encountered unrelated external font fetch/network failures in this environment.

ROADMAP Ref: INFRA

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b88a4f137c83338f33066a237cb0ba)