### PR TITLE
fix(e2e): graceful skip product-dependent tests when no seed data [V3-5]

### DIFF
--- a/.github/workflows/cd-staging.yml
+++ b/.github/workflows/cd-staging.yml
@@ -90,6 +90,13 @@ jobs:
           script: |
             bash /opt/nordhjem/scripts/seed-env.sh staging || echo "⚠️ Seed had warnings (non-fatal)"
 
+            echo "=== Verifying seed data ==="
+            PRODUCT_COUNT=$(curl -s http://localhost:9002/store/products | python3 -c "import sys,json; print(len(json.load(sys.stdin).get('products',[])))" 2>/dev/null || echo "0")
+            echo "Products in staging environment: $PRODUCT_COUNT"
+            if [ "$PRODUCT_COUNT" = "0" ]; then
+              echo "⚠️ Warning: No products found after seed. E2E tests may skip product-dependent scenarios."
+            fi
+
   e2e-staging:
     name: "🧪 E2E → Staging"
     needs: seed-staging

--- a/.github/workflows/cd-test.yml
+++ b/.github/workflows/cd-test.yml
@@ -90,6 +90,13 @@ jobs:
           script: |
             bash /opt/nordhjem/scripts/seed-env.sh test || echo "⚠️ Seed had warnings (non-fatal)"
 
+            echo "=== Verifying seed data ==="
+            PRODUCT_COUNT=$(curl -s http://localhost:9001/store/products | python3 -c "import sys,json; print(len(json.load(sys.stdin).get('products',[])))" 2>/dev/null || echo "0")
+            echo "Products in test environment: $PRODUCT_COUNT"
+            if [ "$PRODUCT_COUNT" = "0" ]; then
+              echo "⚠️ Warning: No products found after seed. E2E tests may skip product-dependent scenarios."
+            fi
+
   e2e-test:
     name: "🧪 E2E → Test"
     needs: seed-test

--- a/e2e-monitor/tests/cart-operations.spec.ts
+++ b/e2e-monitor/tests/cart-operations.spec.ts
@@ -24,6 +24,13 @@ async function addOneProduct(page: Page) {
   await page.waitForTimeout(2000)
 }
 
+async function hasAnyProducts(page: Page) {
+  await page.goto(`${BASE_URL}/en/dk/store`, { timeout: uiTimeout })
+  await page.waitForLoadState('networkidle')
+  const productLinks = page.locator('[data-testid="products-list"] li a, a[href*="/products/"]')
+  return (await productLinks.count()) > 0
+}
+
 test.describe('购物车操作', () => {
   test.beforeEach(async ({ page }) => {
     const apiCheck = await page.request
@@ -56,6 +63,9 @@ test.describe('购物车操作', () => {
   })
 
   test('删除商品并验证空状态', async ({ page }) => {
+    const productsAvailable = await hasAnyProducts(page)
+    test.skip(!productsAvailable, '⚠️ No products found in test environment - skipping product-dependent test')
+
     await goToFirstProduct(page)
     await addOneProduct(page)
     await page.goto(`${BASE_URL}/en/dk/cart`, { timeout: uiTimeout })
@@ -69,6 +79,9 @@ test.describe('购物车操作', () => {
   })
 
   test('多商品购物车', async ({ page }) => {
+    const productsAvailable = await hasAnyProducts(page)
+    test.skip(!productsAvailable, '⚠️ No products found in test environment - skipping product-dependent test')
+
     await goToFirstProduct(page)
     await addOneProduct(page)
     await page.goto(`${BASE_URL}/en/dk/store`, { timeout: uiTimeout })

--- a/e2e-monitor/tests/checkout-flow.spec.ts
+++ b/e2e-monitor/tests/checkout-flow.spec.ts
@@ -32,6 +32,13 @@ async function addFirstProductToCart(page: Page) {
   await page.waitForTimeout(2000)
 }
 
+async function hasAnyProducts(page: Page) {
+  await page.goto(`${BASE_URL}/en/dk/store`, { timeout: checkoutTimeout })
+  await page.waitForLoadState('networkidle')
+  const productLinks = page.locator('[data-testid="products-list"] li a, a[href*="/products/"]')
+  return (await productLinks.count()) > 0
+}
+
 test.describe('完整下单流程', () => {
   test.beforeEach(async ({ page }) => {
     const apiCheck = await page.request
@@ -44,6 +51,9 @@ test.describe('完整下单流程', () => {
   })
 
   test('首页到订单确认完整流转', async ({ page }) => {
+    const productsAvailable = await hasAnyProducts(page)
+    test.skip(!productsAvailable, '⚠️ No products found in test environment - skipping product-dependent test')
+
     await page.goto(`${BASE_URL}/en/dk`, { timeout: checkoutTimeout })
     await expect(page).toHaveURL(/\/en\/dk/, { timeout: checkoutTimeout })
 

--- a/e2e-monitor/tests/product-catalog.spec.ts
+++ b/e2e-monitor/tests/product-catalog.spec.ts
@@ -12,7 +12,11 @@ test.describe('商品目录测试', () => {
 
   test('商品详情页加载、图片加载和变体选择', async ({ page }) => {
     await page.goto(`${BASE_URL}/en/dk/store`, { timeout: uiTimeout })
-    await page.locator('[data-testid="products-list"] li a, a[href*="/products/"]').first().click()
+    const productLinks = page.locator('[data-testid="products-list"] li a, a[href*="/products/"]')
+    const count = await productLinks.count()
+    test.skip(count === 0, '⚠️ No products found in test environment - skipping product-dependent test')
+
+    await productLinks.first().click()
     await page.waitForLoadState('networkidle')
 
     await expect(page.locator('h1').first()).toBeVisible({ timeout: uiTimeout })


### PR DESCRIPTION
Closes #5

### Motivation
- Prevent CI red builds when the test/staging environment has no seeded products by skipping product-dependent Playwright specs instead of failing. 
- Improve observability of the seed step so CD logs clearly indicate when zero products were created. 
- Reduce noise from environment flakiness so real regressions surface more reliably.

### Description
- Added a reusable `hasAnyProducts` precheck and `test.skip()` guards to product-dependent specs in `e2e-monitor/tests/cart-operations.spec.ts`, `e2e-monitor/tests/checkout-flow.spec.ts`, and `e2e-monitor/tests/product-catalog.spec.ts` so those tests are skipped with a clear message when no products exist. 
- Enhanced the seed steps in `.github/workflows/cd-test.yml` and `.github/workflows/cd-staging.yml` to query `/store/products`, print the product count, and emit a non-fatal warning if the count is zero. 
- Kept behavior non-fatal so pipelines continue running remaining tests while surfacing seed-data issues in logs.

### Testing
- Ran `npm ci` in `e2e-monitor` which completed successfully. 
- Ran `npx playwright test --list` in `e2e-monitor` which completed successfully and enumerated the test suite (44 tests listed). 
- No full remote `npx playwright test` run was executed in this branch because environment seed/state varies across CD targets, and the changes are designed to be safe for empty-data environments.

ROADMAP Ref: R-P1-24

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b88a57ec90833392da50a14c736cbb)