### PR TITLE
feat(monitoring): integrate Sentry error tracking into frontend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,4 +23,4 @@ REVALIDATE_SECRET=
 
 # Sentry Error Monitoring
 NEXT_PUBLIC_SENTRY_DSN=
-SENTRY_AUTH_TOKEN=
+SENTRY_AUTH_TOKEN=  # CI only, for source map upload

--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,9 @@ const { withSentryConfig } = require("@sentry/nextjs")
 checkEnvVariables()
 
 const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts")
+const shouldUploadSourcemaps = Boolean(
+  process.env.CI && process.env.SENTRY_AUTH_TOKEN
+)
 
 /**
  * Medusa Cloud-related environment variables
@@ -83,17 +86,17 @@ const nextConfig = {
   },
 }
 
-module.exports = withSentryConfig(
-  withNextIntl(nextConfig),
-  {
-    silent: true,
-    org: "huan-xiao-5d",
-    project: "nordhjem-storefront",
+module.exports = withSentryConfig(withNextIntl(nextConfig), {
+  silent: true,
+  org: "huan-xiao-5d",
+  project: "nordhjem-storefront",
+  authToken: process.env.SENTRY_AUTH_TOKEN,
+  sourcemaps: {
+    disable: !shouldUploadSourcemaps,
+    deleteSourcemapsAfterUpload: shouldUploadSourcemaps,
   },
-  {
-    hideSourceMaps: true,
-    transpileClientSDK: true,
-    tunnelRoute: "/monitoring",
-    reactComponentAnnotation: { enabled: false },
-  }
-)
+  hideSourceMaps: true,
+  transpileClientSDK: true,
+  tunnelRoute: "/monitoring",
+  reactComponentAnnotation: { enabled: false },
+})

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -1,27 +1,26 @@
-import * as Sentry from "@sentry/nextjs";
+import * as Sentry from "@sentry/nextjs"
 
-Sentry.init({
-  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  // Performance Monitoring
-  tracesSampleRate: 0.1,
-  // Session Replay
-  replaysSessionSampleRate: 0.01,
-  replaysOnErrorSampleRate: 0.1,
-  // Core Web Vitals
-  enableTracing: true,
-  integrations: [
-    Sentry.browserTracingIntegration({
-      enableInp: true,
-    }),
-  ],
-  environment: process.env.NODE_ENV,
-  enabled: process.env.NODE_ENV === "production",
-  ignoreErrors: [
-    "ResizeObserver loop",
-    "ResizeObserver loop limit exceeded",
-    "Non-Error promise rejection captured",
-    "AbortError",
-    "ChunkLoadError",
-    "Loading chunk",
-  ],
-})
+const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN
+
+if (dsn) {
+  Sentry.init({
+    dsn,
+    environment: process.env.NODE_ENV,
+    tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
+    replaysOnErrorSampleRate: 1.0,
+    enableTracing: true,
+    integrations: [
+      Sentry.browserTracingIntegration({
+        enableInp: true,
+      }),
+    ],
+    ignoreErrors: [
+      "ResizeObserver loop",
+      "ResizeObserver loop limit exceeded",
+      "Non-Error promise rejection captured",
+      "AbortError",
+      "ChunkLoadError",
+      "Loading chunk",
+    ],
+  })
+}

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -1,8 +1,11 @@
-import * as Sentry from "@sentry/nextjs";
+import * as Sentry from "@sentry/nextjs"
 
-Sentry.init({
-  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  environment: process.env.NODE_ENV,
-  tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
-  enabled: process.env.NODE_ENV === "production",
-})
+const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN
+
+if (dsn) {
+  Sentry.init({
+    dsn,
+    environment: process.env.NODE_ENV,
+    tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
+  })
+}

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -1,8 +1,11 @@
-import * as Sentry from "@sentry/nextjs";
+import * as Sentry from "@sentry/nextjs"
 
-Sentry.init({
-  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  environment: process.env.NODE_ENV,
-  tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
-  enabled: process.env.NODE_ENV === "production",
-})
+const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN
+
+if (dsn) {
+  Sentry.init({
+    dsn,
+    environment: process.env.NODE_ENV,
+    tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
+  })
+}


### PR DESCRIPTION
Closes #ISSUE-BLOCKED

### Motivation
- Ensure the Next.js frontend initializes Sentry only when a DSN is provided so missing Sentry env vars do not break local/dev builds.
- Limit source-map upload behavior to CI runs where `SENTRY_AUTH_TOKEN` exists to avoid accidental uploads and failures outside CI.

### Description
- Gate client/server/edge Sentry initialization on `NEXT_PUBLIC_SENTRY_DSN` by updating `sentry.client.config.ts`, `sentry.server.config.ts`, and `sentry.edge.config.ts` to perform a no-op when the DSN is not set.
- Configure `tracesSampleRate` to `0.1` in production and `1.0` in development and set `replaysOnErrorSampleRate: 1.0` on the client.
- Update `next.config.js` to compute `shouldUploadSourcemaps = Boolean(process.env.CI && process.env.SENTRY_AUTH_TOKEN)` and pass `authToken` and `sourcemaps` options into `withSentryConfig()` so sourcemap upload is enabled only in CI when `SENTRY_AUTH_TOKEN` is present.
- Update `.env.example` to document `NEXT_PUBLIC_SENTRY_DSN` and `SENTRY_AUTH_TOKEN` (marked as CI-only).
- Left a note: Next.js/Sentry build emits an advisory recommending moving `Sentry.init` for server/edge into a Next.js instrumentation hook (`instrumentation.ts`); this should be addressed as a follow-up if migrating to Next's instrumentation hook is desired.

### Testing
- Ran `NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY=pk_test npm run lint` and lint completed (warnings only) — success.
- Verified `require('./next.config.js')` loads without Sentry env vars using `node -e "require('./next.config.js')"` — success.
- Ran `npx tsc --noEmit` which reported type/test-related failures caused by missing test-runner/testing-library type packages in the environment — blocked by missing dev dependencies.
- Ran `npm test` which failed because `vitest` is not available in the runnable environment — blocked by missing dev tooling; `next build` also produced external font fetch failures in this environment and emitted Sentry advisory about `sentry.server.config.ts`/`sentry.edge.config.ts` and Next.js instrumentation.

ROADMAP Ref: INFRA

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bc0e180518833395725238fd9a61c7)