### PR TITLE
fix(e2e-monitor): harden Playwright site monitor selectors

### DIFF
--- a/e2e-monitor/tests/03-product-detail.spec.ts
+++ b/e2e-monitor/tests/03-product-detail.spec.ts
@@ -1,7 +1,27 @@
-import { expect, test } from '@playwright/test'
+import { expect, test, type Page } from '@playwright/test'
 
 const BASE = process.env.BASE_URL || 'https://nordhjem.store'
 const STORE_URL = `${BASE}/en/dk/store`
+
+const getTitleLocator = async (page: Page) => {
+  const productContainer = page.getByTestId('product-container')
+
+  if (await productContainer.count()) {
+    return productContainer.getByTestId('product-title')
+  }
+
+  return page.locator('[data-testid="product-title"]').first()
+}
+
+const getPriceLocator = async (page: Page) => {
+  const productContainer = page.getByTestId('product-container')
+
+  if (await productContainer.count()) {
+    return productContainer.locator('[data-testid="product-price"], [data-testid="price"]').first()
+  }
+
+  return page.locator('[data-testid="product-price"], [data-testid="price"]').first()
+}
 
 test.describe('Business Regression - Product Detail', () => {
   test('open product detail from store list and validate pricing', async ({ page }) => {
@@ -12,9 +32,11 @@ test.describe('Business Regression - Product Detail', () => {
     await firstProduct.click()
 
     await expect(page).toHaveURL(/\/products\//)
-    await expect(page.getByTestId('product-container').getByTestId('product-title')).toBeVisible()
 
-    const price = page.getByTestId('product-container').locator('[data-testid="product-price"], [data-testid="price"]').first()
+    const title = await getTitleLocator(page)
+    await expect(title).toBeVisible()
+
+    const price = await getPriceLocator(page)
     await expect(price).toBeVisible({ timeout: 10000 })
     expect((await price.textContent())?.trim().length).toBeGreaterThan(0)
   })

--- a/e2e-monitor/tests/04-cart-flow.spec.ts
+++ b/e2e-monitor/tests/04-cart-flow.spec.ts
@@ -1,9 +1,14 @@
-import { expect, test } from '@playwright/test'
+import { expect, test, type Locator } from '@playwright/test'
 
 const BASE = process.env.BASE_URL || 'https://nordhjem.store'
 const STORE_URL = `${BASE}/en/dk/store`
 const CART_URL = `${BASE}/en/dk/cart`
 const API_URL = process.env.API_URL || 'http://66.94.127.117:9000'
+
+const clickWhenVisible = async (locator: Locator) => {
+  await locator.waitFor({ state: 'visible', timeout: 15000 })
+  await locator.click({ timeout: 15000 })
+}
 
 test.describe('Business Regression - Cart', () => {
   test.beforeEach(async ({ page }) => {
@@ -28,8 +33,13 @@ test.describe('Business Regression - Cart', () => {
 
   test('can add one product then navigate to cart', async ({ page }) => {
     await page.goto(STORE_URL)
-    await page.locator('[data-testid="products-list"] a').first().click()
-    await page.getByTestId('add-product-button').click()
+
+    const firstProduct = page.locator('[data-testid="products-list"] a').first()
+    await clickWhenVisible(firstProduct)
+
+    const addProductButton = page.getByTestId('add-product-button')
+    await clickWhenVisible(addProductButton)
+
     await page.waitForTimeout(2000)
 
     await page.goto(CART_URL)


### PR DESCRIPTION
Closes #0

### Motivation
- Prevent Playwright strict-mode failures where `[data-testid="product-title"]` matched multiple elements by scoping title/price lookups to the main product container when present.
- Reduce flaky `cart` monitor failures caused by clicks timing out by waiting for visibility and increasing click timeouts before `click()`.

### Description
- Updated `e2e-monitor/tests/03-product-detail.spec.ts` to add helper functions `getTitleLocator` and `getPriceLocator` that prefer a `product-container` scoped locator and fall back to `.first()` when the container is absent.
- Updated `e2e-monitor/tests/04-cart-flow.spec.ts` to add a `clickWhenVisible` helper that waits for `state: 'visible'` (15s) and performs `click({ timeout: 15000 })`, and applied it to product selection and add-to-cart interactions.
- Changes aim to avoid strict-mode collisions and transient click timeouts without altering product behavior or UI selectors globally.

### Testing
- Ran `npx playwright test e2e-monitor/tests/03-product-detail.spec.ts`, which failed to run in this environment due to `npm` registry access error (`403 Forbidden`) while fetching `playwright`.
- Ran `npx playwright test e2e-monitor/tests/04-cart-flow.spec.ts`, which failed for the same `403 Forbidden` registry error when attempting to install `playwright`.
- Local commit and file updates were applied and committed as `fix(e2e-monitor): harden product and cart monitor selectors`.

ROADMAP Ref: INFRA

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b8980a34948333b57b472a4b8ecdec)