### PR TITLE
feat(e2e): 添加 WebKit 浏览器 E2E 测试支持 [P1-03]

### DIFF
--- a/.github/workflows/playwright-monitor.yml
+++ b/.github/workflows/playwright-monitor.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install Playwright browsers
         working-directory: e2e-monitor
-        run: npx playwright install chromium --with-deps
+        run: npx playwright install --with-deps chromium webkit
 
       - name: Run smoke tests
         working-directory: e2e-monitor

--- a/DOC-REGISTRY.json
+++ b/DOC-REGISTRY.json
@@ -42,7 +42,6 @@
     "version": "1.0.0"
   },
   {
-<<<<<<< HEAD
     "id": "AUDIT-WORKFLOW",
     "path": ".github/workflows/audit.yml",
     "file": ".github/workflows/audit.yml",
@@ -51,12 +50,20 @@
     "type": "CI",
     "status": "active",
     "last_updated": "2026-03-17",
-=======
+    "version": "1.0.0"
+  },
+  {
     "id": "CD-PRODUCTION-SMOKE-TEST",
     "path": "docs/CD-PRODUCTION-SMOKE-TEST.md",
     "type": "SMOKE-TEST",
     "status": "active",
->>>>>>> origin/develop
     "version": "1.0.0"
+  },
+  {
+    "id": "E2E-WEBKIT",
+    "file": "docs/E2E-WEBKIT.md",
+    "required": false,
+    "gate": 2,
+    "status": "stub"
   }
 ]

--- a/docs/E2E-WEBKIT.md
+++ b/docs/E2E-WEBKIT.md
@@ -1,0 +1,16 @@
+# E2E WebKit 浏览器配置
+
+> 状态: stub | 最后更新: 2026-03-17
+
+## 概述
+
+Playwright E2E 监控新增 WebKit 浏览器项目，实现多浏览器覆盖。
+
+## 配置
+
+- Playwright config: `e2e-monitor/playwright.config.ts`
+- 支持浏览器: Chromium, WebKit
+
+## 验证
+
+运行 `cd e2e-monitor && npx playwright test --project=webkit` 验证 WebKit 测试通过。

--- a/docs/TASK-REGISTRY.json
+++ b/docs/TASK-REGISTRY.json
@@ -1,0 +1,14 @@
+{
+  "tasks": [
+    {
+      "id": "R-P1-03",
+      "status": "in_progress",
+      "actions": [
+        {
+          "id": "R-P1-03-A1",
+          "status": "in_progress"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/standards/DOC-LIBRARY.json
+++ b/docs/standards/DOC-LIBRARY.json
@@ -97,5 +97,22 @@
   "versioning": {
     "format": "semver",
     "example": "1.0.0"
-  }
+  },
+  "documents": [
+    {
+      "id": "E2E-WEBKIT",
+      "name": "E2E WebKit 浏览器配置",
+      "name_en": "E2E-WEBKIT",
+      "filename": "E2E-WEBKIT.md",
+      "category": "05-testing",
+      "gate": 2,
+      "applicable_to": [
+        "frontend"
+      ],
+      "default_required": false,
+      "required_sections": [],
+      "required_metadata": [],
+      "description": "E2E 测试 WebKit 浏览器支持配置与验证说明"
+    }
+  ]
 }

--- a/e2e-monitor/playwright.config.ts
+++ b/e2e-monitor/playwright.config.ts
@@ -14,6 +14,9 @@ export default defineConfig({
     actionTimeout: 15000,
     navigationTimeout: 30000,
   },
-  projects: [{ name: 'chromium', use: { browserName: 'chromium' } }],
+  projects: [
+    { name: 'chromium', use: { browserName: 'chromium' } },
+    { name: 'webkit', use: { browserName: 'webkit' } },
+  ],
   reporter: [['list'], ['html', { open: 'never' }]],
 });


### PR DESCRIPTION
## 概要

在 E2E 监控中添加 WebKit 浏览器支持，实现多浏览器覆盖。

ROADMAP Ref: INFRA

## EGP Action

EGP Action: R-P1-03-A1

## 变更内容

- 在 playwright.config.ts 添加 WebKit 项目
- 更新 playwright-monitor.yml 安装 WebKit 浏览器
- 新增 docs/E2E-WEBKIT.md stub
- 更新 DOC-REGISTRY.json 和 DOC-LIBRARY.json

Closes #191

<!-- compliance-check-trigger: 1773745607 -->