### PR TITLE
feat(ci): 添加前端生产冒烟测试

### DIFF
--- a/.github/workflows/cd-production.yml
+++ b/.github/workflows/cd-production.yml
@@ -106,3 +106,44 @@ jobs:
             });
 
             console.log(`✅ Logged production deployment: ${sha} by ${actor}`);
+
+  smoke-test-production:
+    name: "💨 Smoke Test → Production"
+    needs: deploy-production
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Wait for service to stabilize
+        run: sleep 30
+
+      - name: Health check
+        run: |
+          PROD_URL="${{ secrets.PRODUCTION_FRONTEND_URL || 'https://nordhjem.com' }}"
+
+          for i in 1 2 3 4 5; do
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$PROD_URL" || echo "000")
+            if [ "$STATUS" = "200" ]; then
+              echo "✅ Health check passed (attempt $i)"
+              exit 0
+            fi
+            echo "⏳ Attempt $i: status=$STATUS, retrying in 10s..."
+            sleep 10
+          done
+
+          echo "❌ Production health check failed after 5 attempts"
+          exit 1
+
+      - name: Page load smoke test
+        run: |
+          PROD_URL="${{ secrets.PRODUCTION_FRONTEND_URL || 'https://nordhjem.com' }}"
+
+          echo "Testing homepage..."
+          BODY=$(curl -s "$PROD_URL")
+          if echo "$BODY" | grep -q "</html>"; then
+            echo "✅ Homepage renders HTML"
+          else
+            echo "❌ Homepage does not render properly"
+            exit 1
+          fi
+
+          echo "✅ All production smoke tests passed"

--- a/DOC-REGISTRY.json
+++ b/DOC-REGISTRY.json
@@ -40,5 +40,12 @@
     "type": "DEPLOY-LOG",
     "status": "active",
     "version": "1.0.0"
+  },
+  {
+    "id": "CD-PRODUCTION-SMOKE-TEST",
+    "path": "docs/CD-PRODUCTION-SMOKE-TEST.md",
+    "type": "SMOKE-TEST",
+    "status": "active",
+    "version": "1.0.0"
   }
 ]

--- a/docs/CD-PRODUCTION-SMOKE-TEST.md
+++ b/docs/CD-PRODUCTION-SMOKE-TEST.md
@@ -1,0 +1,28 @@
+# Production Smoke Test (Frontend)
+
+This document defines the post-deployment smoke checks executed by `.github/workflows/cd-production.yml`.
+
+## Purpose
+
+- Verify the production storefront is reachable after deployment.
+- Verify the homepage returns renderable HTML.
+- Fail fast in CI/CD if production health degrades right after release.
+
+## Workflow Job
+
+`smoke-test-production` runs after `deploy-production` and performs:
+
+1. **Stabilization wait**: sleep 30 seconds.
+2. **Health check**: retry `curl` up to 5 times (10-second interval), expecting HTTP 200.
+3. **Page smoke test**: fetch homepage HTML and validate `</html>` exists.
+
+## Target URL
+
+The checks use:
+
+- `secrets.PRODUCTION_FRONTEND_URL` when provided.
+- Fallback: `https://nordhjem.com`.
+
+## Failure Behavior
+
+If either check fails, the job exits non-zero and the workflow run is marked failed.

--- a/docs/standards/DOC-LIBRARY.json
+++ b/docs/standards/DOC-LIBRARY.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "updated_at": "2026-03-16",
+  "updated_at": "2026-03-17",
   "types": [
     {
       "id": "ARCHITECTURE",
@@ -76,6 +76,11 @@
       "id": "DEPLOY-LOG",
       "name": "Deploy Log",
       "description": "Automated deployment event logs with environment, SHA, actor, and workflow metadata."
+    },
+    {
+      "id": "SMOKE-TEST",
+      "name": "Smoke Test",
+      "description": "Post-deployment smoke checks validating core availability and render readiness."
     }
   ],
   "status_values": [


### PR DESCRIPTION
## 概要
添加前端生产冒烟测试工作流，部署后自动验证页面可访问。

## EGP Action
EGP Action: R-P1-08-A1

## 变更内容
- 添加前端生产冒烟测试工作流
- 部署到 production 后自动触发
- 检测核心页面可访问性

Closes #186

<!-- compliance-check-trigger: 1773742811 -->